### PR TITLE
Use Logger extension for saving the acquisition with PID extension (in progress)

### DIFF
--- a/src/pymodaq/daq_logger.py
+++ b/src/pymodaq/daq_logger.py
@@ -420,18 +420,25 @@ class DAQ_Logging(QObject):
 
         Parameters
         ----------
-
-        acquisition_from_viewer : OrderedDict
+        acquisition_from_viewer : OrderedDict{
+                    Ndatas : int
+                    acq_time_s : float
+                    name : str
+                    data0D : OrderedDict{
+                                <channel name> : DataToExport
+                                …
+                                }
+                        The dictionary data0D can contain data from 0D detectors, but also some measurements (e.g. an
+                        ROI integration).
+                    data1D : OrderedDict
+                        Same as data0D but for 1D data.
+                    data2D : OrderedDict
+                        Same for 2D data.
+                    dataND : OrderedDict
+                        Same for ND data.
+                    }
             Dictionary that contains data, metadata and measurements corresponding to an acquisition. Data of different
-            dimensions are classified in different entries of the dictionary. For example:
-
-            acquisition_from_viewer["name"] is the name of the detector
-
-            acquisition_from_viewer["data0D"] would contain the lineouts from defined ROIs
-
-            acquisition_from_viewer["data1D"] would contain the spectrum from a spectrometer
-
-            …
+            dimensions are classified in different keys of the dictionary.
 
         """
         try:

--- a/src/pymodaq/daq_logger.py
+++ b/src/pymodaq/daq_logger.py
@@ -63,8 +63,8 @@ class DAQ_Logger(CustomApp):
         self.wait_time = 1000
 
         self.logger_thread = None
-        self.logger = None  # should be a reference either to self.h5saver or self.dblogger depending the choice of the user
-
+        self.logger = None  # should be a reference either to self.h5saver or self.dblogger depending on the choice of
+        # the user
         self.setup_ui()
 
     def setup_actions(self):
@@ -122,11 +122,11 @@ class DAQ_Logger(CustomApp):
 
     def connect_things(self):
         self.status_signal[str].connect(self.dashboard.add_status)
-        self._actions['quit'].triggered.connect(self.quit_fun)
-        self._actions['start'].triggered.connect(self.start_logging)
-        self._actions['stop'].triggered.connect(self.stop_logging)
-        self._actions['grab_all'].triggered.connect(self.start_all)
-        self._actions['infos'].triggered.connect(self.dashboard.show_log)
+        self._actions['quit'].connect_to(self.quit_fun)
+        self._actions['start'].connect_to(self.start_logging)
+        self._actions['stop'].connect_to(self.stop_logging)
+        self._actions['grab_all'].connect_to(self.start_all)
+        self._actions['infos'].connect_to(self.dashboard.show_log)
 
     def setup_menu(self):
         """

--- a/src/pymodaq/daq_logger.py
+++ b/src/pymodaq/daq_logger.py
@@ -249,8 +249,12 @@ class DAQ_Logger(CustomApp):
         self.settings.child('log_type').setValue(log_type)
 
     def start_logging(self):
-        """
-            Start a logging.
+        """Start saving the detectors data and measurements.
+
+        This method is called from the Logger extension module UI main menu: Play.
+
+        Instantiate a DAQ_Logging object, put it into a thread, and call its own start_logging method.
+
         """
         self.status_widget.setText('Starting logging')
 
@@ -413,11 +417,13 @@ class DAQ_Logging(QObject):
             logger.exception(str(e))
 
     def connect_detectors(self, status=True):
-        """
-        Connect detectors to DAQ_Logging do_save_continuous method
+        """Connect detectors grab_done_signals to DAQ_Logging.do_save_continuous method.
+
         Parameters
         ----------
-        status: (bool) If True make the connection else disconnect
+        status : bool
+            If True make the connection else disconnect.
+
         """
         self.modules_manager.connect_detectors(connect=status, slot=self.do_save_continuous)
 
@@ -440,6 +446,11 @@ class DAQ_Logging(QObject):
         self.data_logger.stop_logger()
 
     def start_logging(self):
+        """Start saving the detectors data and measurements.
+
+        This method is called by the DAQ_Logger.start_logging method.
+
+        """
         try:
             self.connect_detectors()
             self.stop_logging_flag = False

--- a/src/pymodaq/daq_logger.py
+++ b/src/pymodaq/daq_logger.py
@@ -425,6 +425,7 @@ class DAQ_Logging(QObject):
                                         Ndatas : int
                                         acq_time_s : float
                                         name : str
