### PR TITLE
Making sure nested dict in the config are properly updated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "simple_pid",
     "toml",
     "qtconsole",
-    "tables"
+    "tables",
 ]
 
 [project.scripts]


### PR DESCRIPTION
An issue was raised if the user config file was only defining some of the entries of the nested configs. In this case the entire dict level was replaced with this partial dict. Now, the corresponding entry is updated leaving all the other ones intact. I think this was creating for a long time an issue in the CI related to the [general] entry (but not sure)