### PR TITLE
One can modify configuration and allow settings edition during grab

### DIFF
--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -165,7 +165,8 @@ class DAQ_Move(ParameterManager, ControlModule):
         elif cmd.command == 'show_log':
             self.show_log()
         elif cmd.command == 'show_config':
-            self.show_config(config)
+            self.config = self.show_config(self.config)
+            self.ui.config = self.config
         elif cmd.command == 'actuator_changed':
             self.actuator = cmd.attribute
         elif cmd.command == 'rel_value':

--- a/src/pymodaq/control_modules/daq_move_ui.py
+++ b/src/pymodaq/control_modules/daq_move_ui.py
@@ -276,7 +276,7 @@ class DAQ_Move_UI(ControlModuleUI):
         self.connect_action('move_abs_2', lambda: self.emit_move_abs(self.abs_value_sb_2))
         self.connect_action('log', lambda: self.command_sig.emit(ThreadCommand('show_log', )))
         self.connect_action('stop', lambda: self.command_sig.emit(ThreadCommand('stop', )))
-        self.connect_action('show_config', lambda : self.command_sig.emit(ThreadCommand('show_config', )))
+        self.connect_action('show_config', lambda: self.command_sig.emit(ThreadCommand('show_config', )))
 
         self.move_abs_pb.clicked.connect(lambda: self.emit_move_abs(self.abs_value_sb_bis))
 

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -171,6 +171,7 @@ class DAQ_Viewer(ParameterManager, ControlModule):
         self._set_setting_tree()  # to activate parameters of default Mock detector
 
         self.grab_done_signal.connect(self._save_export_data)
+        self.update_plugin_config()
 
     def __repr__(self):
         return f'{self.__class__.__name__}: {self.title} ({self.daq_type}/{self.detector}'
@@ -204,6 +205,7 @@ class DAQ_Viewer(ParameterManager, ControlModule):
                 * do_bkg
                 * take_bkg
                 * viewers_changed
+                * show_config
         """
 
         if cmd.command == 'init':
@@ -237,6 +239,9 @@ class DAQ_Viewer(ParameterManager, ControlModule):
         elif cmd.command == 'viewers_changed':
             self._viewer_types: List[ViewersEnum] = cmd.attribute['viewer_types']
             self.viewers = cmd.attribute['viewers']
+        elif cmd.command == 'show_config':
+            self.config = self.show_config(self.config)
+            self.ui.config = self.config
 
     @property
     def bkg(self) -> DataToExport:
@@ -427,7 +432,7 @@ class DAQ_Viewer(ParameterManager, ControlModule):
 
                 hardware = DAQ_Detector(self._title, self.settings, self.detector)
                 self._hardware_thread = QThread()
-                if config('viewer', 'viewer_in_thread'):
+                if self.config('viewer', 'viewer_in_thread'):
                     hardware.moveToThread(self._hardware_thread)
 
                 self.command_hardware[ThreadCommand].connect(hardware.queue_command)
@@ -437,7 +442,7 @@ class DAQ_Viewer(ParameterManager, ControlModule):
                 self._update_settings_signal[edict].connect(hardware.update_settings)
 
                 self._hardware_thread.hardware = hardware
-                if config('viewer', 'viewer_in_thread'):
+                if self.config('viewer', 'viewer_in_thread'):
                     self._hardware_thread.start()
                 self.command_hardware.emit(ThreadCommand("ini_detector", attribute=[
                     self.settings.child('detector_settings').saveState(), self.controller]))
@@ -926,10 +931,9 @@ class DAQ_Viewer(ParameterManager, ControlModule):
 
         elif param.name() == 'ip_address' or param.name == 'port':
             self._command_tcpip.emit(
-                ThreadCommand('update_connection', dict(ipaddress=self.settings['main_settings', 'tcpip',
-                                                                                      'ip_address'],
-                                                        port=self.settings['main_settings', 'tcpip',
-                                                                                 'port'])))
+                ThreadCommand('update_connection',
+                              dict(ipaddress=self.settings['main_settings', 'tcpip', 'ip_address'],
+                                   port=self.settings['main_settings', 'tcpip', 'port'])))
 
         elif param.name() == 'plugin_config':
             self.show_config(self.plugin_config)

--- a/src/pymodaq/control_modules/daq_viewer_ui.py
+++ b/src/pymodaq/control_modules/daq_viewer_ui.py
@@ -279,7 +279,8 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
         """Slot from the *grab* action"""
         self.command_sig.emit(ThreadCommand('grab', attribute=self.is_action_checked('grab')))
         self._enable_ini_buttons(not self.is_action_checked('grab'))
-        self._settings_widget.setEnabled(not self.is_action_checked('grab'))
+        if not config('viewer', 'allow_settings_edition'):
+            self._settings_widget.setEnabled(not self.is_action_checked('grab'))
 
     def do_init(self, do_init=True):
         """Programmatically press the Init button