+                                            Name of the detector.
                                         data0D : OrderedDict{
                                                     <channel name> : DataToExport
                                                     …

--- a/src/pymodaq/daq_logger.py
+++ b/src/pymodaq/daq_logger.py
@@ -408,7 +408,7 @@ class DAQ_Logging(QObject):
             self.stop_logging()
 
     @Slot(OrderedDict)
-    def do_save_continuous(self, acquisition_from_viewer):
+    def do_save_continuous(self, acquisition_from_viewer: OrderedDict) -> None:
         """Receive raw data, metadata and measurements from the detectors and call the data_logger to save it.
 
         Triggered by the grab_done_signals of the detectors (DAQ_Viewers modules). It is triggered each time a detector

--- a/src/pymodaq/daq_logger.py
+++ b/src/pymodaq/daq_logger.py
@@ -65,6 +65,8 @@ class DAQ_Logger(CustomApp):
         self.logger_thread = None
         self.logger = None  # should be a reference either to self.h5saver or self.dblogger depending the choice of the user
 
+        self.setup_ui()
+
     def setup_actions(self):
         '''
         subclass method from ActionManager
@@ -120,13 +122,11 @@ class DAQ_Logger(CustomApp):
 
     def connect_things(self):
         self.status_signal[str].connect(self.dashboard.add_status)
-        self._actions['quit'].connect(self.quit_fun)
-
-        self._actions['start'].connect(self.start_logging)
-        self._actions['stop'].connect(self.stop_logging)
-        self._actions['grab_all'].connect(self.start_all)
-
-        self._actions['infos'].connect(self.dashboard.show_log)
+        self._actions['quit'].triggered.connect(self.quit_fun)
+        self._actions['start'].triggered.connect(self.start_logging)
+        self._actions['stop'].triggered.connect(self.stop_logging)
+        self._actions['grab_all'].triggered.connect(self.start_all)
+        self._actions['infos'].triggered.connect(self.dashboard.show_log)
 
     def setup_menu(self):
         """

--- a/src/pymodaq/daq_logger.py
+++ b/src/pymodaq/daq_logger.py
@@ -407,17 +407,40 @@ class DAQ_Logging(QObject):
             self.stop_scan_flag = True
             self.stop_logging()
 
-    def do_save_continuous(self, datas):
-        """
+    def do_save_continuous(self, acquisition_from_viewer):
+        """Receive data, metadata and measurements from the detectors and call the data_logger to save it.
+
+        Triggered by the grab_done_signals of the detectors (DAQ_Viewers modules). It is triggered each time a detector
+        (selected in the configuration of the logger) has finished its acquisition.
+
+        The signals are connected by the DAQ_Logging.connect_detectors method.
+
+        The type of the data_logger depends on the choice of the user. The data can be saved in a h5 file or a database.
+        It will be a H5Logger if the user choose to save the data in a h5 file.
+
+        Parameters
+        ----------
+
+        acquisition_from_viewer : OrderedDict
+            Dictionary that contains data, metadata and measurements corresponding to an acquisition. Data of different
+            dimensions are classified in different entries of the dictionary. For example:
+
+            acquisition_from_viewer["name"] is the name of the detector
+
+            acquisition_from_viewer["data0D"] would contain the lineouts from defined ROIs
+
+            acquisition_from_viewer["data1D"] would contain the spectrum from a spectrometer
+
+            …
 
         """
         try:
-            self.data_logger.add_datas(datas)
+            self.data_logger.add_datas(acquisition_from_viewer)
         except Exception as e:
             logger.exception(str(e))
 
     def connect_detectors(self, status=True):
-        """Connect detectors grab_done_signals to DAQ_Logging.do_save_continuous method.
+        """Connect detectors (DAQ_Viewer modules) grab_done_signals to DAQ_Logging.do_save_continuous method.
 
         Parameters
         ----------

--- a/src/pymodaq/daq_logger.py
+++ b/src/pymodaq/daq_logger.py
@@ -407,8 +407,9 @@ class DAQ_Logging(QObject):
             self.stop_scan_flag = True
             self.stop_logging()
 
+    @Slot(OrderedDict)
     def do_save_continuous(self, acquisition_from_viewer):
-        """Receive data, metadata and measurements from the detectors and call the data_logger to save it.
+        """Receive raw data, metadata and measurements from the detectors and call the data_logger to save it.
 
         Triggered by the grab_done_signals of the detectors (DAQ_Viewers modules). It is triggered each time a detector
         (selected in the configuration of the logger) has finished its acquisition.
@@ -421,22 +422,22 @@ class DAQ_Logging(QObject):
         Parameters
         ----------
         acquisition_from_viewer : OrderedDict{
-                    Ndatas : int
-                    acq_time_s : float
-                    name : str
-                    data0D : OrderedDict{
-                                <channel name> : DataToExport
-                                …
-                                }
-                        The dictionary data0D can contain data from 0D detectors, but also some measurements (e.g. an
-                        ROI integration).
-                    data1D : OrderedDict
-                        Same as data0D but for 1D data.
-                    data2D : OrderedDict
-                        Same for 2D data.
-                    dataND : OrderedDict
-                        Same for ND data.
-                    }
+                                        Ndatas : int
+                                        acq_time_s : float
+                                        name : str
+                                        data0D : OrderedDict{
+                                                    <channel name> : DataToExport
+                                                    …
+                                                    }
+                                            The dictionary data0D can contain data from 0D detectors, but also some
+                                            measurements (e.g. an ROI integration).
+                                        data1D : OrderedDict
+                                            Same as data0D but for 1D data.
+                                        data2D : OrderedDict
+                                            Same for 2D data.
+                                        dataND : OrderedDict
+                                            Same for ND data.
+                                        }
             Dictionary that contains data, metadata and measurements corresponding to an acquisition. Data of different
             dimensions are classified in different keys of the dictionary.
 

--- a/src/pymodaq/daq_utils/daq_utils.py
+++ b/src/pymodaq/daq_utils/daq_utils.py
@@ -464,10 +464,10 @@ def get_data_dimension(data: np.ndarray, scan_type='scan1D', remove_scan_dimensi
 
     """
     if not isinstance(data, np.ndarray):
-        raise Exception("Input parameter should be an ndarray.")
+        raise TypeError(f"Input parameter should be an ndarray: {type(data)} received.")
 
     if data.ndim == 0:
-        raise Exception("The dimension of the array should be superior to zero.")
+        raise ValueError("The dimension of the array should be superior to zero.")
 
     dimension = data.ndim
 

--- a/src/pymodaq/daq_utils/daq_utils.py
+++ b/src/pymodaq/daq_utils/daq_utils.py
@@ -2,9 +2,6 @@ import os
 import sys
 from collections import OrderedDict
 from ctypes import CFUNCTYPE
-
-from pymodaq.daq_utils.config import get_set_config_path, get_set_preset_path, Config
-from pymodaq.daq_utils.messenger import deprecation_msg
 if 'win32' in sys.platform:
     from ctypes import WINFUNCTYPE
 import datetime
@@ -21,21 +18,22 @@ import pkgutil
 import traceback
 import warnings
 import numbers
-
-import numpy as np
-from qtpy import QtCore
-from qtpy.QtCore import QLocale
-from pymodaq.daq_utils.qvariant import QVariant
-
 python_version = f'{str(sys.version_info.major)}.{str(sys.version_info.minor)}'
 if version_mod.parse(python_version) >= version_mod.parse('3.8'):  # from version 3.8 this feature is included in the
     # standard lib
     from importlib import metadata
 else:
     import importlib_metadata as metadata  # pragma: no cover
+from typing import Tuple
 
+import numpy as np
+from qtpy import QtCore
+from qtpy.QtCore import QLocale
+
+from pymodaq.daq_utils.qvariant import QVariant
+from pymodaq.daq_utils.config import get_set_config_path, get_set_preset_path, Config
+from pymodaq.daq_utils.messenger import deprecation_msg
 from pymodaq.daq_utils.exceptions import DataSourceError
-
 
 plot_colors = [(255, 255, 255), (255, 0, 0), (0, 255, 0), (0, 0, 255), (14, 207, 189), (207, 14, 166), (207, 204, 14)]
 config = Config()
@@ -442,7 +440,7 @@ def uncapitalize(string, Nfirst=1):
     return string[:Nfirst].lower() + string[Nfirst:]
 
 
-def get_data_dimension(data: np.ndarray, scan_type='scan1D', remove_scan_dimension=False):
+def get_data_dimension(data: np.ndarray, scan_type='scan1D', remove_scan_dimension=False) -> Tuple[Tuple, str, str]:
     """Return the shape, dimension and size of the input data.
 
     Notice that the dimension returned does not necessarily correspond to the size of the input ndarray. If the shape of

--- a/src/pymodaq/daq_utils/daq_utils.py
+++ b/src/pymodaq/daq_utils/daq_utils.py
@@ -443,6 +443,25 @@ def uncapitalize(string, Nfirst=1):
 
 
 def get_data_dimension(arr, scan_type='scan1D', remove_scan_dimension=False):
+    """Get a numpy ndarray and return its shape, dimension and size.
+
+    Parameters
+    ----------
+    arr : numpy ndarray
+        Typically raw data from an acquisition (a spectrum, an image…).
+    scan_type : str
+        ??
+    remove_scan_dimension : bool
+        ??
+
+    Returns
+    -------
+    tuple of tuple, string, int
+
+    """
+    if not isinstance(arr, np.ndarray):
+        raise Exception
+
     dimension = len(arr.shape)
     if dimension == 1:
         if arr.size == 1:
@@ -456,6 +475,7 @@ def get_data_dimension(arr, scan_type='scan1D', remove_scan_dimension=False):
     else:
         if dimension > 2:
             dimension = 'N'
+
     return arr.shape, f'{dimension}D', arr.size
 
 
@@ -725,15 +745,20 @@ class DataFromPlugins(Data):
 
 class DataToExport(Data):
     def __init__(self, data=None, dim='', source='raw', **kwargs):
-        """
-        Utility class defining a data being exported from pymodaq's viewers, attributes can be accessed as dictionary keys
+        """Utility class defining a data being exported from pymodaq's viewers, attributes can be accessed as dictionary
+        keys.
+
         Parameters
         ----------
-        data: (ndarray or a scalar)
-        dim: (str) data dimensionality (either Data0D, Data1D, Data2D or DataND)
-        source: (str) either 'raw' for raw data or 'roi' for data extracted from a roi
+        data : ndarray or float or int or None
+        dim : str
+            Data dimensionality (either Data0D, Data1D, Data2D or DataND).
+        source : str
+            Either 'raw' for raw data or 'roi' for data extracted from a roi.
+
         """
         super().__init__(source=source, **kwargs)
+
         if data is None or isinstance(data, np.ndarray) or isinstance(data, float) or isinstance(data, int):
             self['data'] = data
         else:
@@ -754,6 +779,7 @@ class DataToExport(Data):
             else:
                 dim = 'Data0D'
         self['dim'] = dim
+
         if source not in DATASOURCES:
             raise DataSourceError(f'Data source should be in {DATASOURCES}')
 

--- a/src/pymodaq/daq_utils/daq_utils.py
+++ b/src/pymodaq/daq_utils/daq_utils.py
@@ -442,12 +442,16 @@ def uncapitalize(string, Nfirst=1):
     return string[:Nfirst].lower() + string[Nfirst:]
 
 
-def get_data_dimension(arr, scan_type='scan1D', remove_scan_dimension=False):
-    """Get a numpy ndarray and return its shape, dimension and size.
+def get_data_dimension(data: np.ndarray, scan_type='scan1D', remove_scan_dimension=False):
+    """Return the shape, dimension and size of the input data.
+
+    Notice that the dimension returned does not necessarily correspond to the size of the input ndarray. If the shape of
+    the ndarray is (1,) it is interpreted as a scalar data, thus of dimension 0. This is done because it seems to be the
+    way pytables library manages scalar data (https://www.pytables.org/_modules/tables/earray.html#EArray.append).
 
     Parameters
     ----------
-    arr : numpy ndarray
+    data : numpy ndarray
         Typically raw data from an acquisition (a spectrum, an image…).
     scan_type : str
         ??
@@ -459,13 +463,16 @@ def get_data_dimension(arr, scan_type='scan1D', remove_scan_dimension=False):
     tuple of tuple, string, int
 
     """
-    if not isinstance(arr, np.ndarray):
-        raise Exception
+    if not isinstance(data, np.ndarray):
+        raise Exception("Input parameter should be an ndarray.")
 
-    dimension = len(arr.shape)
-    if dimension == 1:
-        if arr.size == 1:
-            dimension = 0
+    if data.ndim == 0:
+        raise Exception("The dimension of the array should be superior to zero.")
+
+    dimension = data.ndim
+
+    if data.shape == (1,):  # Case of a scalar data.
+        dimension = 0
 
     if remove_scan_dimension:
         if scan_type.lower() == 'scan1d':
@@ -476,7 +483,7 @@ def get_data_dimension(arr, scan_type='scan1D', remove_scan_dimension=False):
         if dimension > 2:
             dimension = 'N'
 
-    return arr.shape, f'{dimension}D', arr.size
+    return data.shape, f'{dimension}D', data.size
 
 
 def scroll_log(scroll_val, min_val, max_val):

--- a/src/pymodaq/daq_utils/h5modules.py
+++ b/src/pymodaq/daq_utils/h5modules.py
@@ -1887,17 +1887,25 @@ class H5Logger(AbstractLogger):
 
         Parameters
         ----------
-        datas : OrderedDict
+        datas : OrderedDict{
+                    Ndatas : int
+                    acq_time_s : float
+                    name : str
+                    data0D : OrderedDict{
+                                <channel name> : DataToExport
+                                …
+                                }
+                        The dictionary data0D can contain data from 0D detectors, but also some measurements (e.g. an
+                        ROI integration).
+                    data1D : OrderedDict
+                        Same as data0D but for 1D data.
+                    data2D : OrderedDict
+                        Same for 2D data.
+                    dataND : OrderedDict
+                        Same for ND data.
+                    }
             Dictionary that contains data, metadata and measurements corresponding to an acquisition. Data of different
-            dimensions are classified in different entries of the dictionary. For example:
-
-            acquisition_from_viewer["name"] is the name of the detector
-
-            acquisition_from_viewer["data0D"] would contain the lineouts from defined ROIs
-
-            acquisition_from_viewer["data1D"] would contain the spectrum from a spectrometer
-
-            …
+            dimensions are classified in different keys of the dictionary.
 
         """
         det_name = datas['name']

--- a/src/pymodaq/daq_utils/h5modules.py
+++ b/src/pymodaq/daq_utils/h5modules.py
@@ -1962,6 +1962,7 @@ class H5Logger(AbstractLogger):
                     if isinstance(acquisition[data_dimension][channel]["data"], (float, int)):
                         acquisition[data_dimension][channel]["data"] = \
                             np.array([acquisition[data_dimension][channel]["data"]])
+                        logger.warning("Data has been converted from scalar to ndarray.")
 
                     channel_group = self.h5saver.get_group_by_title(data_group, channel)
                     if channel_group is None:  # First iteration.

--- a/src/pymodaq/daq_utils/h5modules.py
+++ b/src/pymodaq/daq_utils/h5modules.py
@@ -1939,34 +1939,35 @@ class H5Logger(AbstractLogger):
         time_array = self.h5saver.get_node(det_group, 'Logger_time_axis')
         time_array.append(np.array([acquisition['acq_time_s']]))
 
-        data_types = ['data0D', 'data1D']
+        acquisition_key_dimensions = ['data0D', 'data1D']
         if self.settings.child('save_2D').value():
-            data_types.extend(['data2D', 'dataND'])
+            acquisition_key_dimensions.extend(['data2D', 'dataND'])
 
-        for data_type in data_types:
-            if data_type in acquisition.keys() and len(acquisition[data_type]) != 0:
-                if not self.h5saver.is_node_in_group(det_group, data_type):
-                    data_group = self.h5saver.add_data_group(det_group, data_type, metadata=dict(type='scan'))
+        for data_dimension in acquisition_key_dimensions:
+            if data_dimension in acquisition.keys() and len(acquisition[data_dimension]) != 0:
+                if not self.h5saver.is_node_in_group(det_group, data_dimension):
+                    data_group = self.h5saver.add_data_group(det_group, data_dimension, metadata=dict(type='scan'))
                 else:
-                    data_group = self.h5saver.get_node(det_group, utils.capitalize(data_type))
+                    data_group = self.h5saver.get_node(det_group, utils.capitalize(data_dimension))
 
-                for ind_channel, channel in enumerate(acquisition[data_type]):
+                for ind_channel, channel in enumerate(acquisition[data_dimension]):
                     channel_group = self.h5saver.get_group_by_title(data_group, channel)
                     if channel_group is None:
                         channel_group = self.h5saver.add_CH_group(data_group, title=channel)
                         # This condition should be added for the 0D case because H5Saver.add_data requires that the key
                         # data_dict["data"] should be an ndarray, and not a float.
-                        if data_type == "data0D":
-                            acquisition[data_type][channel]["data"] = np.array(acquisition[data_type][channel]["data"])
+                        if data_dimension == "data0D":
+                            acquisition[data_dimension][channel]["data"] = \
+                                np.array(acquisition[data_dimension][channel]["data"])
 
-                        data_array = self.h5saver.add_data(channel_group, acquisition[data_type][channel],
+                        data_array = self.h5saver.add_data(channel_group, acquisition[data_dimension][channel],
                                                            scan_type='scan1D', enlargeable=True)
                     else:
                         data_array = self.h5saver.get_node(channel_group, 'Data')
-                    if data_type == 'data0D':
-                        data_array.append(np.array([acquisition[data_type][channel]['data']]))
+                    if data_dimension == 'data0D':
+                        data_array.append(np.array([acquisition[data_dimension][channel]['data']]))
                     else:
-                        data_array.append(acquisition[data_type][channel]['data'])
+                        data_array.append(acquisition[data_dimension][channel]['data'])
 
         self.h5saver.flush()
         self.settings.child('N_saved').setValue(

--- a/src/pymodaq/daq_utils/h5modules.py
+++ b/src/pymodaq/daq_utils/h5modules.py
@@ -1897,7 +1897,7 @@ class H5Logger(AbstractLogger):
                                      title='Time axis',
                                      metadata=dict(label='Time axis', units='s', nav_index=0))
 
-    def add_datas(self, acquisition):
+    def add_datas(self, acquisition: OrderedDict) -> None:
         """Get raw data, metadata and measurements from a detector module (DAQ_Viewer) in the form of a dictionary.
         Construct the h5 file structure according to the dictionary structure to welcome and save the new data from the
         acquisition.

--- a/src/pymodaq/daq_utils/h5modules.py
+++ b/src/pymodaq/daq_utils/h5modules.py
@@ -1954,7 +1954,8 @@ class H5Logger(AbstractLogger):
                 for ind_channel, channel in enumerate(acquisition[data_dimension]):
                     # This condition should be added for the 0D case because H5Saver.add_data requires that the key
                     # data_dict["data"] should be an ndarray, and not a float or an int. Here we transform a scalar
-                    # into a ndarray of shape (1,), which seems the easy way to save a scalar with pytables.
+                    # into a ndarray of shape (1,), which seems the easy way to save a scalar with pytables
+                    # (https://www.pytables.org/_modules/tables/earray.html#EArray.append).
                     # The "data" key of DataToExport object can be a float, an int, a ndarray or None.
                     # This condition could be skipped if we would impose DataToExport["data"] to be a ndarray.
                     # Do we manage the None case properly?

--- a/src/pymodaq/daq_utils/managers/modules_manager.py
+++ b/src/pymodaq/daq_utils/managers/modules_manager.py
@@ -38,7 +38,7 @@ class ModulesManager(QObject):
         ]},
     ]
 
-    def __init__(self, detectors=[], actuators=[], selected_detectors=[], selected_actuators=[], timeout=10000):
+    def __init__(self, detectors=[], actuators=[], selected_detectors=[], selected_actuators=[], timeout=10):
         super().__init__()
 
         for mod in selected_actuators:
@@ -46,7 +46,7 @@ class ModulesManager(QObject):
         for mod in selected_detectors:
             assert mod in detectors
 
-        self.timeout = timeout  # in ms
+        self.timeout = timeout  # in seconds
 
         self.det_done_datas = OrderedDict()
         self.det_done_flag = False

--- a/src/pymodaq/daq_utils/managers/modules_manager.py
+++ b/src/pymodaq/daq_utils/managers/modules_manager.py
@@ -243,7 +243,7 @@ class ModulesManager(QObject):
 
             try:
                 # If the detector is not grabbing (detector_acquisition is None), we send a grab signal. But if it is
-                # not grabbing, we do not need to send the grab signal, which would freeze the acquisition.
+                # grabbing, we do not need to send the grab signal, which would freeze the acquisition.
                 if detector_acquisition is None:
                     detector.grab_done_signal.connect(self.det_done)
                     detector_acquisition = self.grab_one_detector(detector)
@@ -259,6 +259,8 @@ class ModulesManager(QObject):
                     data_listND.extend([f'{det_name}/{ch_name}' for ch_name in detector_acquisition['dataND'].keys()])
 
             except Exception as e:
+                self.logger.warning("There may be a connection problem with the detector that prevents to construct"
+                                    "the acquisition channels.")
                 self.logger.exception(str(e))
 
         self.settings.child('data_dimensions', 'det_data_list0D').setValue(

--- a/src/pymodaq/daq_utils/managers/modules_manager.py
+++ b/src/pymodaq/daq_utils/managers/modules_manager.py
@@ -232,7 +232,14 @@ class ModulesManager(QObject):
         return self.settings.child('data_dimensions', f'det_data_list{dim.upper()}').value()['selected']
 
     def grab_datas(self, **kwargs):
-        """Send a command to every managed detectors to do a single grab.
+        """Send a command to every managed detectors to do a single grab and return the acquisitions classified in an
+        ordered dictionary.
+
+        In principle the detectors will send their signals and self.det_done_datas will be constructed from all their
+        contributions.
+
+        If all the detectors do not send the data before timeout, then the det_done_signal is emitted anyway, and the
+        method returns the dictionary, which will be "incomplete" in this case.
 
         Parameters
         ----------
@@ -240,7 +247,26 @@ class ModulesManager(QObject):
 
         Returns
         -------
-        self.det_done_data : OrderedDict
+        self.det_done_datas : OrderedDict{
+            Ndatas : int
+            acq_time_s : float
+            name : str
+            data0D : OrderedDict{
+                        <channel name> : DataToExport
+                        …
+                        }
+                The dictionary data0D can contain data from 0D detectors, but also some measurements (e.g. an
+                ROI integration).
+            data1D : OrderedDict
+                Same as data0D but for 1D data.
+            data2D : OrderedDict
+                Same for 2D data.
+            dataND : OrderedDict
+                Same for ND data.
+            }
+
+            Dictionary that contains data, metadata and measurements corresponding to an acquisition. Data of different
+            dimensions are classified in different keys of the dictionary.
 
         """
         self.det_done_datas = OrderedDict()

--- a/src/pymodaq/daq_utils/managers/modules_manager.py
+++ b/src/pymodaq/daq_utils/managers/modules_manager.py
@@ -241,22 +241,25 @@ class ModulesManager(QObject):
             detector_acquisition = detector.data_to_save_export
             det_name = detector.detector_name
 
-            # In this case the detector is not grabbing.
-            if detector_acquisition is None:
-                detector.grab_done_signal.connect(self.det_done)
-                detector_acquisition = self.grab_one_detector(detector)
-                detector.grab_done_signal.disconnect(self.det_done)
-            # In this case the detector is grabbing, thus we do not need to send the grab signal, which would freeze the
-            # acquisition.
+            try:
+                # If the detector is not grabbing (detector_acquisition is None), we send a grab signal. But if it is
+                # not grabbing, we do not need to send the grab signal, which would freeze the acquisition.
+                if detector_acquisition is None:
+                    detector.grab_done_signal.connect(self.det_done)
+                    detector_acquisition = self.grab_one_detector(detector)
+                    detector.grab_done_signal.disconnect(self.det_done)
 
-            if 'data0D' in detector_acquisition.keys():
-                data_list0D.extend([f'{det_name}/{ch_name}' for ch_name in detector_acquisition['data0D'].keys()])
-            if 'data1D' in detector_acquisition.keys():
-                data_list1D.extend([f'{det_name}/{ch_name}' for ch_name in detector_acquisition['data1D'].keys()])
-            if 'data2D' in detector_acquisition.keys():
-                data_list2D.extend([f'{det_name}/{ch_name}' for ch_name in detector_acquisition['data2D'].keys()])
-            if 'data1D' in detector_acquisition.keys():
-                data_listND.extend([f'{det_name}/{ch_name}' for ch_name in detector_acquisition['dataND'].keys()])
+                if 'data0D' in detector_acquisition.keys():
+                    data_list0D.extend([f'{det_name}/{ch_name}' for ch_name in detector_acquisition['data0D'].keys()])
+                if 'data1D' in detector_acquisition.keys():
+                    data_list1D.extend([f'{det_name}/{ch_name}' for ch_name in detector_acquisition['data1D'].keys()])
+                if 'data2D' in detector_acquisition.keys():
+                    data_list2D.extend([f'{det_name}/{ch_name}' for ch_name in detector_acquisition['data2D'].keys()])
+                if 'data1D' in detector_acquisition.keys():
+                    data_listND.extend([f'{det_name}/{ch_name}' for ch_name in detector_acquisition['dataND'].keys()])
+
+            except Exception as e:
+                self.logger.exception(str(e))
 
         self.settings.child('data_dimensions', 'det_data_list0D').setValue(
             dict(all_items=data_list0D, selected=[]))

--- a/src/pymodaq/daq_utils/managers/modules_manager.py
+++ b/src/pymodaq/daq_utils/managers/modules_manager.py
@@ -99,8 +99,13 @@ class ModulesManager(QObject):
         ]},
     ]
 
