### PR TITLE
Fix 168 threading problems

### DIFF
--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -338,19 +338,6 @@ class DAQ_Move(ParameterManager, ControlModule):
             self.ui.close()
         # self.parent.close()
 
-    def init_hardware_ui(self, do_init=True):
-        """Programmatic actuator's Initialization
-
-        Programmatic way to simulate a click on the init button of the UI to initialize the communication with the
-        hardware
-
-        Parameters
-        ----------
-        do_init: bool
-            if the init or des-init should be performed
-        """
-        self.ui.do_init(do_init)
-
     def init_hardware(self, do_init=True):
         """ Init or desinit the selected instrument plugin class """
         if not do_init:

--- a/src/pymodaq/control_modules/daq_move_ui.py
+++ b/src/pymodaq/control_modules/daq_move_ui.py
@@ -302,11 +302,11 @@ class DAQ_Move_UI(ControlModuleUI):
         do_init: bool
             will fire the Init button depending on the argument value and the button check state
         """
-        if (do_init and not self.ini_actuator_pb.isChecked()) or ((not do_init) and self.ini_actuator_pb.isChecked()):
+        if do_init is not self.ini_actuator_pb.isChecked():
             self.ini_actuator_pb.click()
 
-    def send_init(self):
-        self.actuators_combo.setEnabled(not self.ini_actuator_pb.isChecked())
+    def send_init(self, checked):
+        self.actuators_combo.setEnabled(not checked)
         self.command_sig.emit(ThreadCommand('init', [self.ini_actuator_pb.isChecked(),
                                                      self.actuators_combo.currentText()]))
 

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -404,11 +404,6 @@ class DAQ_Viewer(ParameterManager, ControlModule):
     #  #####################################
     #  Methods for running the acquisition
 
-    def init_hardware_ui(self, do_init=True):
-        """Send a command to the underlying UI to click the init button"""
-        if self.ui is not None:
-            self.ui.do_init()
-
     def init_hardware(self, do_init=True):
         """ Init the selected detector
 

--- a/src/pymodaq/control_modules/daq_viewer_ui.py
+++ b/src/pymodaq/control_modules/daq_viewer_ui.py
@@ -232,7 +232,7 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
         self.connect_action('save_new', lambda: self.command_sig.emit(ThreadCommand('save_new', )))
         self.connect_action('open', lambda: self.command_sig.emit(ThreadCommand('open', )))
 
-        self._ini_det_pb.clicked.connect(self._send_init)
+        self._ini_det_pb.clicked.connect(self.send_init)
 
         self._detectors_combo.currentTextChanged.connect(
             lambda mod: self.command_sig.emit(ThreadCommand('detector_changed', mod)))
@@ -289,7 +289,7 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
         do_init: bool
             will fire the Init button depending on the argument value and the button check state
         """
-        if (do_init and not self._ini_det_pb.isChecked()) or ((not do_init) and self._ini_det_pb.isChecked()):
+        if do_init is not self._ini_det_pb.isChecked():
             self._ini_det_pb.click()
 
     def do_grab(self, do_grab=True):
@@ -317,10 +317,9 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
         if self.is_action_checked('grab'):
             self.get_action('grab').trigger()
 
-    def _send_init(self):
-        self._enable_detchoices(not self._ini_det_pb.isChecked())
-        self._ini_det_pb.isChecked()
-        self.command_sig.emit(ThreadCommand('init', [self._ini_det_pb.isChecked(),
+    def send_init(self, checked: bool):
+        self._enable_detchoices(not checked)
+        self.command_sig.emit(ThreadCommand('init', [checked,
                                                      self._daq_types_combo.currentText(),
                                                      self._detectors_combo.currentText()]))
 

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -374,6 +374,6 @@ class ControlModuleUI(CustomApp):
         """
         raise NotImplementedError
 
-    def send_init(self):
-        """Should be implemented to send to the main app the fact that someone pressed init."""
+    def send_init(self, checked: bool):
+        """Should be implemented to send to the main app the fact that someone (un)checked init."""
         raise NotImplementedError

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -102,6 +102,7 @@ class ControlModule(QObject):
     _update_settings_signal = Signal(edict)
     status_sig = Signal(str)
     custom_sig = Signal(ThreadCommand)
+    ui = None
 
     def __init__(self):
         super().__init__()
