### PR TITLE
Live data grouping and filtering by DataSource when saving

### DIFF
--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -589,7 +589,8 @@ class DAQ_Viewer(ParameterManager, ControlModule):
                                 where=None)
         self._h5saver_continuous.settings.child('N_saved').setValue(self._h5saver_continuous.settings['N_saved'] + 1)
 
-    def insert_data(self, indexes: Tuple[int], where=None, distribution=DataDistribution['uniform']):
+    def insert_data(self, indexes: Tuple[int], where=None, distribution=DataDistribution['uniform'],
+                    save_raw_only=True):
         """Insert DataToExport to a DetectorExtendedSaver at specified indexes
 
         Parameters
@@ -598,12 +599,15 @@ class DAQ_Viewer(ParameterManager, ControlModule):
             The indexes within the extended array where to place these data
         where: Node or str
         distribution: DataDistribution enum
+        save_raw_only: bool
+            If True save only Raw data (no data processed from Roi)
 
         See Also
         --------
         DAQ_Scan, DetectorExtendedSaver
         """
-        self._add_data_to_saver(self._data_to_save_export, init_step=np.all(np.array(indexes) == 0), where=where,
+        data = self._data_to_save_export if not save_raw_only else self._data_to_save_export.get_data_from_source('raw')
+        self._add_data_to_saver(data, init_step=np.all(np.array(indexes) == 0), where=where,
                                 indexes=indexes, distribution=distribution)
 
     def _add_data_to_saver(self, data: DataToExport, init_step=False, where=None, **kwargs):

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -589,8 +589,7 @@ class DAQ_Viewer(ParameterManager, ControlModule):
                                 where=None)
         self._h5saver_continuous.settings.child('N_saved').setValue(self._h5saver_continuous.settings['N_saved'] + 1)
 
-    def insert_data(self, indexes: Tuple[int], where=None, distribution=DataDistribution['uniform'],
-                    save_raw_only=True):
+    def insert_data(self, indexes: Tuple[int], where=None, distribution=DataDistribution['uniform']):
         """Insert DataToExport to a DetectorExtendedSaver at specified indexes
 
         Parameters
@@ -606,12 +605,13 @@ class DAQ_Viewer(ParameterManager, ControlModule):
         --------
         DAQ_Scan, DetectorExtendedSaver
         """