-    def __init__(self, detectors=[], actuators=[], selected_detectors=[], selected_actuators=[], timeout_s=None):
+    def __init__(self, detectors=None, actuators=None, selected_detectors=None, selected_actuators=None, timeout_s=None):
         super().__init__()
+
+        detectors = detectors or []
+        actuators = actuators or []
+        selected_detectors = selected_detectors or []
+        selected_actuators = selected_actuators or []
 
         # check that selected_actuator and selected_detectors are subset of actuators and detectors respectively
         for mod in selected_actuators:

--- a/src/pymodaq/daq_utils/managers/modules_manager.py
+++ b/src/pymodaq/daq_utils/managers/modules_manager.py
@@ -192,6 +192,12 @@ class ModulesManager(QObject):
                 pass
 
     def get_det_data_list(self):
+        """Construct the list of data channels that are available with the current configuration of the module manager.
+
+        It will display all the data channels as selectable parameters in the module manager UI.
+        This method is called by the "Probe detectors’ data" button of the module manager UI.
+
+        """
         self.connect_detectors()
 
         datas = self.grab_datas()

--- a/src/pymodaq/daq_utils/managers/modules_manager.py
+++ b/src/pymodaq/daq_utils/managers/modules_manager.py
@@ -10,6 +10,13 @@ logger = utils.set_logger(utils.get_module_name(__file__))
 
 
 class ModulesManager(QObject):