@@ -281,7 +282,8 @@ class ControlModule(QObject):
         -----
         This method should be preferred to :meth:`init_hardware`
         """
-        raise NotImplementedError
+        if self.ui is not None:
+            self.ui.do_init(do_init)
 
     def show_log(self):
         """Open the log file in the default text editor"""
@@ -373,5 +375,5 @@ class ControlModuleUI(CustomApp):
         raise NotImplementedError
 
     def send_init(self):
-        """Shoudl be implemented to send to the main app the fact that someone pressed init"""
+        """Should be implemented to send to the main app the fact that someone pressed init."""
         raise NotImplementedError

--- a/src/pymodaq/control_modules/viewer_utility_classes.py
+++ b/src/pymodaq/control_modules/viewer_utility_classes.py
@@ -114,7 +114,7 @@ def main(plugin_file=None, init=True):
     prog.daq_type = det_type
     prog.detector = detector
     if init:
-        prog.init_hardware()
+        prog.init_hardware_ui()
 
     sys.exit(app.exec_())
 

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -755,24 +755,27 @@ class DashBoard(QObject):
                             self.add_move(plug_name, plug_settings, plug_type, move_docks, move_forms,
                                           actuators_modules)
 
-                            if ind_plugin == 0:  # should be a master type plugin
-                                if plugin['status'] != "Master":
-                                    logger.error('error in the master/slave type for plugin {}'.format(plug_name))
-                                if plug_init:
-                                    actuators_modules[-1].init_hardware_ui()
-                                    QtWidgets.QApplication.processEvents()
-                                    self.poll_init(actuators_modules[-1])
-                                    QtWidgets.QApplication.processEvents()
-                                    master_controller = actuators_modules[-1].controller
-                            else:
-                                if plugin['status'] != "Slave":
-                                    logger.error('error in the master/slave type for plugin {}'.format(plug_name))
-                                if plug_init:
-                                    actuators_modules[-1].controller = master_controller
-                                    actuators_modules[-1].init_hardware_ui()
-                                    QtWidgets.QApplication.processEvents()
-                                    self.poll_init(actuators_modules[-1])
-                                    QtWidgets.QApplication.processEvents()
+                            try:
+                                if ind_plugin == 0:  # should be a master type plugin
+                                    if plugin['status'] != "Master":
+                                        logger.error('error in the master/slave type for plugin {}'.format(plug_name))
+                                    if plug_init:
+                                        actuators_modules[-1].init_hardware_ui()
+                                        QtWidgets.QApplication.processEvents()
+                                        self.poll_init(actuators_modules[-1])
+                                        QtWidgets.QApplication.processEvents()
+                                        master_controller = actuators_modules[-1].controller
+                                else:
+                                    if plugin['status'] != "Slave":
+                                        logger.error('error in the master/slave type for plugin {}'.format(plug_name))
+                                    if plug_init:
+                                        actuators_modules[-1].controller = master_controller
+                                        actuators_modules[-1].init_hardware_ui()
+                                        QtWidgets.QApplication.processEvents()
+                                        self.poll_init(actuators_modules[-1])
+                                        QtWidgets.QApplication.processEvents()
+                            except Exception as e:
+                                logger.exception(str(e))
                         except ActuatorError as e:
                             self.splash_sc.close()
                             messagebox(text=f'{str(e)}\nQuitting the application...', title='Incompatibility')

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -791,7 +791,7 @@ class DashBoard(QObject):
                                     if plugin['status'] != "Master":
                                         logger.error('error in the master/slave type for plugin {}'.format(plug_name))
                                     if plug_init:
-                                        detector_modules[-1].init_hardware()
+                                        detector_modules[-1].init_hardware_ui()
                                         QtWidgets.QApplication.processEvents()
                                         self.poll_init(detector_modules[-1])
                                         QtWidgets.QApplication.processEvents()
@@ -801,7 +801,7 @@ class DashBoard(QObject):
                                         logger.error('error in the master/slave type for plugin {}'.format(plug_name))
                                     if plug_init:
                                         detector_modules[-1].controller = master_controller
-                                        detector_modules[-1].init_hardware()
+                                        detector_modules[-1].init_hardware_ui()
                                         QtWidgets.QApplication.processEvents()
                                         self.poll_init(detector_modules[-1])
                                         QtWidgets.QApplication.processEvents()


### PR DESCRIPTION
The first commit (2e1ae5b) closes #168
The culprit was to call "init_hardware" instead of "init_hardware_ui" in dashboard

The other commits harmonize viewer and move in "send_init" etc.

I found another bug which stops the dashboard from loading. Catching that error (just a try except clause added) allows the dashboard to load. See #175 