--- a/src/pymodaq/control_modules/daq_viewer_ui.py
+++ b/src/pymodaq/control_modules/daq_viewer_ui.py
@@ -209,6 +209,8 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
         self.add_action('show_settings', 'Show Settings', 'tree', "Show Settings", checkable=True)
 
         self.add_action('quit', 'Quit the module', 'close2')
+        self.add_action('show_config', 'Show Config', 'Settings', "Show PyMoDAQ Config", checkable=False,
+                        toolbar=self.toolbar)
         self.add_action('log', 'Show Log file', 'information2')
 
         self._data_ready_led = QLED(readonly=True)
@@ -218,6 +220,7 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
         self.connect_action('show_controls', lambda show: self._detector_widget.setVisible(show))
         self.connect_action('show_settings', lambda show: self._settings_widget.setVisible(show))
         self.connect_action('quit', lambda: self.command_sig.emit(ThreadCommand('quit', )))
+        self.connect_action('show_config', lambda: self.command_sig.emit(ThreadCommand('show_config', )))
 
         self.connect_action('log', lambda: self.command_sig.emit(ThreadCommand('show_log', )))
         self.connect_action('stop', lambda: self.command_sig.emit(ThreadCommand('stop', )))
@@ -279,7 +282,7 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
         """Slot from the *grab* action"""
         self.command_sig.emit(ThreadCommand('grab', attribute=self.is_action_checked('grab')))
         self._enable_ini_buttons(not self.is_action_checked('grab'))
-        if not config('viewer', 'allow_settings_edition'):
+        if not self.config('viewer', 'allow_settings_edition'):
             self._settings_widget.setEnabled(not self.is_action_checked('grab'))
 
     def do_init(self, do_init=True):

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -107,7 +107,7 @@ class ControlModule(QObject):
     def __init__(self):
         super().__init__()
         self._title = ""
-
+        self.config = config
         # the hardware controller instance set after initialization and to be used by other modules if they share the
         # same controller
         self.controller = None
@@ -290,13 +290,15 @@ class ControlModule(QObject):
         import webbrowser
         webbrowser.open(self.logger.parent.handlers[0].baseFilename)
 
-    def show_config(self, config: Config):
+    def show_config(self, config: Config) -> Config:
         """ Display in a tree the current configuration"""
         if config is not None:
             print('showing config')
             from pymodaq.utils.gui_utils.widgets.tree_toml import TreeFromToml
             config_tree = TreeFromToml(config)
             config_tree.show_dialog()