+    """
+
+    Attributes
+    ----------
+    detectors : list of DAQ_Viewer
+
+    """
     detectors_changed = Signal(list)
     actuators_changed = Signal(list)
     det_done_signal = Signal(OrderedDict)
@@ -195,27 +202,26 @@ class ModulesManager(QObject):
         """Construct the list of data channels that are available with the current configuration of the module manager.
 
         It will display all the data channels as selectable parameters in the module manager UI.
+
         This method is called by the "Probe detectors’ data" button of the module manager UI.
 
         """
-        self.connect_detectors()
-
-        datas = self.grab_datas()
-
         data_list0D = []
         data_list1D = []
         data_list2D = []
         data_listND = []
 
-        for k in datas.keys():
-            if 'data0D' in datas[k].keys():
-                data_list0D.extend([f'{k}/{name}' for name in datas[k]['data0D'].keys()])
-            if 'data1D' in datas[k].keys():
-                data_list1D.extend([f'{k}/{name}' for name in datas[k]['data1D'].keys()])
-            if 'data2D' in datas[k].keys():
-                data_list2D.extend([f'{k}/{name}' for name in datas[k]['data2D'].keys()])
-            if 'dataND' in datas[k].keys():
-                data_listND.extend([f'{k}/{name}' for name in datas[k]['dataND'].keys()])
+        for detector in self.detectors:
+            detector_acquisition = detector.data_to_save_export
+
+            if 'data0D' in detector_acquisition.keys():
+                data_list0D.extend([f'{name}' for name in detector_acquisition['data0D'].keys()])
+            if 'data1D' in detector_acquisition.keys():
+                data_list1D.extend([f'{name}' for name in detector_acquisition['data1D'].keys()])
+            if 'data2D' in detector_acquisition.keys():
+                data_list2D.extend([f'{name}' for name in detector_acquisition['data2D'].keys()])
+            if 'data1D' in detector_acquisition.keys():
+                data_listND.extend([f'{name}' for name in detector_acquisition['dataND'].keys()])
 
         self.settings.child('data_dimensions', 'det_data_list0D').setValue(
             dict(all_items=data_list0D, selected=[]))
@@ -225,8 +231,6 @@ class ModulesManager(QObject):
             dict(all_items=data_list2D, selected=[]))
         self.settings.child('data_dimensions', 'det_data_listND').setValue(
             dict(all_items=data_listND, selected=[]))
-
-        self.connect_detectors(False)
 
     def get_selected_probed_data(self, dim='0D'):
         return self.settings.child('data_dimensions', f'det_data_list{dim.upper()}').value()['selected']

--- a/src/pymodaq/daq_utils/managers/modules_manager.py
+++ b/src/pymodaq/daq_utils/managers/modules_manager.py
@@ -164,7 +164,6 @@ class ModulesManager(QObject):
             self.settings.child('modules', 'actuators').setValue(dict(all_items=self.actuators_name,
                                                                       selected=actuators))
 
-
     def parameter_tree_changed(self, param, changes):
         """
             Check for changes in the given (parameter,change,information) tuple list.
@@ -227,7 +226,7 @@ class ModulesManager(QObject):
         return self.settings.child('data_dimensions', f'det_data_list{dim.upper()}').value()['selected']
 
     def grab_datas(self, **kwargs):
-        """Send a command to every managed detectors to do a single grab
+        """Send a command to every managed detectors to do a single grab.
 
         Parameters
         ----------

--- a/src/pymodaq/daq_utils/managers/modules_manager.py
+++ b/src/pymodaq/daq_utils/managers/modules_manager.py
@@ -41,6 +41,7 @@ class ModulesManager(QObject):
     def __init__(self, detectors=[], actuators=[], selected_detectors=[], selected_actuators=[], timeout=10):
         super().__init__()
 
+        # check that selected_actuator and selected_detectors are subset of actuators and detectors respectively
         for mod in selected_actuators:
             assert mod in actuators
         for mod in selected_detectors:
@@ -226,9 +227,20 @@ class ModulesManager(QObject):
         return self.settings.child('data_dimensions', f'det_data_list{dim.upper()}').value()['selected']
 
     def grab_datas(self, **kwargs):
+        """Send a command to every managed detectors to do a single grab
+
+        Parameters
+        ----------
+        **kwargs : dict
+
+        Returns
+        -------
+        self.det_done_data : OrderedDict
+
+        """
         self.det_done_datas = OrderedDict()
         self.det_done_flag = False
-        self.settings.child(('det_done')).setValue(self.det_done_flag)
+        self.settings.child('det_done').setValue(self.det_done_flag)
         tzero = time.perf_counter()
 
         for sig in [mod.command_detector for mod in self.detectors]:
@@ -265,6 +277,7 @@ class ModulesManager(QObject):
     def connect_detectors(self, connect=True, slot=None):
         """
         Connect selected DAQ_Viewers's grab_done_signal to the given slot
+
         Parameters
         ----------
         connect: (bool) if True, connect to the given slot (or default slot)

--- a/src/pymodaq/daq_utils/managers/modules_manager.py
+++ b/src/pymodaq/daq_utils/managers/modules_manager.py
@@ -11,12 +11,28 @@ logger = utils.set_logger(utils.get_module_name(__file__))
 
 
 class ModulesManager(QObject):
-    """
+    """The module manager is an object used to deal with:
+
+    * Selection of actuators and detectors by a user (and internal facilities to manipulate them, see the API when it
+        will be written…).
+    * Synchronize acquisition from selected detectors.
+    * Synchronize moves from selected actuators.
+    * Probe as lists all the data that will be exported by the selected detectors.
+    * Test actuators positioning. Clicking on "test_actuator" button on the UI will let you enter positions for all
+        selected actuators that will be displayed when reached.
+
+    See: https://pymodaq.cnrs.fr/en/latest/usage/modules/Utility_Modules.html#module-manager
 
     Attributes
     ----------
