### PR TITLE
scan_done patch

### DIFF
--- a/src/pymodaq/utils/h5modules/module_saving.py
+++ b/src/pymodaq/utils/h5modules/module_saving.py
@@ -336,9 +336,9 @@ class ScanSaver(ModuleSaver):
             saver_xml = ET.SubElement(settings_xml, 'H5Saver', type='group')
             saver_xml.append(ioxml.walk_parameters_to_xml(param=self._h5saver.settings))
 
-        return self._h5saver.add_incremental_group(self.group_type, where, title=self._module.title,
-                                                   settings_as_xml=ET.tostring(settings_xml),
-                                                   metadata=metadata)
+        return self._h5saver.add_scan_group(where, title=self._module.title,
+                                            settings_as_xml=ET.tostring(settings_xml),
+                                            metadata=metadata)
 
     def add_nav_axes(self, axes: List[Axis]):
         for detector in self._module.modules_manager.detectors:

--- a/src/pymodaq/utils/h5modules/saving.py
+++ b/src/pymodaq/utils/h5modules/saving.py
@@ -383,14 +383,16 @@ class H5SaverLowLevel(H5Backend):
         return group
 
     def add_scan_group(self, where='/RawData', title='', settings_as_xml='', metadata=dict([])):
-        """
-        Add a new group of type scan
+        """Add a new group of type scan
+
+        At creation adds the attributes description and scan_done to be used elsewhere
+
         See Also
         -------
         add_incremental_group
         """
         metadata.update(dict(description='', scan_done=False))
-        group = self.add_incremental_group('scan', where, title, settings_as_xml, metadata)
+        group = self.add_incremental_group(GroupType['scan'], where, title, settings_as_xml, metadata)
         return group
 
     def add_ch_group(self, where, title='', settings_as_xml='', metadata=dict([])):


### PR DESCRIPTION
any scan node should contain a scan_done attribute. This is made sure by calling the add_scan_group in the ScanSaver object (module_saving). But somehow the add_incremental_group was used so the automatic added attribute could not be done.