### PR TITLE
Add plugin package name to documentation

### DIFF
--- a/docs/src/developer_folder/instrument_plugins.rst
+++ b/docs/src/developer_folder/instrument_plugins.rst
@@ -54,6 +54,7 @@ Naming convention:
 For an instrument plugin to be properly recognised by PyMoDAQ, the location and name of the underlying script must
 follow some rules and syntax. The `plugin template package`__ could be copied locally as a starting point:
 
+* The plugin package will be named pymodaq_plugins_xxxx (name: xxxx)
 * An actuator plugin (name: xxxx) will be a script whose name is daq_move_Xxxx (notice first X letter is capital)
 * The main instrument class within the script will be named DAQ_Move_Xxxx (notice the capital letters here as well and sorry
   if it is troublesome)


### PR DESCRIPTION
The naming convention does not mention the name of the package, which you have to find elsewhere (http://pymodaq.cnrs.fr/en/latest/glossary.html#term-Plugin). This PR adds that name in the naming convention to make creating plugins more easy.