### PR TITLE
List paramater as dict and plugin configuration display

### DIFF
--- a/docs/src/api/api_control_modules/API_DAQMove_Module.rst
+++ b/docs/src/api/api_control_modules/API_DAQMove_Module.rst
@@ -19,10 +19,20 @@ applications.
 
 
 The DAQ_Move UI class
-*******************
+*********************
 
 This object is the User Interface of the DAQ_Viewer, allowing easy access to all of the DAQ_Viewer functionnalities
 in a generic interface.
 
 .. autoclass:: pymodaq.control_modules.daq_move_ui::DAQ_Move_UI
+   :members:
+
+
+The DAQ_Move Plugin Class
+*************************
+
+This object is the base class from which all actuator plugins should inherit. It exposes a few methods, attributes
+and signal that could be useful to understand.
+
+.. autoclass:: pymodaq.control_modules.move_utility_classes::DAQ_Move_base
    :members:

--- a/src/pymodaq/control_modules/daq_move_ui.py
+++ b/src/pymodaq/control_modules/daq_move_ui.py
@@ -39,6 +39,8 @@ class DAQ_Move_UI(ControlModuleUI):
             * show_log
             * actuator_changed
             * rel_value
+            * show_config
+            * show_plugin_config
 
     Methods
     -------
@@ -237,6 +239,8 @@ class DAQ_Move_UI(ControlModuleUI):
                         toolbar=self.toolbar)
         self.add_action('show_settings', 'Show Settings', 'Settings', "Show Settings", checkable=True,
                         toolbar=self.toolbar)
