### PR TITLE
Fix "use PID as actuator" in preset

### DIFF
--- a/src/pymodaq/extensions/pid/daq_move_PID.py
+++ b/src/pymodaq/extensions/pid/daq_move_PID.py
@@ -17,15 +17,14 @@ class DAQ_Move_PID(DAQ_Move_base):
 
 
     def update_position(self, dict_val):
-        self.current_position = dict_val[self.parent.title]
+        self.current_value = dict_val[self.parent.title]
 
-    def check_position(self):
+    def get_actuator_value(self):
         self.controller['emit_curr_points'].emit()
-        pos = self.current_position
+        pos = self.current_value
         #
         # pos = self.get_position_with_scaling(pos)
-        # self.current_position = pos
-        self.emit_status(ThreadCommand('check_position', [pos]))
+        # self.current_value = pos
         return pos
 
     def close(self):
@@ -54,7 +53,7 @@ class DAQ_Move_PID(DAQ_Move_base):
             self.status.info = info
             self.status.controller = self.controller
             self.status.initialized = True
-            return self.status
+            return self.status.info, self.status.initialized
 
         except Exception as e:
             self.status.info = str(e)
@@ -75,8 +74,8 @@ class DAQ_Move_PID(DAQ_Move_base):
     def move_Rel(self, position):
         """
         """
-        position = self.check_bound(self.current_position + position) - self.current_position
-        self.target_position = position + self.current_position
+        position = self.check_bound(self.current_value + position) - self.current_value
+        self.target_position = position + self.current_value
 
         self.controller['setpoint'].emit({self.parent.title: self.target_position})
         self.poll_moving()

--- a/src/pymodaq/extensions/pid/pid_controller.py
+++ b/src/pymodaq/extensions/pid/pid_controller.py
@@ -106,9 +106,6 @@ class DAQ_PID(CustomApp):
 
         self.emit_curr_points_sig.connect(self.emit_curr_points)
 
-    def set_module_manager(self, detector_modules, actuator_modules):
-        self.modules_manager = ModulesManager(detector_modules, actuator_modules)
-
     def ini_PID(self):
 
         if self.is_action_checked('ini_pid'):

--- a/src/pymodaq/utils/daq_utils.py
+++ b/src/pymodaq/utils/daq_utils.py
@@ -620,6 +620,7 @@ def get_instrument_plugins():  # pragma: no cover
                 except ModuleNotFoundError:
                     pass
 
+
             # check if modules are importable
             for mod in plugin_list:
                 try:
@@ -637,6 +638,20 @@ def get_instrument_plugins():  # pragma: no cover
                                  f' from module: {mod["parent_module"].__package__}')
         except Exception as e:  # pragma: no cover
             logger.debug(str(e))
+
+    # add utility plugin for PID
+    try:
+        pidmodule = importlib.import_module('pymodaq.extensions.pid')
+        mod = [{'name': 'PID',
+               'module': pidmodule,
+               'parent_module': pidmodule,
+               'type': 'daq_move'}]
+        importlib.import_module(f'{pidmodule.__package__}.daq_move_PID')
+        plugins_import.extend(mod)
+
+    except Exception as e:
+        logger.debug(f'Impossible to import PID utility plugin: {str(e)}')
+
     return plugins_import
 
 


### PR DESCRIPTION
Hi,
In version 4, the option to check "use pid as actuator" in a preset was not working yet. Loading the PID module directly with the preset bugged, and so did the initialization of the "fake" associated actuator.

This is fixed by moving the PID module initialization after the dashboard has a properly defined self.modules_manager (which is accessible to the DAQ_PID afterwards). Then the fake actuator is created, after which we update the dashboard's self.modules_manager to add it. The utility plugin (daq_move_PID) also is now added to the list of available plugins (done in get_instrument_plugins()). 
 
Tested using mock detectors and actuators together with one of our PID models https://github.com/Attolab/pymodaq_plugins_PIDStabFringes/blob/main/src/pymodaq_plugins_pid/models/PIDSpatialInterferometrySE1bis.py