-        data = self._data_to_save_export if not save_raw_only else self._data_to_save_export.get_data_from_source('raw')
-        self._add_data_to_saver(data, init_step=np.all(np.array(indexes) == 0), where=where,
+        self._add_data_to_saver(self._data_to_save_export, init_step=np.all(np.array(indexes) == 0), where=where,
                                 indexes=indexes, distribution=distribution)
 
     def _add_data_to_saver(self, data: DataToExport, init_step=False, where=None, **kwargs):
         """Adds DataToExport data to the current node using the declared module_and_data_saver
+
+        Filters the data to be saved by DataSource as specified in the current H5Saver (see self.module_and_data_saver)
 
         Parameters
         ----------
@@ -628,6 +628,9 @@ class DAQ_Viewer(ParameterManager, ControlModule):
 
         """
         detector_node = self.module_and_data_saver.get_set_node(where)
+        data = data if not self.module_and_data_saver.h5saver.settings['save_raw_only'] else\
+            self._data_to_save_export.get_data_from_source('raw')
+
         self.module_and_data_saver.add_data(detector_node, data, **kwargs)
 
         if init_step:

--- a/src/pymodaq/extensions/daq_scan.py
+++ b/src/pymodaq/extensions/daq_scan.py
@@ -1124,8 +1124,7 @@ class DAQScanAcquisition(QObject):
                 nav_axes = self.scanner.get_nav_axes()
                 self.module_and_data_saver.add_nav_axes(nav_axes)
 
-            self.module_and_data_saver.add_data(indexes=indexes, distribution=self.scanner.distribution,
-                                                save_raw_only=self.h5saver.settings['save_raw_only'])
+            self.module_and_data_saver.add_data(indexes=indexes, distribution=self.scanner.distribution)
 
             #todo related to adaptive (solution lies along the Enlargeable data saver)
             if self.isadaptive:

--- a/src/pymodaq/extensions/daq_scan.py
+++ b/src/pymodaq/extensions/daq_scan.py
@@ -74,7 +74,7 @@ class DAQScan(QObject, ParameterManager):
         ]},
         {'title': 'Scan options', 'name': 'scan_options', 'type': 'group', 'children': [
             {'title': 'Naverage:', 'name': 'scan_average', 'type': 'int', 'value': 1, 'min': 1},
-            {'title': 'Group 0D data:', 'name': 'group0D', 'type': 'bool', 'value': False},
+            {'title': 'Group 0D data:', 'name': 'group0D', 'type': 'bool', 'value': True},
             {'title': 'Sort 1D scan data:', 'name': 'sort_scan1D', 'type': 'bool', 'value': False},]},
 
         {'title': 'Plotting options', 'name': 'plot_options', 'type': 'group', 'children': [
@@ -616,12 +616,15 @@ class DAQScan(QObject, ParameterManager):
 
         viewers_enum = [ViewersEnum('Data0D').increase_dim(self.scanner.n_axes)
                         for _ in range(len(self.settings['plot_options', 'plot_0d']['selected']))]
+        data_names = self.settings['plot_options', 'plot_0d']['selected']
 
         if self.settings['scan_options', 'group0D'] and len(viewers_enum) > 0 and ViewersEnum('Data1D') in viewers_enum:
             viewers_enum = [ViewersEnum('Data1D')]
+            data_names = [self.live_plotter.grouped_data1D_fullname]
         viewers_enum.extend([ViewersEnum('Data1D').increase_dim(self.scanner.n_axes)
                              for _ in range(len(self.settings['plot_options', 'plot_1d']['selected']))])
-        self.live_plotter.prepare_viewers(viewers_enum)
+        data_names.extend(self.settings['plot_options', 'plot_1d']['selected'])
+        self.live_plotter.prepare_viewers(viewers_enum, viewers_name=data_names)
 
     def update_status(self, txt, wait_time=0, log_type=None):
         """
@@ -1121,7 +1124,8 @@ class DAQScanAcquisition(QObject):
                 nav_axes = self.scanner.get_nav_axes()
                 self.module_and_data_saver.add_nav_axes(nav_axes)
 
-            self.module_and_data_saver.add_data(indexes=indexes, distribution=self.scanner.distribution)
+            self.module_and_data_saver.add_data(indexes=indexes, distribution=self.scanner.distribution,
+                                                save_raw_only=self.h5saver.settings['save_raw_only'])
 
             #todo related to adaptive (solution lies along the Enlargeable data saver)
             if self.isadaptive:

--- a/src/pymodaq/utils/data.py
+++ b/src/pymodaq/utils/data.py
@@ -1567,6 +1567,23 @@ class DataToExport(DataLowLevel):
 
         return dims
 
+    def get_data_from_source(self, source: DataSource, deepcopy=False) -> DataToExport:
+        """Get the data matching the given DataSource
+
+        Returns
+        -------
+        DataToExport: filtered with data matching the dimensionality
+        """
+        source = enum_checker(DataSource, source)
+        selection = find_objects_in_list_from_attr_name_val(self.data, 'source', source, return_first=False)
+
+        selection.sort(key=lambda elt: elt[0].name)
+        if deepcopy:
+            data = [sel[0].deepcopy() for sel in selection]
+        else:
+            data = [sel[0] for sel in selection]
+        return DataToExport(name=self.name, data=data)
+
     def get_data_from_dim(self, dim: DataDim, deepcopy=False) -> DataToExport:
         """Get the data matching the given DataDim
 

--- a/src/pymodaq/utils/h5modules/module_saving.py
+++ b/src/pymodaq/utils/h5modules/module_saving.py
@@ -332,12 +332,10 @@ class ScanSaver(ModuleSaver):
         for detector in self._module.modules_manager.detectors:
             detector.module_and_data_saver.add_nav_axes(self._module_group, axes)
 
-    def add_data(self, indexes: Tuple[int] = None, distribution=DataDistribution['uniform'],
-                 save_raw_only=True):
+    def add_data(self, indexes: Tuple[int] = None, distribution=DataDistribution['uniform']):
         for detector in self._module.modules_manager.detectors:
             try:
-                detector.insert_data(indexes, where=self._module_group, distribution=distribution,
-                                     save_raw_only=save_raw_only)
+                detector.insert_data(indexes, where=self._module_group, distribution=distribution)
             except Exception as e:
                 pass
 

--- a/src/pymodaq/utils/h5modules/module_saving.py
+++ b/src/pymodaq/utils/h5modules/module_saving.py
@@ -332,10 +332,12 @@ class ScanSaver(ModuleSaver):
         for detector in self._module.modules_manager.detectors:
             detector.module_and_data_saver.add_nav_axes(self._module_group, axes)
 
-    def add_data(self, indexes: Tuple[int] = None, distribution=DataDistribution['uniform']):
+    def add_data(self, indexes: Tuple[int] = None, distribution=DataDistribution['uniform'],
+                 save_raw_only=True):
         for detector in self._module.modules_manager.detectors:
             try:
-                detector.insert_data(indexes, where=self._module_group, distribution=distribution)
+                detector.insert_data(indexes, where=self._module_group, distribution=distribution,
+                                     save_raw_only=save_raw_only)
             except Exception as e:
                 pass
 

--- a/tests/utils/data_test.py
+++ b/tests/utils/data_test.py
@@ -36,10 +36,10 @@ def init_axis(data=None, index=0):
     return data_mod.Axis(label=LABEL, units=UNITS, data=data, index=index)
 
 
-def init_data(data=None, Ndata=1, axes=[], name='myData') -> data_mod.DataWithAxes:
+def init_data(data=None, Ndata=1, axes=[], name='myData', source=data_mod.DataSource['raw']) -> data_mod.DataWithAxes:
     if data is None:
         data = DATA2D
-    return data_mod.DataWithAxes(name, data_mod.DataSource(0), data=[data for ind in range(Ndata)],
+    return data_mod.DataWithAxes(name, source, data=[data for ind in range(Ndata)],
                                  axes=axes)
 
 
@@ -523,6 +523,20 @@ class TestDataToExport:
         data.append(dat3)
         assert len(data) == 3
         assert data.data == [dat1, dat2, dat3]
+
+    def test_get_data_from_source(self):
+        dat0D = init_data(DATA0D, 2, name='my0DData', source='raw')
+        dat1D_calculated = init_data(DATA1D, 2, name='my1DDatacalculated', source='calculated')
+        dat1D_raw = init_data(DATA1D, 2, name='my1DDataraw', source='raw')
+
+        data = data_mod.DataToExport(name='toexport', data=[dat0D, dat1D_calculated, dat1D_raw])
+
+        assert len(data.get_data_from_source('calculated')) == 1
+        assert data.get_data_from_source('calculated').data == [dat1D_calculated]
+
+        assert len(data.get_data_from_source('raw')) == 2
+        assert data.get_data_from_source('raw').get_data_from_dim('Data0D').data == [dat0D]
+        assert data.get_data_from_source('raw').get_data_from_dim('Data1D').data == [dat1D_raw]
 
     def test_get_data_by_dim(self, ini_data_to_export):
         dat1, dat2, data = ini_data_to_export


### PR DESCRIPTION
Solve issue #101 when one want to plot all 0D data on the same viewer (scan1D)

In Saving option, one can choose to save only raw data, this is implemented here using the module_saving objects and modifying the insert_data from daq_viewer