### PR TITLE
Aspect ratio on Viewer2D

### DIFF
--- a/src/pymodaq/utils/plotting/data_viewers/viewer2D.py
+++ b/src/pymodaq/utils/plotting/data_viewers/viewer2D.py
@@ -440,7 +440,7 @@ class View2D(ActionManager, QtCore.QObject):
         self.add_action('roi', 'ROI', 'Region', tip='Show/Hide ROI Manager', checkable=True)
         self.add_action('isocurve', 'IsoCurve', 'meshPlot', tip='Show/Hide Isocurve', checkable=True)
         self.add_action('aspect_ratio', 'Aspect Ratio', 'Zoom_1_1', tip='Fix Aspect Ratio', checkable=True)
-
+        self.set_action_checked('aspect_ratio',True)
         self.add_action('crosshair', 'CrossHair', 'reset', tip='Show/Hide data Crosshair', checkable=True)
         self.add_action('ROIselect', 'ROI Select', 'Select_24',
                         tip='Show/Hide ROI selection area', checkable=True)


### PR DESCRIPTION
The aspect ratio on Viewer2D is initially set to be 1:1 but the button is not correctly toggled.
This patch adds the toggling of the button such that the interface is consistent with the initial definition of the imageWidget (see setupUI in ImageWidget.py)

Idea: Add an extra keyword to the add_action function such as  "isChecked/isToggled"?