-    detectors : list of DAQ_Viewer
-
+    detectors : list of DAQ_Viewer objects
+        The detectors that have been selected by the user.
+    detectors_all : list of DAQ_Viewer objects
+        All the detectors (even those that are not selected).
+    actuators : list of DAQ_Move objects
+        The actuators that have been selected by the user.
+    actuators_all : list of DAQ_Viewer objects
+        All the actuators (even those that are not selected).
     det_done_datas : OrderedDict{
                         <name of detector 1> : OrderedDict{
                                                     Ndatas : int

--- a/src/pymodaq/daq_utils/plotting/data_viewers/viewer1D.py
+++ b/src/pymodaq/daq_utils/plotting/data_viewers/viewer1D.py
@@ -510,7 +510,7 @@ class Viewer1D(QtWidgets.QWidget, QObject):
                 self.data_to_export['data0D']['Measure_{:03d}'.format(ind)] = utils.DataToExport(name=self.title,
                                                                                                  data=data_lo[ind],
                                                                                                  source='roi')
-            self.roi_manager.settings.child(('measurements')).setValue(self.measure_data_dict)
+            self.roi_manager.settings.child('measurements').setValue(self.measure_data_dict)
 
             for ind, key in enumerate(self.lo_items):
                 self.lo_data[key] = np.append(self.lo_data[key], data_lo[ind])

--- a/src/pymodaq/daq_utils/plotting/data_viewers/viewer1D.py
+++ b/src/pymodaq/daq_utils/plotting/data_viewers/viewer1D.py
@@ -10,6 +10,7 @@ from pymodaq.daq_utils.plotting.items.crosshair import Crosshair
 import pyqtgraph as pg
 import numpy as np
 from pymodaq.daq_utils import daq_utils as utils
+from pymodaq.daq_utils import math_utils as mutils
 from pymodaq.daq_utils.managers.action_manager import QAction
 from pymodaq.daq_utils.plotting.data_viewers.viewer1Dbasic import Viewer1DBasic
 from pymodaq.daq_utils.managers.roi_manager import ROIManager
@@ -666,7 +667,7 @@ class Viewer1D_math(QObject):
             # self.status_sig.emit(["Update_Status","doing math"])
             data_lo = []
             for ind_meas in range(len(self.operations)):
-                indexes = utils.find_index(self.x_axis, self.ROI_bounds[ind_meas])
+                indexes = mutils.find_index(self.x_axis, self.ROI_bounds[ind_meas])
                 ind1 = indexes[0][0]
                 ind2 = indexes[1][0]
                 sub_data = self.datas[self.channels[ind_meas]][ind1:ind2]

--- a/src/pymodaq/daq_utils/plotting/data_viewers/viewer1D.py
+++ b/src/pymodaq/daq_utils/plotting/data_viewers/viewer1D.py
@@ -292,14 +292,18 @@ class Viewer1D(QtWidgets.QWidget, QObject):
             self.ui.y_label.setVisible(False)
 
     def do_math_fun(self):
+        """Display/hide the ROI and lineouts widgets.
+
+        This method is triggered by the "Do Math using ROI" button from the Viewer1D UI.
+
+        """
         try:
             if self.ui.Do_math_pb.isChecked():
                 self.roi_manager.roiwidget.show()
                 self.ui.Graph_Lineouts.show()
-
             else:
-                self.ui.Graph_Lineouts.hide()
                 self.roi_manager.roiwidget.hide()
+                self.ui.Graph_Lineouts.hide()
 
         except Exception as e:
             logger.exception(str(e))
@@ -443,6 +447,24 @@ class Viewer1D(QtWidgets.QWidget, QObject):
 
     @Slot(list)
     def show_data(self, datas, labels=None, x_axis=None):
+        """Transfert the acquired raw data from the detector(s).
+
+        Called by DAQ_Viewer.set_datas_to_viewers.
+        Start to construct self.data_to_export filling the "data1D" key with the raw data.
+        Set the abscissa of the viewer and label the curves if they are given.
+        Call update_graph1D.
+        Call update_measurement_module if the "Do measurement" push button has been checked by the user.
+
+        Parameters
+        ----------
+        datas : list of ndarray of floats
+            Each array represents the spectrum from the acquisition of a 1D detector.
+        labels : ??
+            Names for each data curve (in case there are several detectors?).
+        x_axis : ??
+            The abscissa of the detection window.
+
+        """
         try:
             self.datas = datas
             self.update_labels(self.labels)
@@ -462,8 +484,6 @@ class Viewer1D(QtWidgets.QWidget, QObject):
                 self.set_x_axis(x_axis)
 
             self.update_graph1D(datas)
-
-
 
             if labels is not None:
                 self.update_labels(labels)
@@ -504,6 +524,19 @@ class Viewer1D(QtWidgets.QWidget, QObject):
 
     @Slot(list)
     def show_math(self, data_lo):
+        """
+
+        This method is called by the update_graph1D method if the user defined some ROIs.
+        It will complete the data_to_export dictionary with the lineouts from the ROIs (measurements). They are put
+            within the "data0D" key of the dictionary.
+        Emit the data_to_export_signal with the updated data_to_export dictionary.
+
+        Parameters
+        ----------
+        data_lo : list of float
+            The values of the lineouts of the ROIs (e.g. the mean value of the segments defined by the ROIs).
+
+        """
         # self.data_to_export=OrderedDict(x_axis=None,y_axis=None,z_axis=None,data0D=None,data1D=None,data2D=None)
         if len(data_lo) != 0:
             for ind, key in enumerate(self.lo_items):
@@ -547,6 +580,16 @@ class Viewer1D(QtWidgets.QWidget, QObject):
 
     def update_graph1D(self, datas):
         # self.data_to_export=OrderedDict(data0D=OrderedDict(),data1D=OrderedDict(),data2D=None)
+        """
+
+        If the user defined some ROI, the lineouts values will be sent as argument to the show_math method.
+
+        Parameters
+        ----------
+        datas : list of ndarray
+            Spectra from the detectors.
+
+        """
         try:
 
             pens = []

--- a/src/pymodaq/daq_viewer/daq_viewer_main.py
+++ b/src/pymodaq/daq_viewer/daq_viewer_main.py
@@ -1171,8 +1171,11 @@ class DAQ_Viewer(QObject):
         ----------
         datas : list of DataFromPlugins
             The objects in this list contain the acquired raw data and the associated metadada. This list can contain
-            several DataFromPlugins objects because the DAQ_Viewer can manage several detectors???
-
+            several DataFromPlugins objects because the DAQ_Viewer can manage several viewers. One instrument can export
+            many kind of data that would be better rendered in different viewers. For instance the output of a lockin
+            amplifier gives you an amplitude in volt and a phase in degree. Plotting both on the same viewer is
+            misleading and make one of the signal invisible (the amplitude) so you can use this to automatically plot
+            each on separate viewers.
         """
         try:
             if self.settings.child('main_settings', 'tcpip', 'tcp_connected').value() and self.send_to_tcpip:

--- a/src/pymodaq/daq_viewer/daq_viewer_main.py
+++ b/src/pymodaq/daq_viewer/daq_viewer_main.py
@@ -739,6 +739,7 @@ class DAQ_Viewer(QObject):
 
         """
         if self.data_to_save_export is None:
+            self.update_status(f'{self.title}: Nothing to save. Grab data before.')
             logger.error("The data buffer should not be empty if you call the save_current method. Grab data before.")
             return
 

--- a/src/pymodaq/daq_viewer/daq_viewer_main.py
+++ b/src/pymodaq/daq_viewer/daq_viewer_main.py
@@ -1203,6 +1203,8 @@ class DAQ_Viewer(QObject):
                 refresh = time.perf_counter() - self.start_grab_time > self.settings.child('main_settings',
                                                                                            'refresh_time').value() /\
                           1000
+                if refresh:
+                    self.start_grab_time = time.perf_counter()
             else:
                 refresh = True  # if single
             if self.settings.child('main_settings', 'show_data').value() and refresh:

--- a/src/pymodaq/daq_viewer/daq_viewer_main.py
+++ b/src/pymodaq/daq_viewer/daq_viewer_main.py
@@ -61,6 +61,12 @@ DAQ_NDViewer_Det_types = get_plugins('daq_NDviewer')
 
 class DAQ_Viewer(QObject):
     """
+
+    Attributes
+    ----------
+    do_save_data : bool
+        Set to True if the current acquisition should be saved (see save_export_data).
+
         ========================= =======================================
         **Attributes**             **Type**
 
@@ -724,16 +730,20 @@ class DAQ_Viewer(QObject):
             self.logger.exception(str(e))
 
     def save_current(self):
-        """
+        """Method called by the UI "Save current data" button.
 
+        Popup a window to ask the user to select a h5 file to save the current acquisition.
 
-            See Also
-            --------
-            gutils.select_file, save_export_data
+        This method should not be accessible if data_to_save_export is None (i.e. if there has been no grabbing). We
+        check that it is not None and write a message in the log file if it is the case.
+
         """
+        if self.data_to_save_export is None:
+            logger.error("The data buffer should not be empty if you call the save_current method. Grab data before.")
+            return
+
         self.do_save_data = True
-        self.save_file_pathname = select_file(start_path=self.save_file_pathname, save=True,
-                                                                                  ext='h5')  # see daq_utils
+        self.save_file_pathname = select_file(start_path=self.save_file_pathname, save=True, ext='h5')
         self.save_export_data(self.data_to_save_export)
 
     def save_new(self):

--- a/src/pymodaq/daq_viewer/daq_viewer_main.py
+++ b/src/pymodaq/daq_viewer/daq_viewer_main.py
@@ -1162,7 +1162,7 @@ class DAQ_Viewer(QObject):
 
     @Slot(list)
     def show_data(self, datas: List[utils.DataFromPlugins]):
-        """Transfert the acquired data from the detector (DAQ_Detector) to the UI viewer.
+        """Transfer the acquired data from the detector (DAQ_Detector) to the UI viewer.
 
         Triggered by DAQ_Detector.data_detector_sig.
         Emit the grab_done_signal.

--- a/src/pymodaq/daq_viewer/daq_viewer_main.py
+++ b/src/pymodaq/daq_viewer/daq_viewer_main.py
@@ -74,14 +74,30 @@ class DAQ_Viewer(QObject):
         user) to other modules that need the detector acquisition (e.g. Logger extension module to save the
         acquisition).
     command_detector : pyqt signal
-        This signal allows to send commands from the DAQ_Viewer thread to the DAQ_Detector thread.
+        This signal allows sending commands from the DAQ_Viewer thread to the DAQ_Detector thread.
         It is connected to DAQ_Detector.queue_command. This last method will call the proper method of the DAQ_Detector
         depending on the string that is sent in the ThreadCommand.
 
     Parameters
     ----------
-    refresh_time : ??
-        ??
+    refresh_time : int
+        Time delay (in ms) between two updates of the viewer in the UI. This time delay (contrary to
+        DAQ_Viewer.wait_time) will not directly affect the actual speed of the acquisition. If for example the
+        acquisition loop runs at 50 Hz, there is no point to display on the UI at such a speed. In that case the user
+        can specify a refresh time longer than 20 ms. Notice that the longer the refresh time, the better the
+        performances, since the displaying is quite costly in terms of resources. A very short refresh time can slow
+        down the program. For most applications, a refreshing time higher than 200 ms is enough. If the user wants to
+        optimize the performance of the program, he can untick the "Show data and process" parameter on the UI. If the
+        user chooses a refreshing time shorter than the delay between two acquisitions, then it just means that the
+        viewer will display all the acquisitions. Notice also that the ROI lineouts are calculated each time the
+        viewer is refreshed. It means that (up to now) the user cannot perform ROI lineouts calculation and saving
+        faster than the refresh time of the viewer. This is probably not an expected behavior.
+    show_data : bool
+        Corresponds to the "Show data and process" parameter on the UI.
+        If True the viewer is updated on the UI, if False the visualization of the acquisition is stopped. Notice that
+        the latter case does not mean that the backend treatment of the acquisition is stopped (e.g. each acquisition
+        can still be saved). The user can untick this parameter if he wants to optimize the speed of the program and
+        does not need to visualize what is going on.
 
     Attributes
     ----------
@@ -114,7 +130,6 @@ class DAQ_Viewer(QObject):
         ========================= =======================================
         **Attributes**             **Type**
 
-        *command_detector*         instance of pyqt Signal
         *quit_signal*              instance of pyqt Signal
         *update_settings_signal*   instance of pyqt Signal
         *overshoot_signal*         instance of pyqt Signal

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -554,22 +554,22 @@ class DashBoard(QObject):
             self.save_layout_state(path)
 
     def add_move(self, plug_name, plug_settings, plug_type, move_docks, move_forms, actuators_modules):
-        """Add an actuator to the dashboard?
+        """Add an actuator module to the dashboard
 
         Parameters
         ----------
         plug_name : str
             Title of the actuator module
-        plug_settings : ?
-            ?
-        plug_type : ?
-            ?
+        plug_settings : GroupParameter
+            Settings of the actuator module
+        plug_type : str
+            Plugin type (i.e. "SmarActMCS")
         move_docks : list of Dock
-            List of the DAQ_Move docks
-        move_forms : list of QWidget
-            ?
+            List of the actuators pyqtgraph docks (floating subwindows in the dashboard main window)
+        move_forms : list of Ui_Form
+            List of forms that define the graphical aspects of the UI of the modules
         actuators_modules : list of DAQ_Move objects
-            ?
+            The actuator modules of the dashboard
 
         """
         move_docks.append(Dock(plug_name, size=(150, 250)))
@@ -627,42 +627,7 @@ class DashBoard(QObject):
             det_docks_viewer = []
             move_forms = []
 
-            # # # set PID if checked in managers
-            # try:
-            #     if self.preset_manager.preset_params.child('use_pid').value():
-            #         self.load_pid_module()
-            #
-            #         self.pid_module.settings.child('models', 'model_class').setValue(
-            #             self.preset_manager.preset_params.child('pid_models').value())
-            #         QtWidgets.QApplication.processEvents()
-            #         self.pid_module.set_model()
-            #
-            #         QtWidgets.QApplication.processEvents()
-            #
-            #         for child in putils.iter_children_params(self.preset_manager.preset_params.child('model_settings'),
-            #                                                  []):
-            #             preset_path = self.preset_manager.preset_params.child('model_settings').childPath(child)
-            #             path = ['models', 'model_params']
-            #             path.extend(preset_path)
-            #             self.pid_module.settings.child(*path).setValue(child.value())
-            #
-            #         model_class = utils.get_models(
-            #             self.preset_manager.preset_params.child('pid_models').value())['class']
-            #         for setp in model_class.setpoints_names:
-            #             self.add_move(setp, None, 'PID', move_docks, move_forms, actuators_modules)
-            #             actuators_modules[-1].controller = dict(curr_point=self.pid_module.curr_points_signal,
-            #                                                setpoint=self.pid_module.setpoints_signal,
-            #                                                emit_curr_points=self.pid_module.emit_curr_points_sig)
-            #             actuators_modules[-1].ui.IniStage_pb.click()
-            #             QtWidgets.QApplication.processEvents()
-            #             self.poll_init(actuators_modules[-1])
-            #             QtWidgets.QApplication.processEvents()
-            #
-            # except Exception as e:
-            #     logger.exception(str(e))
-
-            # ################################################################
-            # ##### sort plugins by IDs and within the same IDs by Master and Slave status
+            # Sort plugins by IDs and within the same IDs by Master and Slave status
             plugins = []
             plugins += [{'type': 'move', 'value': child} for child in
                         self.preset_manager.preset_params.child('Moves').children()]
@@ -1056,7 +1021,7 @@ class DashBoard(QObject):
             for area in self.dockarea.tempAreas:
                 area.window().setVisible(False)
 
-            self.splash_sc.show()
+            #self.splash_sc.show()
             QtWidgets.QApplication.processEvents()
             self.splash_sc.raise_()
             self.splash_sc.showMessage('Loading Modules, please wait', color=Qt.white)

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -192,7 +192,7 @@ class DashBoard(QObject):
         if win is None:
             win = QtWidgets.QMainWindow()
 
-        win.showFullScreen()
+        win.showMaximized()
         dockarea = DockArea()
         win.setCentralWidget(dockarea)
         win.setWindowTitle('Logger extension module')
@@ -213,14 +213,13 @@ class DashBoard(QObject):
         else:
             self.pid_window = win
 
-        self.pid_window.showFullScreen()
         dockarea = DockArea()
         self.pid_window.setCentralWidget(dockarea)
         self.pid_window.setWindowTitle('PID extension module')
         self.pid_module = DAQ_PID(dockarea=dockarea)
         self.pid_module.set_module_manager(self.detector_modules, self.actuators_modules)
         self.extensions['DAQ_PID'] = self.pid_module
-        self.pid_window.show()
+        self.pid_window.showMaximized()
         return self.pid_module
 
     def load_extensions_module(self, ext):

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -554,7 +554,24 @@ class DashBoard(QObject):
             self.save_layout_state(path)
 
     def add_move(self, plug_name, plug_settings, plug_type, move_docks, move_forms, actuators_modules):
+        """Add an actuator to the dashboard?
 
+        Parameters
+        ----------
+        plug_name : str
+            Title of the actuator module
+        plug_settings : ?
+            ?
+        plug_type : ?
+            ?
+        move_docks : list of Dock
+            List of the DAQ_Move docks
+        move_forms : list of QWidget
+            ?
+        actuators_modules : list of DAQ_Move objects
+            ?
+
+        """
         move_docks.append(Dock(plug_name, size=(150, 250)))
         if len(move_docks) == 1:
             self.dockarea.addDock(move_docks[-1], 'right', self.logger_dock)
@@ -582,21 +599,21 @@ class DashBoard(QObject):
         actuators_modules.append(mov_mod_tmp)
 
     def set_file_preset(self, filename):
+        """Load a preset file.
+
+        Return the lists of actuator and detector modules defined in the preset file.
+
+        Parameters
+        ----------
+        filename : str
+            The full name of the xml file to be converted/treated
+
+        Returns
+        -------
+        actuators_modules, detector_modules : tuple list of DAQ_Move, list of DAQ_Viewer
+            The updated (Move modules list, Detector modules list).
+
         """
-            Set a file managers from the converted xml file given by the filename parameter.
-
-
-            =============== =========== ===================================================
-            **Parameters**    **Type**    **Description**
-            *filename*        string      the name of the xml file to be converted/treated
-            =============== =========== ===================================================
-
-            Returns
-            -------
-            (Object list, Object list) tuple
-                The updated (Move modules list, Detector modules list).
-
-           """
         actuators_modules = []
         detector_modules = []
         if not isinstance(filename, Path):
@@ -610,39 +627,39 @@ class DashBoard(QObject):
             det_docks_viewer = []
             move_forms = []
 
-            # # set PID if checked in managers
-            try:
-                if self.preset_manager.preset_params.child('use_pid').value():
-                    self.load_pid_module()
-
-                    self.pid_module.settings.child('models', 'model_class').setValue(
-                        self.preset_manager.preset_params.child('pid_models').value())
-                    QtWidgets.QApplication.processEvents()
-                    self.pid_module.set_model()
-
-                    QtWidgets.QApplication.processEvents()
-
-                    for child in putils.iter_children_params(self.preset_manager.preset_params.child('model_settings'),
-                                                             []):
-                        preset_path = self.preset_manager.preset_params.child('model_settings').childPath(child)
-                        path = ['models', 'model_params']
-                        path.extend(preset_path)
-                        self.pid_module.settings.child(*path).setValue(child.value())
-
-                    model_class = utils.get_models(
-                        self.preset_manager.preset_params.child('pid_models').value())['class']
-                    for setp in model_class.setpoints_names:
-                        self.add_move(setp, None, 'PID', move_docks, move_forms, actuators_modules)
-                        actuators_modules[-1].controller = dict(curr_point=self.pid_module.curr_points_signal,
-                                                           setpoint=self.pid_module.setpoints_signal,
-                                                           emit_curr_points=self.pid_module.emit_curr_points_sig)
-                        actuators_modules[-1].ui.IniStage_pb.click()
-                        QtWidgets.QApplication.processEvents()
-                        self.poll_init(actuators_modules[-1])
-                        QtWidgets.QApplication.processEvents()
-
-            except Exception as e:
-                logger.exception(str(e))
+            # # # set PID if checked in managers
+            # try:
+            #     if self.preset_manager.preset_params.child('use_pid').value():
+            #         self.load_pid_module()
+            #
+            #         self.pid_module.settings.child('models', 'model_class').setValue(
+            #             self.preset_manager.preset_params.child('pid_models').value())
+            #         QtWidgets.QApplication.processEvents()
+            #         self.pid_module.set_model()
+            #
+            #         QtWidgets.QApplication.processEvents()
+            #
+            #         for child in putils.iter_children_params(self.preset_manager.preset_params.child('model_settings'),
+            #                                                  []):
+            #             preset_path = self.preset_manager.preset_params.child('model_settings').childPath(child)
+            #             path = ['models', 'model_params']
+            #             path.extend(preset_path)
+            #             self.pid_module.settings.child(*path).setValue(child.value())
+            #
+            #         model_class = utils.get_models(
+            #             self.preset_manager.preset_params.child('pid_models').value())['class']
+            #         for setp in model_class.setpoints_names:
+            #             self.add_move(setp, None, 'PID', move_docks, move_forms, actuators_modules)
+            #             actuators_modules[-1].controller = dict(curr_point=self.pid_module.curr_points_signal,
+            #                                                setpoint=self.pid_module.setpoints_signal,
+            #                                                emit_curr_points=self.pid_module.emit_curr_points_sig)
+            #             actuators_modules[-1].ui.IniStage_pb.click()
+            #             QtWidgets.QApplication.processEvents()
+            #             self.poll_init(actuators_modules[-1])
+            #             QtWidgets.QApplication.processEvents()
+            #
+            # except Exception as e:
+            #     logger.exception(str(e))
 
             # ################################################################
             # ##### sort plugins by IDs and within the same IDs by Master and Slave status
@@ -785,8 +802,8 @@ class DashBoard(QObject):
                 self.load_layout_state(path)
 
             self.mainwindow.setWindowTitle(f'PyMoDAQ Dashboard: {self.title}')
-            if self.pid_module is not None:
-                self.pid_module.set_module_manager(detector_modules, actuators_modules)
+            # if self.pid_module is not None:
+            #     self.pid_module.set_module_manager(detector_modules, actuators_modules)
             return actuators_modules, detector_modules
         else:
             logger.error('Invalid file selected')
@@ -1111,6 +1128,39 @@ class DashBoard(QObject):
                 self.preset_loaded_signal.emit(True)
 
             logger.info(f'Preset file: {filename} has been loaded')
+
+            # If the preset is configured to use the pid extension
+            if self.preset_manager.preset_params.child('use_pid').value():
+                self.load_pid_module()
+
+                self.pid_module.settings.child('models', 'model_class').setValue(
+                    self.preset_manager.preset_params.child('pid_models').value())
+                QtWidgets.QApplication.processEvents()
+                self.pid_module.set_model()
+
+                QtWidgets.QApplication.processEvents()
+
+                for child in putils.iter_children_params(self.preset_manager.preset_params.child('model_settings'),
+                                                         []):
+                    preset_path = self.preset_manager.preset_params.child('model_settings').childPath(child)
+                    path = ['models', 'model_params']
+                    path.extend(preset_path)
+                    self.pid_module.settings.child(*path).setValue(child.value())
+
+                model_class = utils.get_models(
+                    self.preset_manager.preset_params.child('pid_models').value())['class']
+
+                # Add a mock actuator modules that will control each setpoint
+                for setp in model_class.setpoints_names:
+                    self.add_move(setp, None, 'PID', [], [], actuators_modules)
+                    actuators_modules[-1].controller = dict(
+                        curr_point=self.pid_module.curr_points_signal,
+                        setpoint=self.pid_module.setpoints_signal,
+                        emit_curr_points=self.pid_module.emit_curr_points_sig)
+                    actuators_modules[-1].ui.IniStage_pb.click()
+                    QtWidgets.QApplication.processEvents()
+                    self.poll_init(actuators_modules[-1])
+                    QtWidgets.QApplication.processEvents()
 
         except Exception as e:
             logger.exception(str(e))

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -167,17 +167,28 @@ class DashBoard(QObject):
             logger.exception(str(e))
 
     def load_scan_module(self, win=None):
+        """Load the Scan extension module.
+
+        This method is called from the dashboard UI main menu: Extension > Scan
+
+        """
         if win is None:
             win = QtWidgets.QMainWindow()
-        area = DockArea()
-        win.setCentralWidget(area)
-        self.scan_module = DAQ_Scan(dockarea=area, dashboard=self)
+
+        dockarea = DockArea()
+        win.setCentralWidget(dockarea)
+        self.scan_module = DAQ_Scan(dockarea=dockarea, dashboard=self)
         self.extensions['DAQ_Scan'] = self.scan_module
         self.scan_module.status_signal.connect(self.add_status)
         win.show()
         return self.scan_module
 
     def load_log_module(self, win=None):
+        """Load the Logger extension module.
+
+        This method is called from the dashboard UI main menu: Extension > Log data
+
+        """
         if win is None:
             win = QtWidgets.QMainWindow()
 
@@ -192,6 +203,11 @@ class DashBoard(QObject):
         return self.log_module
 
     def load_pid_module(self, win=None):
+        """Load the PID extension module.
+
+        This method is called from the dashboard UI main menu: Extension > PID
+
+        """
         if win is None:
             self.pid_window = QtWidgets.QMainWindow()
         else:

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -995,26 +995,16 @@ class DashBoard(QObject):
         """Load a preset file.
 
         This method is called from the dashboard UI main menu: Preset modes > Load preset > <preset name>
-            | Set the managers mode from the given filename.
-            |
-            | In case of "mock" or "canon" move, set the corresponding managers calling set_(*)_preset procedure.
-            |
-            | Else set the managers file using set_file_preset function.
-            | Once done connect the move and detector modules to logger to recipe/transmit informations.
 
-            Finally update DAQ_scan_settings tree with :
-                * Detectors
-                * Move
-                * plot_form.
+        Parameters
+        ----------
+        filename : str
+            Complete path of the preset file
 
-            =============== =========== =============================================
-            **Parameters**    **Type**    **Description**
-            *filename*        string      the name of the managers file to be treated
-            =============== =========== =============================================
+        See Also
+        --------
+        set_file_preset, add_status, update_status
 
-            See Also
-            --------
-            set_Mock_preset, set_canon_preset, set_file_preset, add_status, update_status
         """
         try:
             if not isinstance(filename, Path):
@@ -1087,10 +1077,6 @@ class DashBoard(QObject):
                 self.settings_menu.setEnabled(True)
                 self.update_init_tree()
 
-                self.preset_loaded_signal.emit(True)
-
-            logger.info(f'Preset file: {filename} has been loaded')
-
             # If the preset is configured to use the pid extension
             if self.preset_manager.preset_params.child('use_pid').value():
                 self.load_pid_module()
@@ -1124,7 +1110,11 @@ class DashBoard(QObject):
                     self.poll_init(actuators_modules[-1])
                     QtWidgets.QApplication.processEvents()
 
+            self.preset_loaded_signal.emit(True)
+            logger.info(f'Preset file: {filename} has been loaded')
+
         except Exception as e:
+            logger.error(f'Preset file: {filename} has not been loaded properly')
             logger.exception(str(e))
 
     def update_init_tree(self):

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -667,8 +667,8 @@ class DashBoard(QObject):
                         plug['status'] = 'Master'
 
             IDs = list(set([plug['ID'] for plug in plugins]))
-            # %%
             plugins_sorted = []
+
             for id in IDs:
                 plug_Ids = []
                 for plug in plugins:
@@ -676,8 +676,6 @@ class DashBoard(QObject):
                         plug_Ids.append(plug)
                 plug_Ids.sort(key=lambda status: status['status'])
                 plugins_sorted.append(plug_Ids)
-            #################################################################
-            #######################
 
             ind_det = -1
             for plug_IDs in plugins_sorted:
@@ -787,8 +785,6 @@ class DashBoard(QObject):
                 self.load_layout_state(path)
 
             self.mainwindow.setWindowTitle(f'PyMoDAQ Dashboard: {self.title}')
-            # if self.pid_module is not None:
-            #     self.pid_module.set_module_manager(detector_modules, actuators_modules)
             return actuators_modules, detector_modules
         else:
             logger.error('Invalid file selected')

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -992,7 +992,9 @@ class DashBoard(QObject):
         return self.actuators_modules
 
     def set_preset_mode(self, filename):
-        """
+        """Load a preset file.
+
+        This method is called from the dashboard UI main menu: Preset modes > Load preset > <preset name>
             | Set the managers mode from the given filename.
             |
             | In case of "mock" or "canon" move, set the corresponding managers calling set_(*)_preset procedure.
@@ -1031,6 +1033,7 @@ class DashBoard(QObject):
 
             logger.info(f'Loading Preset file: {filename}')
             actuators_modules, detector_modules = self.set_file_preset(filename)
+
             if not (not actuators_modules and not detector_modules):
                 self.update_status('Preset mode ({}) has been loaded'.format(filename.name), log_type='log')
                 self.settings.child('loaded_files', 'preset_file').setValue(filename.name)
@@ -1038,12 +1041,6 @@ class DashBoard(QObject):
                 self.detector_modules = detector_modules
 
                 self.modules_manager = ModulesManager(self.detector_modules, self.actuators_modules)
-                #
-                if self.pid_module is not None:
-                    self.pid_module.ini_model_action.click()
-                #
-
-                #####################################################
                 self.overshoot_manager = OvershootManager(det_modules=[det.title for det in detector_modules],
                                                           actuators_modules=[move.title for move in actuators_modules])
                 # load overshoot if present
@@ -1101,7 +1098,7 @@ class DashBoard(QObject):
                 self.pid_module.settings.child('models', 'model_class').setValue(
                     self.preset_manager.preset_params.child('pid_models').value())
                 QtWidgets.QApplication.processEvents()
-                self.pid_module.set_model()
+                self.pid_module.ini_model()
 
                 QtWidgets.QApplication.processEvents()
 
@@ -1115,7 +1112,7 @@ class DashBoard(QObject):
                 model_class = utils.get_models(
                     self.preset_manager.preset_params.child('pid_models').value())['class']
 
-                # Add a mock actuator modules that will control each setpoint
+                # Add a mock actuator module that will control each setpoint defined in the model.
                 for setp in model_class.setpoints_names:
                     self.add_move(setp, None, 'PID', [], [], actuators_modules)
                     actuators_modules[-1].controller = dict(

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -193,9 +193,11 @@ class DashBoard(QObject):
             self.pid_window = QtWidgets.QMainWindow()
         else:
             self.pid_window = win
+
+        self.pid_window.showFullScreen()
         dockarea = DockArea()
         self.pid_window.setCentralWidget(dockarea)
-        self.pid_window.setWindowTitle('PID Controller')
+        self.pid_window.setWindowTitle('PID extension module')
         self.pid_module = DAQ_PID(dockarea=dockarea)
         self.pid_module.set_module_manager(self.detector_modules, self.actuators_modules)
         self.extensions['DAQ_PID'] = self.pid_module
@@ -1013,7 +1015,7 @@ class DashBoard(QObject):
             for area in self.dockarea.tempAreas:
                 area.window().setVisible(False)
 
-            #self.splash_sc.show()
+            self.splash_sc.show()
             QtWidgets.QApplication.processEvents()
             self.splash_sc.raise_()
             self.splash_sc.showMessage('Loading Modules, please wait', color=Qt.white)

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -180,9 +180,12 @@ class DashBoard(QObject):
     def load_log_module(self, win=None):
         if win is None:
             win = QtWidgets.QMainWindow()
-        area = DockArea()
-        win.setCentralWidget(area)
-        self.log_module = DAQ_Logger(dockarea=area, dashboard=self)
+
+        win.showFullScreen()
+        dockarea = DockArea()
+        win.setCentralWidget(dockarea)
+        win.setWindowTitle('Logger extension module')
+        self.log_module = DAQ_Logger(dockarea=dockarea, dashboard=self)
         self.extensions['DAQ_Logger'] = self.log_module
         self.log_module.status_signal.connect(self.add_status)
         win.show()

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -205,7 +205,15 @@ class DashBoard(QObject):
     def load_pid_module(self, win=None):
         """Load the PID extension module.
 
-        This method is called from the dashboard UI main menu: Extension > PID
+        This method is called from the dashboard UI main menu: Extension > PID.
+        It can also be called automatically (from Dashboard.set_preset_mode) if the preset file is configured to use the
+            PID extension.
+        It creates a new window to interact with the PID extension module.
+
+        Returns
+        -------
+        self.pid_module : DAQ_PID object
+            Main object to deal with the PID extension module.
 
         """
         if win is None:
@@ -1096,12 +1104,10 @@ class DashBoard(QObject):
             # If the preset is configured to use the pid extension
             if self.preset_manager.preset_params.child('use_pid').value():
                 self.load_pid_module()
-
                 self.pid_module.settings.child('models', 'model_class').setValue(
                     self.preset_manager.preset_params.child('pid_models').value())
                 QtWidgets.QApplication.processEvents()
                 self.pid_module.ini_model()
-
                 QtWidgets.QApplication.processEvents()
 
                 for child in putils.iter_children_params(self.preset_manager.preset_params.child('model_settings'),

--- a/src/pymodaq/pid/pid_controller.py
+++ b/src/pymodaq/pid/pid_controller.py
@@ -592,7 +592,7 @@ class PIDRunner(QObject):
                     self.outputs = [pid.setpoint for pid in self.pids]
 
                 dt = time.perf_counter() - self.current_time
-                self.outputs_to_actuators = self.model_class.convert_output(self.outputs, dt, stab=True)
+                self.outputs_to_actuators = self.model_class.convert_output(self.outputs)
 
                 if not self.paused:
                     self.modules_manager.move_actuators(self.outputs_to_actuators.values,

--- a/src/pymodaq/pid/utils.py
+++ b/src/pymodaq/pid/utils.py
@@ -9,7 +9,6 @@ DAQ_2DViewer_Det_types = get_plugins('daq_2Dviewer')
 DAQ_NDViewer_Det_types = get_plugins('daq_NDviewer')
 
 
-
 class InputFromDetector:
     def __init__(self, values=[]):
         super().__init__()
@@ -90,7 +89,6 @@ class PIDModelGeneric:
             name = name.split('//')
             self.data_names.append(name)
 
-
     def update_settings(self, param):
         """
         Get a parameter instance whose value has been modified by a user on the UI
@@ -107,6 +105,7 @@ class PIDModelGeneric:
     def convert_input(self, measurements):
         """
         Convert the measurements in the units to be fed to the PID (same dimensionality as the setpoint)
+
         Parameters
         ----------
         measurements: (Ordereddict) Ordereded dict of object from which the model extract a value of the same units as the setpoint
@@ -121,6 +120,7 @@ class PIDModelGeneric:
     def convert_output(self, outputs, dt, stab=True):
         """
         Convert the output of the PID in units to be fed into the actuator
+
         Parameters
         ----------
         outputs: (list of float) output value from the PID from which the model extract a value of the same units as the actuator

--- a/src/pymodaq/resources/config_template.toml
+++ b/src/pymodaq/resources/config_template.toml
@@ -81,3 +81,6 @@ default_preset_for_logger = "preset_default"
     [scan.tabular]
     type = "Linear" #either "Linear", "Adaptive" see pymodaq.daq_utils.scanner.py
     curvilinear = 0.1
+
+[module_manager]
+    timeout_s = 10  # in second


### PR DESCRIPTION
As I wanted to use the Logger extension in combination with the PID extension I faced a strange behavior: the amount of ROI values saved (defined in a 1Dviewer in my case) would not be the same as the number of spectra saved. So I digged quite a lot into pymodaq internals to understand this behavior. Finally I understood that the ROI values are calculated by the viewer, and that using a refresh time of the viewer higher than the actual acquisition rate would provoke that the ROI values are not calculated and saved for each acquisition. And this provokes a discrepency between the spectra saved and the ROI values, which is for sure not an expected behavior. An easy solution is just to put the refresh time at 0 and let the visualization running, but this is not fully satisfactory.

For now this PR does NOT solve this problem, but I hope it will come soon. As soon is the time for vacations I wanted to do a first stop and maybe have a first partial review ;)

In the end it is mainly docstrings that I put along my way, I followed the Numpy convention: [https://numpydoc.readthedocs.io/en/latest/format.html#documenting-class-instances](https://numpydoc.readthedocs.io/en/latest/format.html#documenting-class-instances). Hope it will help the reading of the code. Maybe I obsessed a bit with documentation but it is like that ;)

A modification in the Modules manager: asking "Probe detectors’ data" would freeze a running acquisition. Now we separate two cases: if the detector is not grabbing we ask for a grab, otherwise it is not needed and then we do not disturb the running acquisition.

There are also a few bug fixes in the related modules.

There is still some work to do:

* the ROI values saving should not depend on the refresh time of the viewer (explained above)
* include actuators in the logger extension (and not only detectors) so that we can also save their position.
* stopping the logger extension will stop the acquisition. This is not an expected behavior.
* how to save other parameters? For exemple in my case I would like to save the actuator position, but also a phase that is the result of a calculation from the ROI values and other parameters.

Enjoy! :D
