### PR TITLE
ROI 

### DIFF
--- a/src/pymodaq/utils/managers/roi_manager.py
+++ b/src/pymodaq/utils/managers/roi_manager.py
@@ -441,8 +441,6 @@ class ROIManager(QObject):
                     else:
                         newroi = EllipseROI(index=newindex, pos=pos,
                                             size=[width, height])
-                        
-                    newroi.setTransformOriginPoint(QPointF(pos[0],pos[1]))
                     newroi.setPen(par['Color'])
 
                 newroi.sigRegionChanged.connect(lambda: self.ROI_changed.emit())

--- a/src/pymodaq/utils/managers/roi_manager.py
+++ b/src/pymodaq/utils/managers/roi_manager.py
@@ -21,6 +21,8 @@ from pymodaq.utils.daq_utils import plot_colors
 from pymodaq.utils.logger import get_module_name, set_logger
 from pymodaq.utils.config import get_set_roi_path
 from pymodaq.utils.gui_utils import select_file
+from pymodaq.utils.math_utils import rotate2D
+
 import numpy as np
 from pathlib import Path
 from pymodaq.post_treatment.process_to_scalar import DataProcessorFactory
@@ -172,8 +174,10 @@ class EllipseROI(ROI):
         self.index = index
         self.sigRegionChangeFinished.connect(self.emit_index_signal)
 
-    def center(self):
-        return QPointF(self.pos().x() + self.size().x() / 2, self.pos().y() + self.size().y() / 2)
+    def center(self):       
+        # Project width/height in rotated frame         
+        width,height = rotate2D((0,0),(self.size().x(),self.size().y()),np.deg2rad(self.angle()))
+        return QPointF(self.pos().x() + width / 2, self.pos().y() + height / 2)
 
     def emit_index_signal(self):
         self.index_signal.emit(self.index)
@@ -257,8 +261,10 @@ class RectROI(ROI):
         self.index = index
         self.sigRegionChangeFinished.connect(self.emit_index_signal)
 
-    def center(self):
-        return QPointF(self.pos().x() + self.size().x() / 2, self.pos().y() + self.size().y() / 2)
+    def center(self):       
+        # Project width/height in rotated frame         
+        width,height = rotate2D((0,0),(self.size().x(),self.size().y()),np.deg2rad(self.angle()))
+        return QPointF(self.pos().x() + width / 2, self.pos().y() + height / 2)
 
     def emit_index_signal(self):
         self.index_signal.emit(self.index)

--- a/src/pymodaq/utils/managers/roi_manager.py
+++ b/src/pymodaq/utils/managers/roi_manager.py
@@ -63,7 +63,7 @@ class ROIPositionMapper(QtWidgets.QWidget):
         self.settings_tree.setParameters(self.settings, showTop=False)
         dialog.setLayout(vlayout)
 
-        buttonBox = QtWidgets.QDialogButtonBox(parent=self);
+        buttonBox = QtWidgets.QDialogButtonBox(parent=self)
         buttonBox.addButton('Apply', buttonBox.AcceptRole)
         buttonBox.accepted.connect(dialog.accept)
         buttonBox.addButton('Cancel', buttonBox.RejectRole)
@@ -421,6 +421,7 @@ class ROIManager(QObject):
                     roi_type = ''
 
                     pos = self.viewer_widget.plotItem.vb.viewRange()[0]
+                    pos = pos[0] + np.diff(pos)*np.array([2,4])/6
                     newroi = LinearROI(index=newindex, pos=pos)
                     newroi.setZValue(-10)
                     newroi.setBrush(par.child('Color').value())
@@ -440,6 +441,8 @@ class ROIManager(QObject):
                     else:
                         newroi = EllipseROI(index=newindex, pos=pos,
                                             size=[width, height])
+                        
+                    newroi.setTransformOriginPoint(QPointF(pos[0],pos[1]))
                     newroi.setPen(par['Color'])
 
                 newroi.sigRegionChanged.connect(lambda: self.ROI_changed.emit())
@@ -497,7 +500,7 @@ class ROIManager(QObject):
             self._ROIs[roi_key].setPos(poss)
 
         elif param.name() == 'angle':
