### PR TITLE
Add --input-file optional command-line argument to h5browser.py 

### DIFF
--- a/docs/src/usage/modules/Utility_Modules.rst
+++ b/docs/src/usage/modules/Utility_Modules.rst
@@ -305,6 +305,38 @@ data viewer (type :ref:`NDviewer` that can display data dimensionality up to 4)
 
 .. :download:`png <h5browser.png>`
 
+Associating H5Browser with .h5 files
++++++++++++++++++++++++++++++++++++++
+
+By default, the H5Browser always asks the user to select a file. One can instead open a specified .h5 file directly,
+using the --input optional command line argument as follows:
+
+``python h5browser.py --input my_h5_file.h5``.
+
+One can also associate H5Browser to all .h5 file so that it directly opens a file when double clicking on it. Here is
+how to do it on Windows. Let us assume that you have a conda environment named *my_env*, in which PyMoDAQ is installed.
+
+In Windows, the path to your conda executable will be something like:
+
+``C:\Miniconda\condabin\conda.bat``
+
+and the path to the H5Browser will be (note that we are going into the *my_env* folder):
+
+``C:\Miniconda\envs\my_env\Lib\site-packages\pymodaq\h5browser.py``
+
+Now that you have written down these two paths, open your favorite text editing tool (e.g. notepad) and create a file
+called *H5Opener.bat* (for instance) with the following contents:
+
+  .. code-block:: python
+
+    @ECHO OFF
+    call C:\Miniconda\condabin\conda.bat activate my_env
+    python "C:\Miniconda\envs\my_env\Lib\site-packages\pymodaq\h5browser.py" --input %1
+
+After creating the file, simply right click on any .h5 file, choose **Open with**, *Try an app on this PC*, you should see a list of programs, at the bottom
+you have to tick *Always use this app to open .h5 files* and then click *Look for another app on this PC*. You can browse to the location
+of *H5Opener.bat* and you are done. Double clicking any .h5 file will now open the H5Browser directly loading the selected file.
+
 
 .. _h5saver_module:
 

--- a/src/pymodaq/h5browser.py
+++ b/src/pymodaq/h5browser.py
@@ -2,6 +2,8 @@ import sys
 from qtpy import QtWidgets
 from pymodaq.daq_utils.h5modules import H5Browser
 from pymodaq.daq_utils.config import Config
+import getopt, sys
+from pathlib import Path
 
 config = Config()
 
@@ -11,12 +13,22 @@ def main():
         import qdarkstyle
         app.setStyleSheet(qdarkstyle.load_stylesheet())
 
+    h5file_path = None
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "i:", ["input-file="])
+    except getopt.GetoptError as err:
+        print(err)
+        sys.exit(2)
+
+    for o, a in opts:
+        if o in ("-i", "--input-file"):
+            h5file_path = Path(a).resolve()  # Transform to absolute Path in case it is relative
+
     win = QtWidgets.QMainWindow()
-    prog = H5Browser(win)
+    prog = H5Browser(win, h5file_path=h5file_path)
     win.show()
     QtWidgets.QApplication.processEvents()
     sys.exit(app.exec_())
-
 
 if __name__ == '__main__':
     main()

--- a/src/pymodaq/h5browser.py
+++ b/src/pymodaq/h5browser.py
@@ -2,8 +2,12 @@ import sys
 from qtpy import QtWidgets
 from pymodaq.daq_utils.h5modules import H5Browser
 from pymodaq.daq_utils.config import Config
-import getopt, sys
 from pathlib import Path
+
+import argparse
+parser = argparse.ArgumentParser(description="Opens HDF5 files and navigate their contents")
+parser.add_argument("-i", "--input", help="specify path to the file to be opened")
+args = parser.parse_args()
 
 config = Config()
 
@@ -14,15 +18,13 @@ def main():
         app.setStyleSheet(qdarkstyle.load_stylesheet())
 
     h5file_path = None
-    try:
-        opts, args = getopt.getopt(sys.argv[1:], "i:", ["input-file="])
-    except getopt.GetoptError as err:
-        print(err)
-        sys.exit(2)
 
-    for o, a in opts:
-        if o in ("-i", "--input-file"):
-            h5file_path = Path(a).resolve()  # Transform to absolute Path in case it is relative
+    if args.input:
+        h5file_path = Path(args.input).resolve()  # Transform to absolute Path in case it is relative
+
+        if not h5file_path.exists():
+            print('Error: '+args.input+ ' does not exist. Opening h5browser without input file.')
+            h5file_path = None
 
     win = QtWidgets.QMainWindow()
     prog = H5Browser(win, h5file_path=h5file_path)


### PR DESCRIPTION
Hi,
I wanted to associate the h5browser to .h5 files so that I can open them directly when double clicking on them.
Here's a suggestion to make that work, h5browser.py now accepts an optional command-line argument, either one of:
```
python h5browser.py -i filename.h5
python h5browser.py --input-file=filename.h5
```

Then we can create a simple batch file (here on windows 10):
_H5Opener.bat_
```
@ECHO OFF
"C:\Miniconda\envs\myenv\python.exe" "your\path\to\pymodaq\h5browser.py" -i %1
```

Then do the "Right click/Open with..." on an .h5 file, and set H5Opener as the default program to read .h5 and .hdf5 files!

Possible future improvements:
- modify the h5browser.exe script too, so that one can run "h5browser -i file.h5"
- provide a simple utility that associates h5 files to h5browser automatically. and perhaps while we're at it, set a nice icon to h5 files too :-)

Cheers