### PR TITLE
Using axis names methods

### DIFF
--- a/src/pymodaq/control_modules/daq_move_ui.py
+++ b/src/pymodaq/control_modules/daq_move_ui.py
@@ -249,9 +249,9 @@ class DAQ_Move_UI(ControlModuleUI):
                         toolbar=self.move_toolbar)
         self.add_action('show_controls', 'Show Controls', 'Add_Step', "Show more controls", checkable=True,
                         toolbar=self.toolbar)
-        self.add_action('show_settings', 'Show Settings', 'Settings', "Show Settings", checkable=True,
+        self.add_action('show_settings', 'Show Settings', 'tree', "Show Settings", checkable=True,
                         toolbar=self.toolbar)
-        self.add_action('show_config', 'Show Config', 'tree', "Show Plugin Config", checkable=False,
+        self.add_action('show_config', 'Show Config', 'Settings', "Show PyMoDAQ Config", checkable=False,
                         toolbar=self.toolbar)
         self.add_action('show_graph', 'Show Graph', 'graph', "Show Graph", checkable=True,
                         toolbar=self.toolbar)

--- a/src/pymodaq/control_modules/move_utility_classes.py
+++ b/src/pymodaq/control_modules/move_utility_classes.py
@@ -253,6 +253,7 @@ class DAQ_Move_base(QObject):
                 self.settings.child('multiaxes', 'axis').setValue(name)
             elif isinstance(limits, dict):
                 self.settings.child('multiaxes', 'axis').setValue(limits[name])
+            QtWidgets.QApplication.processEvents()
 
     @property
     def axis_names(self) -> Union[List, Dict]:
@@ -272,6 +273,7 @@ class DAQ_Move_base(QObject):
             names = list(names.keys())
         grouped_axes.update({'all_items': names, 'selected': []})
         self.settings.child('grouping', 'grouped_axes').setValue(grouped_axes)
+        QtWidgets.QApplication.processEvents()
 
     def ini_attributes(self):
         """ To be subclassed, in order to init specific attributes needed by the real implementation"""

--- a/src/pymodaq/control_modules/move_utility_classes.py
+++ b/src/pymodaq/control_modules/move_utility_classes.py
@@ -217,6 +217,10 @@ class DAQ_Move_base(QObject):
                 self.settings.restoreState(params_state.saveState())
 
         self.settings.sigTreeStateChanged.connect(self.send_param_status)
+        # self.settings.child('multiaxes',
+        #                     'axis').sigLimitsChanged.connect(lambda param,
+        #                                                             limits: self.send_param_status(
+        #    param, [(param, 'limits', None)]))
         if parent is not None:
             self._title = parent.title
         else:
@@ -262,7 +266,12 @@ class DAQ_Move_base(QObject):
 
     @axis_names.setter
     def axis_names(self, names: Union[List, Dict]):
-        self.settings.child('multiaxes', 'axis').opts['limits'] = names
+        self.settings.child('multiaxes', 'axis').setLimits(names)
+        grouped_axes = self.settings['grouping', 'grouped_axes'].copy()  # copying the dict otherwise the valuechanged will not be triggered
+        if isinstance(names, dict):
+            names = list(names.keys())
+        grouped_axes.update({'all_items': names, 'selected': []})
+        self.settings.child('grouping', 'grouped_axes').setValue(grouped_axes)
 
     def ini_attributes(self):
         """ To be subclassed, in order to init specific attributes needed by the real implementation"""
@@ -517,6 +526,9 @@ class DAQ_Move_base(QObject):
                                                                    change]))  # send parameters values/limits back to the GUI
             elif change == 'parent':
                 pass
+            elif change == 'limits':
+                self.emit_status(ThreadCommand('update_settings', [self.parent_parameters_path + path, data,
+                                                                   change]))
 
     def get_position_with_scaling(self, pos: DataActuator) -> DataActuator:
         """ Get the current position from the hardware with scaling conversion.

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -190,6 +190,7 @@ class ControlModule(QObject):
                 elif status.attribute[2] == 'limits':
                     self.settings.child(f'{control_module_type}_settings',
                                         *status.attribute[0]).setLimits(status.attribute[1])
+
                 elif status.attribute[2] == 'options':
                     self.settings.child(f'{control_module_type}_settings',
                                         *status.attribute[0]).setOpts(**status.attribute[1])


### PR DESCRIPTION
PR on the few methods to get/set the axis_names programatically in the DAQ_Move plugins