-            self._ROIs[roi_key].setAngle(param.value())
+            self._ROIs[roi_key].setAngle(param.value(),center=[0.5,0.5])
         elif param.name() == 'width':
             size = self._ROIs[roi_key].size()
             self._ROIs[roi_key].setSize((param.value(), size[1]))

--- a/src/pymodaq/utils/math_utils.py
+++ b/src/pymodaq/utils/math_utils.py
@@ -221,12 +221,22 @@ def gauss2D(x, x0, dx, y, y0, dy, n=1, angle=0):
     return data
 
 
-def rotate(origin, point, angle):
+def rotate2D(origin:tuple = (0,0), point:tuple = (0,0), angle:float = 0):
     """
     Rotate a point counterclockwise by a given angle around a given origin.
 
     The angle should be given in radians.
-    """
+    Parameters
+    ----------
+    origin: (tuple) x,y coordinate from which to rotate
+    point: (tuple) x,y coordinate of point to rotate
+    angle: (float) a float to rotate main axes, in radian
+
+    Returns
+    -------
+    out : (tuple) x,y coordinate of rotated point
+
+    """    
     ox, oy = origin
     px, py = point
 

--- a/src/pymodaq/utils/math_utils.py
+++ b/src/pymodaq/utils/math_utils.py
@@ -221,6 +221,19 @@ def gauss2D(x, x0, dx, y, y0, dy, n=1, angle=0):
     return data
 
 
+def rotate(origin, point, angle):
+    """
+    Rotate a point counterclockwise by a given angle around a given origin.
+
+    The angle should be given in radians.
+    """
+    ox, oy = origin
+    px, py = point
+
+    qx = ox + np.cos(angle) * (px - ox) - np.sin(angle) * (py - oy)
+    qy = oy + np.sin(angle) * (px - ox) + np.cos(angle) * (py - oy)
+    return qx, qy
+
 def ftAxis(Npts, omega_max):
     """
     Given two numbers Npts,omega_max, return two vectors spanning the temporal

--- a/tests/utils/math_utils_test.py
+++ b/tests/utils/math_utils_test.py
@@ -192,3 +192,24 @@ class TestMath:
             mutils.ift2(x, dim=(1.1, 1.2))
         with pytest.raises(TypeError):
             mutils.ift2(x, dim=1.1)
+            
+    def test_rotate2D(self):
+        accuracy = 10 # Rouding precision
+        x,y = (0,0) # Point to rotate
+        ox,oy = (1,1) # Origin 
+        angle = np.pi/2 # Angle
+        x_r,y_r = mutils.rotate2D((ox,oy),(x,y),angle)    
+        assert (np.round((x_r,y_r),accuracy) == np.array([2,0])).all()        
+        angle = np.pi
+        x_r,y_r = mutils.rotate2D((ox,oy),(x,y),angle)    
+        assert (np.round((x_r,y_r),accuracy) == np.array([2,2])).all()
+        ox,oy = (1,0)
+        x_r,y_r = mutils.rotate2D((ox,oy),(x,y),angle)                 
+        assert (np.round((x_r,y_r),accuracy) == np.array([2,0])).all()
+        ox,oy = (0,1)
+        x_r,y_r = mutils.rotate2D((ox,oy),(x,y),angle)                         
+        assert (np.round((x_r,y_r),accuracy) == np.array([0,2])).all()
+        x,y = (1,1)
+        x_r,y_r = mutils.rotate2D((ox,oy),(x,y),angle)                                 
+        assert (np.round((x_r,y_r),accuracy) == np.array([-1,1])).all()
+


### PR DESCRIPTION
I detected a few errors in the roi_manager.

- The center definition was not properly working when giving an angle to the ROI.
This is now fixed by using a new function rotate2D and a redefinition of the center function
- The setAngle was not defined to rotate the ROI with respect to its center. I think it is much more intuitive for the user if this is the case.
This is now fixed by adding the argument center = [0.5,0.5] in setAngle


Ideas: Many functions are shared between ellipse/rect roi. It could be worth to add a baseclass for it.