+        self.add_action('show_config', 'Show Config', 'tree', "Show Plugin Config", checkable=False,
+                        toolbar=self.toolbar)
         self.add_action('refresh_value', 'Refresh', 'Refresh2', "Refresh Value", checkable=True,
                         toolbar=self.toolbar)
         self.add_action('stop', 'Stop', 'stop', "Stop Motion", checkable=False,
@@ -256,6 +260,7 @@ class DAQ_Move_UI(ControlModuleUI):
         self.connect_action('move_abs_2', lambda: self.emit_move_abs(self.abs_value_sb_2))
         self.connect_action('log', lambda: self.command_sig.emit(ThreadCommand('show_log', )))
         self.connect_action('stop', lambda: self.command_sig.emit(ThreadCommand('stop', )))
+        self.connect_action('show_config', lambda : self.command_sig.emit(ThreadCommand('show_config', )))
 
         self.move_abs_pb.clicked.connect(lambda: self.emit_move_abs(self.abs_value_sb_bis))
 

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -5,7 +5,7 @@ Created on Wed Jan 10 16:54:14 2018
 @author: Weber Sébastien
 """
 from __future__ import annotations
-
+from importlib import import_module
 from collections import OrderedDict
 import copy
 import os
@@ -295,6 +295,7 @@ class DAQ_Viewer(ParameterManager, ControlModule):
 
     def detector_changed_from_ui(self, detector: str):
         self._detector = detector
+        self.update_plugin_config()
         self._set_setting_tree()
 
     @property
@@ -307,9 +308,16 @@ class DAQ_Viewer(ParameterManager, ControlModule):
         if det not in self.detectors:
             raise ValueError(f'{det} is not a valid Detector: {self.detectors}')
         self._detector = det
+        self.update_plugin_config()
         if self.ui is not None:
             self.ui.detector = det
         self._set_setting_tree()
+
+    def update_plugin_config(self):
+        parent_module = utils.find_dict_in_list_from_key_val(DET_TYPES[self.daq_type.name], 'name', self.detector)
+        mod = import_module(parent_module['module'].__package__.split('.')[0])
+        if hasattr(mod, 'config'):
+            self.plugin_config = mod.config
 
     def detectors_changed_from_ui(self, detectors: List[str]):
         self._detectors = detectors
@@ -912,10 +920,13 @@ class DAQ_Viewer(ParameterManager, ControlModule):
 
         elif param.name() == 'ip_address' or param.name == 'port':
             self._command_tcpip.emit(
-                ThreadCommand('update_connection', dict(ipaddress=self.settings.child('main_settings', 'tcpip',
-                                                                                      'ip_address').value(),
-                                                        port=self.settings.child('main_settings', 'tcpip',
-                                                                                 'port').value())))
+                ThreadCommand('update_connection', dict(ipaddress=self.settings['main_settings', 'tcpip',
+                                                                                      'ip_address'],
+                                                        port=self.settings['main_settings', 'tcpip',
+                                                                                 'port'])))
+
+        elif param.name() == 'plugin_config':
+            self.show_config(self.plugin_config)
 
         if path is not None:
             if 'main_settings' not in path:

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -15,6 +15,7 @@ from pymodaq.utils.parameter import Parameter
 from pymodaq.utils.enums import BaseEnum, enum_checker
 from pymodaq.utils.plotting.data_viewers.viewer import ViewersEnum
 from pymodaq.utils.exceptions import DetectorError
+from pymodaq.utils import config as configmod
 
 
 class DAQTypesEnum(BaseEnum):
@@ -114,6 +115,7 @@ class ControlModule(QObject):
         self._tcpclient_thread = None
         self._hardware_thread = None
         self.module_and_data_saver = None
+        self.plugin_config: configmod.Config = None
 
     def __repr__(self):
         return f'{self.__class__.__name__}: {self.title}'
@@ -135,6 +137,7 @@ class ControlModule(QObject):
                 * raise_timeout:
                 * show_splash: Display the splash screen with attribute as message
                 * close_splash
+                * show_config: display the plugin configuration
         """
 
         if status.command == "Update_Status":
@@ -283,6 +286,12 @@ class ControlModule(QObject):
         """Open the log file in the default text editor"""
         import webbrowser
         webbrowser.open(self.logger.parent.handlers[0].baseFilename)
+
+    def show_config(self, config: Config):
+        """ Display in a tree the current configuration"""
+        if config is not None:
+            config_tree = configmod.TreeFromToml(config)
+            config_tree.show_dialog()
 
     def update_status(self, txt, log=True):
         """Display a message in the ui status bar and eventually log the message

--- a/src/pymodaq/control_modules/viewer_utility_classes.py
+++ b/src/pymodaq/control_modules/viewer_utility_classes.py
@@ -36,6 +36,7 @@ params = [
          'readonly': True},
         {'title': 'Detector type:', 'name': 'detector_type', 'type': 'str', 'value': '', 'readonly': True},
         {'title': 'Detector Name:', 'name': 'module_name', 'type': 'str', 'value': '', 'readonly': True},
+        {'title': 'Plugin Config:', 'name': 'plugin_config', 'type': 'bool_push', 'label': 'Show Config', },
         {'title': 'Controller ID:', 'name': 'controller_ID', 'type': 'int', 'value': 0, 'default': 0, 'readonly': False},
         {'title': 'Show data and process:', 'name': 'show_data', 'type': 'bool', 'value': True, },
         {'title': 'Refresh time (ms):', 'name': 'refresh_time', 'type': 'float', 'value': 50., 'min': 0.},

--- a/src/pymodaq/utils/config.py
+++ b/src/pymodaq/utils/config.py
@@ -342,7 +342,7 @@ class BaseConfig:
 
     def dict_to_add_to_user(self):
         """To subclass"""
-        return None
+        return dict([])
 
     @property
     def config_path(self):

--- a/src/pymodaq/utils/daq_utils.py
+++ b/src/pymodaq/utils/daq_utils.py
@@ -408,6 +408,7 @@ def rint(x):
     """
     return int(np.rint(x))
 
+
 def elt_as_first_element(elt_list, match_word='Mock'):
     if not hasattr(elt_list, '__iter__'):
         raise TypeError('elt_list must be an iterable')
@@ -446,6 +447,11 @@ def elt_as_first_element_dicts(elt_list, match_word='Mock', key='name'):
     else:
         plugins = []
     return plugins
+
+
+def find_keys_from_val(dict_tmp: dict, val: object):
+    """Returns the keys from a dict if its value is matching val"""
+    return [k for k, v in dict_tmp.items() if v == val]
 
 
 def find_object_if_matched_attr_name_val(obj, attr_name, attr_value):

--- a/src/pymodaq/utils/parameter/ioxml.py
+++ b/src/pymodaq/utils/parameter/ioxml.py
@@ -163,14 +163,14 @@ def dict_from_param(param):
             readonly = '0'
     opts.update(dict(readonly=readonly))
 
-    if 'limits' in param.opts:
-        values = str(param.opts['limits'])
-        opts.update(dict(values=values))
+    # if 'limits' in param.opts:
+    #     values = str(param.opts['limits'])
+    #     opts.update(dict(values=values))
 
     if 'limits' in param.opts:
         limits = str(param.opts['limits'])
         opts.update(dict(limits=limits))
-        opts.update(dict(values=limits))
+        # opts.update(dict(values=limits))
 
     if 'addList' in param.opts:
         addList = str(param.opts['addList'])
@@ -273,13 +273,13 @@ def elt_to_dict(el):
         addText = str(el.get('addText'))
         param.update(dict(addText=addText))
 
-    if 'limits' in el.attrib.keys():
-        try:
-            values = list(eval(el.get('limits')))  # make sure the evaluated values are returned as list (in case another
-        # iterator type has been used
-            param.update(dict(values=values))
-        except:
-            pass
+    # if 'limits' in el.attrib.keys():
+    #     try:
+    #         values = list(eval(el.get('limits')))  # make sure the evaluated values are returned as list (in case another
+    #     # iterator type has been used
+    #         param.update(dict(values=values))
+    #     except:
+    #         pass
 
     if 'limits' in el.attrib.keys():
         try:
@@ -531,4 +531,4 @@ def XML_string_to_pobject(xml_string):
     --------
     parameter_to_xml_string
     """
-    return Parameter.create(name='settings', type='group', children=XML_file_to_parameter(xml_string))
+    return Parameter.create(name='settings', type='group', children=XML_string_to_parameter(xml_string))

--- a/src/pymodaq/utils/parameter/pymodaq_ptypes/list.py
+++ b/src/pymodaq/utils/parameter/pymodaq_ptypes/list.py
@@ -2,6 +2,7 @@ from qtpy import QtWidgets, QtGui, QtCore
 from pyqtgraph.parametertree.parameterTypes.list import ListParameter, ListParameterItem
 from pyqtgraph.parametertree.Parameter import ParameterItem
 
+
 class Combo_pb(QtWidgets.QWidget):
 
     def __init__(self, items=[]):

--- a/src/pymodaq/utils/parameter/utils.py
+++ b/src/pymodaq/utils/parameter/utils.py
@@ -121,7 +121,6 @@ def get_param_dict_from_name(parent_list, name, pop=False):
                 return ch
 
 
-
 if __name__ == '__main__':              # pragma: no cover
     parent = [
         {'title': 'Spectro Settings:', 'name': 'spectro_settings', 'type': 'group', 'expanded': True,
@@ -156,9 +155,15 @@ def set_param_from_param(param_old, param_new):
 
         if 'group' not in param_type:  # covers 'group', custom 'groupmove'...
             # try:
-            if 'list' in param_type:  # check if the value is in the limits of the old params (limits are usually set at initialization)
-                if child_new.value() not in child_old.opts['limits']:
-                    child_old.opts['limits'].append(child_new.value())
+            if 'list' in param_type:  # check if the value is in the limits of the old params
+                # (limits are usually set at initialization) but carefull as such paramater limits can be a list or a
+                # dict object
+                if isinstance(child_old.opts['limits'], list):
+                    if child_new.value() not in child_old.opts['limits']:
+                        child_old.opts['limits'].append(child_new.value())
+                elif isinstance(child_old.opts['limits'], dict):
+                    if child_new.value() not in child_old.opts['limits'].values():
+                        child_old.opts['limits'].update(dict(str(child_new.value()), child_new.value()))
 
                 child_old.setValue(child_new.value())
             elif 'str' in param_type or 'browsepath' in param_type or 'text' in param_type:

--- a/tests/control_modules/daq_move_test.py
+++ b/tests/control_modules/daq_move_test.py
@@ -36,6 +36,7 @@ def ini_daq_move_ui(init_qt):
     widget = QtWidgets.QWidget()
     qtbot.addWidget(widget)
     prog = DAQ_Move(widget)
+    widget.show()
     yield prog, qtbot, widget
     widget.close()
 
@@ -54,4 +55,5 @@ class TestMethods:
         assert ControlModule.quit_fun != DAQ_Move.quit_fun
         assert ControlModule.init_hardware != DAQ_Move.init_hardware
         assert ControlModule.init_hardware_ui != DAQ_Move.init_hardware_ui
+
 

--- a/tests/control_modules/move_utility_test.py
+++ b/tests/control_modules/move_utility_test.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""
+Created the 31/08/2023
+
+@author: Sebastien Weber
+"""
+
+from pymodaq_plugins_mock.daq_move_plugins.daq_move_MockNamedAxes import DAQ_Move_MockNamedAxes
+
+import pytest
+from pytest import fixture, approx
+
+
+@fixture
+def init_qt(qtbot):
+    return qtbot
+
+
+def test_stage_names(init_qt):
+    qtbot = init_qt
+    axis_names = DAQ_Move_MockNamedAxes.stage_names.copy()
+    prog = DAQ_Move_MockNamedAxes()
+
+    prog.ini_stage()
+    assert axis_names == prog.axis_names
+    name_axis = 'anotheraxis'
+    index_axis = 45
+    axis_names.update({name_axis: index_axis})
+    prog.axis_names = axis_names
+    assert prog.axis_names == axis_names
+
+    assert name_axis in prog.axis_names
+    prog.axis_name = name_axis
+    assert name_axis == prog.axis_name
+    assert prog.settings.child('multiaxes', 'axis').value() == index_axis

--- a/tests/utils/parameter_test/param_ioxml_test.py
+++ b/tests/utils/parameter_test/param_ioxml_test.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+Created the 29/08/2023
+
+@author: Sebastien Weber
+"""
+
+import numpy as np
+import pytest
+
+from pymodaq.utils.parameter import Parameter
+from pymodaq.utils.parameter import utils as putils
+from pymodaq.utils.parameter import ioxml
+from unittest import mock
+
+
+axes_names = {'Axis 1': 0, 'Axis 2': 1, 'Axis 3': 2}
+
+params = [{'title': 'Axes', 'name': 'axes', 'type': 'list', 'limits': axes_names}]
+
+settings = Parameter.create(name='settings', type='group', children=params)
+
+
+string = ioxml.parameter_to_xml_string(settings.child('axes'))
+
+ioxml.XML_string_to_pobject(string)


### PR DESCRIPTION
This PR deals with the actuator plugins defining multi axes not as a list but as a dict. The keys are what is shown in the UI tree but the value is the actual axis value (usually an integer for C/C++ libraries). 

A few convenience methods have been added in the plugin base class to get/set these axes or the current one. 

Finally mechanism to display plugin configuration has been added. This allow the user to define a custom config file to set the parameters of their actuators/detectors. One need to discuss how this should interact when defining presets in the dashboard...
