### PR TITLE
Fix node exporters

### DIFF
--- a/src/pymodaq/utils/gui_utils/file_io.py
+++ b/src/pymodaq/utils/gui_utils/file_io.py
@@ -6,6 +6,58 @@ from qtpy import QtWidgets
 config = Config()
 
 
+def select_file_filter(start_path=config('data_saving', 'h5file', 'save_path'), save=True, ext=None, filter=None,
+                force_save_extension=False):
+    """Opens a selection file popup for loading or saving a file
+
+    Parameters
+    ----------
+    start_path: str or Path
+        The strating point in the file/folder system to open the popup from
+    save: bool
+        if True, ask you to enter a filename (with or without extension)
+    ext: str
+        the extension string, e.g. xml, h5, png ...
+    filter: list of string
+        list of possible extensions, mostly valid for loading
+    force_save_extension: bool
+        if True force the extension of the saved file to be set to ext
+
+    Returns
+    -------
+    Path: the Path object of the file to save or load
+    str: the selected filter
+    """
+    if ext is None:
+        ext = '.h5'
+
+    if filter is None:
+        if not save:
+            if not isinstance(ext, list):
+                ext = [ext]
+            filter = "Data files ("
+            for ext_tmp in ext:
+                filter += '*.' + ext_tmp + " "
+            filter += ")"
+
+    if start_path is not None:
+        if not isinstance(start_path, str):
+            start_path = str(start_path)
+    if save:
+        fname, selected_filter = QtWidgets.QFileDialog.getSaveFileName(None, 'Enter a file name', start_path,
+                                                                       filter)
+    else:
+        fname, selected_filter = QtWidgets.QFileDialog.getOpenFileName(None, 'Select a file name', start_path, filter)
+
+    if fname != '':  # execute if the user didn't cancel the file selection
+        fname = Path(fname)
+        if save and force_save_extension:
+            parent = fname.parent
+            filename = fname.stem
+            fname = parent.joinpath(filename + "." + ext)  # forcing the right extension on the filename
+    return fname, selected_filter
+
+
 def select_file(start_path=config('data_saving', 'h5file', 'save_path'), save=True, ext=None, filter=None,
                 force_save_extension=False):
     """Opens a selection file popup for loading or saving a file
@@ -27,34 +79,8 @@ def select_file(start_path=config('data_saving', 'h5file', 'save_path'), save=Tr
     -------
     Path: the Path object of the file to save or load
     """
-    if ext is None:
-        ext = '.h5'
-
-    if filter is None:
-        if not save:
-            if not isinstance(ext, list):
-                ext = [ext]
-            filter = "Data files ("
-            for ext_tmp in ext:
-                filter += '*.' + ext_tmp + " "
-            filter += ")"
-    
-    if start_path is not None:
-        if not isinstance(start_path, str):
-            start_path = str(start_path)
-    if save:
-        fname = QtWidgets.QFileDialog.getSaveFileName(None, 'Enter a file name', start_path,
-                                                      filter)
-    else:
-        fname = QtWidgets.QFileDialog.getOpenFileName(None, 'Select a file name', start_path, filter)
-
-    fname = fname[0]
-    if fname != '':  # execute if the user didn't cancel the file selection
-        fname = Path(fname)
-        if save and force_save_extension:
-            parent = fname.parent
-            filename = fname.stem
-            fname = parent.joinpath(filename + "." + ext)  # forcing the right extension on the filename
+    fname, selected_filter = select_file_filter(start_path, save, ext, filter,
+                                                force_save_extension)
     return fname  # fname is a Path object
 
 

--- a/src/pymodaq/utils/h5modules/browsing.py
+++ b/src/pymodaq/utils/h5modules/browsing.py
@@ -26,7 +26,7 @@ from pymodaq.utils.gui_utils.widgets.tree_layout import TreeLayout
 from pymodaq.utils.daq_utils import capitalize
 from pymodaq.utils.data import Axis
 from pymodaq.utils.gui_utils.utils import h5tree_to_QTree, pngbinary2Qlabel