+
+            return Config()
 
     def update_status(self, txt, log=True):
         """Display a message in the ui status bar and eventually log the message
@@ -360,6 +362,7 @@ class ControlModuleUI(CustomApp):
 
     def __init__(self, parent):
         super().__init__(parent)
+        self.config = config
 
     def display_status(self, txt, wait_time=config('general', 'message_status_persistence')):
         if self.statusbar is not None:

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -293,6 +293,7 @@ class ControlModule(QObject):
     def show_config(self, config: Config):
         """ Display in a tree the current configuration"""
         if config is not None:
+            print('showing config')
             from pymodaq.utils.gui_utils.widgets.tree_toml import TreeFromToml
             config_tree = TreeFromToml(config)
             config_tree.show_dialog()

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -293,7 +293,6 @@ class ControlModule(QObject):
     def show_config(self, config: Config) -> Config:
         """ Display in a tree the current configuration"""
         if config is not None:
-            print('showing config')
             from pymodaq.utils.gui_utils.widgets.tree_toml import TreeFromToml
             config_tree = TreeFromToml(config)
             config_tree.show_dialog()

--- a/src/pymodaq/resources/config_template.toml
+++ b/src/pymodaq/resources/config_template.toml
@@ -79,3 +79,27 @@ default_preset_for_pid = "beam_steering_mock"
     wait_time = 0
     wait_time_between = 0
     timeout = 10000  # in millisecond
+
+    [scan.scan1D]
+    type = "Linear" # either "Linear", "Adaptive", "Linear back to start", "Random" see pymodaq.utils.scanner.py
+    start = 1.0
+    stop = 2.0
+    step = 0.01
+    [scan.scan2D]
+    type = "Spiral" # either "Spiral", "Linear", "Adaptive", "Back&Forth", "Random" see pymodaq.utils.scanner.py
+        [scan.scan2D.spiral]
+        center1 = -5
+        center2 = 5
+        rmax1 = 10
+        rmax2 = 5
+        npts = 10
+        [scan.scan2D.linear]
+        start1 = -5
+        start2 = -5
+        stop1 = 5
+        stop2 = 5
+        step1 = 0.5
+        step2 = 0.5
+    [scan.tabular]
+    type = "Linear" #either "Linear", "Adaptive" see pymodaq.utils.scanner.py
+    curvilinear = 0.1

--- a/src/pymodaq/resources/config_template.toml
+++ b/src/pymodaq/resources/config_template.toml
@@ -39,6 +39,7 @@ name = "User name"  # default name used as author in the hdf5 saving files
 daq_type = 'DAQ0D' #either "DAQ0D", "DAQ1D", "DAQ2D", "DAQND"
 viewer_in_thread = true
 timeout = 10000  # default duration in ms to wait for data to be acquirred
+allow_settings_edition = false
 
 [network]
     [network.logging]
@@ -78,32 +79,3 @@ default_preset_for_pid = "beam_steering_mock"
     wait_time = 0
     wait_time_between = 0
     timeout = 10000  # in millisecond
-
-    [scan.scan1D]
-    type = "Linear" # either "Linear", "Adaptive", "Linear back to start", "Random" see pymodaq.utils.scanner.py
-    start = 1.0
-    stop = 2.0
-    step = 0.01
-
-    [scan.scan2D]
-    type = "Spiral" # either "Spiral", "Linear", "Adaptive", "Back&Forth", "Random" see pymodaq.utils.scanner.py
-
-        [scan.scan2D.spiral]
-        center1 = -5
-        center2 = 5
-        rmax1 = 10
-        rmax2 = 5
-        npts = 10
-
-        [scan.scan2D.linear]
-        start1 = -5
-        start2 = -5
-        stop1 = 5
-        stop2 = 5
-        step1 = 0.5
-        step2 = 0.5
-
-
-    [scan.tabular]
-    type = "Linear" #either "Linear", "Adaptive" see pymodaq.utils.scanner.py
-    curvilinear = 0.1

--- a/src/pymodaq/utils/scanner/utils.py
+++ b/src/pymodaq/utils/scanner/utils.py
@@ -29,7 +29,7 @@ def register_scanner(parent_module_name: str = 'pymodaq.utils.scanner'):
             if file.is_file() and 'py' in file.suffix and file.stem != '__init__':
                 try:
                     scanners.append(import_module(f'.{file.stem}', scanner_module.__name__))
-                except ModuleNotFoundError:
+                except (ModuleNotFoundError, Exception) as e:
                     pass
     except ModuleNotFoundError:
         pass


### PR DESCRIPTION
configuration file content can be opened in a tree from both daq_viewer and daq_move, allowing modification and saving of the config file. It is now reloaded immediately with possible direct use of the modified entries. For this I move the config object as an attribute of the daq_move, daq_viewer, daq_move_ui and daq_viewer_ui objects