### PR TITLE
Pull request for issue  #224

### DIFF
--- a/src/pymodaq/utils/scanner/scan_factory.py
+++ b/src/pymodaq/utils/scanner/scan_factory.py
@@ -127,7 +127,7 @@ class ScannerBase(ScanParameterManager, metaclass=ABCMeta):
                 positions = np.expand_dims(positions, 1)
             axes_unique = []
             for ax in positions.T:
-                axes_unique.append(np.unique(ax))
+                axes_unique.append(ax[np.sort(np.unique(ax, return_index=True)[1])])                
             axes_indexes = np.zeros_like(positions, dtype=int)
             for ind in range(positions.shape[0]):
                 for ind_pos, pos in enumerate(positions[ind]):

--- a/src/pymodaq/utils/scanner/scan_factory.py
+++ b/src/pymodaq/utils/scanner/scan_factory.py
@@ -127,7 +127,7 @@ class ScannerBase(ScanParameterManager, metaclass=ABCMeta):
                 positions = np.expand_dims(positions, 1)
             axes_unique = []
             for ax in positions.T:
-                ax = np.sort(np.unique(ax, return_index=True)[1]) # Getting unique values in ax without any sorting
+                ax = ax[np.sort(np.unique(ax, return_index=True)[1])] # Getting unique values in ax without any sorting
                 axes_unique.append(ax)                
             axes_indexes = np.zeros_like(positions, dtype=int)
             for ind in range(positions.shape[0]):

--- a/src/pymodaq/utils/scanner/scan_factory.py
+++ b/src/pymodaq/utils/scanner/scan_factory.py
@@ -127,7 +127,8 @@ class ScannerBase(ScanParameterManager, metaclass=ABCMeta):
                 positions = np.expand_dims(positions, 1)
             axes_unique = []
             for ax in positions.T:
-                axes_unique.append(ax[np.sort(np.unique(ax, return_index=True)[1])])                
+                ax = np.sort(np.unique(ax, return_index=True)[1]) # Getting unique values in ax without any sorting
+                axes_unique.append(ax)                
             axes_indexes = np.zeros_like(positions, dtype=int)
             for ind in range(positions.shape[0]):
                 for ind_pos, pos in enumerate(positions[ind]):


### PR DESCRIPTION


From scan_factory.py
self.axes_indexes was built with the unique function in  get_info_from_positions and led to a sorting of the value.
This made it not reliable when doing backwards scan as the indexes given did not match the position array which was unsorted)

This fixes the issue #224 by keeping the iniital sorting given by the user