-from pymodaq.utils.gui_utils.file_io import select_file
+from pymodaq.utils.gui_utils.file_io import select_file, select_file_filter
 from pymodaq.utils.plotting.data_viewers.viewerND import ViewerND
 from qtpy import QtWidgets
 from pymodaq.utils import daq_utils as utils
@@ -55,7 +55,7 @@ class H5BrowserUtil(H5Backend):
     def __init__(self, backend='tables'):
         super().__init__(backend=backend)
 
-    def export_data(self, node_path='/', filesavename: str = 'datafile.h5'):
+    def export_data(self, node_path='/', filesavename: str = 'datafile.h5', filter=None):
         """Initialize the correct exporter and export the node"""
 
         # Format the node and file type
@@ -64,7 +64,8 @@ class H5BrowserUtil(H5Backend):
         # Separate dot from extension
         extension = filepath.suffix[1:]
         # Obtain the suitable exporter object
-        exporter = ExporterFactory.create_exporter(extension)
+        exporter = ExporterFactory.create_exporter(extension,
+                                                   ExporterFactory.get_format_from_filter(filter))
         # Export the data
         exporter.export_data(node, filepath)
 
@@ -408,10 +409,10 @@ class H5Browser(QObject, ActionManager):
         """
         try:
             file_filter = ExporterFactory.get_file_filters()
-            file = select_file(save=True, filter=file_filter)
+            file, selected_filter = select_file_filter(save=True, filter=file_filter)
             self.current_node_path = self.get_tree_node_path()
             if file != '':
-                self.h5utils.export_data(self.current_node_path, str(file))
+                self.h5utils.export_data(self.current_node_path, str(file), selected_filter)
 
         except Exception as e:
             logger.exception(str(e))

--- a/src/pymodaq/utils/h5modules/exporters/tes_exporter.py
+++ b/src/pymodaq/utils/h5modules/exporters/tes_exporter.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+Created the 17/10/2023
+
+@author: Sebastien Weber
+"""
+import numpy as np
+
+
+# project imports
+from pymodaq.utils.h5modules.backends import Node
+from pymodaq.utils.h5modules.exporter import ExporterFactory, H5Exporter
+from pymodaq.utils.h5modules.backends import H5Backend
+
+
+@ExporterFactory.register_exporter()
+class H5txtExporter(H5Exporter):
+    """ Exporter object for saving nodes as txt files"""
+
+    FORMAT_DESCRIPTION = "Text files for dummy export"
+    FORMAT_EXTENSION = "txt"
+
+    def export_data(self, node: Node, filename: str) -> None:
+        """Export the node as a .txt file format"""
+        if 'ARRAY' in node.attrs['CLASS']:
+            data = node.read()
+            if not isinstance(data, np.ndarray):
+                # in case one has a list of same objects (array of strings for instance, logger or other)
+                data = np.array(data)
+                np.savetxt(filename, data, '%s', '\t')
+            else:
+                np.savetxt(filename, data, '%.6e', '\t')
+        elif 'GROUP' in node.attrs['CLASS']:
+            data_tot = []
+            header = []
+            dtypes = []
+            fmts = []
+            for subnode_name, subnode in node.children().items():
+                if 'ARRAY' in subnode.attrs['CLASS']:
+                    if len(subnode.attrs['shape']) == 1:
+                        data = subnode.read()
+                        if not isinstance(data, np.ndarray):
+                            # in case one has a list of same objects (array of strings for instance, logger or other)
+                            data = np.array(data)
+                        data_tot.append(data)
+                        dtypes.append((subnode_name, data.dtype))
+                        header.append(subnode_name)
+                        if data.dtype.char == 'U':
+                            fmt = '%s'  # for strings
+                        elif data.dtype.char == 'l':
+                            fmt = '%d'  # for integers
+                        else:
+                            fmt = '%.6f'  # for decimal numbers
+                        fmts.append(fmt)
+
+            data_trans = np.array(list(zip(*data_tot)), dtype=dtypes)
+            np.savetxt(filename, data_trans, fmts, '\t', header='#' + '\t'.join(header))
+


### PR DESCRIPTION
So far if creating an other exporter with the same file extension if would be overwritten. Now the factory takes two identifiers: file format and format description. Like this one obtains a unique identifier (with two dictionnary keys) to not overwrite exporters even of they have the same extension