### PR TITLE
Bug/input arguments h5browser

### DIFF
--- a/docs/src/extensions_folder/h5browser.rst
+++ b/docs/src/extensions_folder/h5browser.rst
@@ -4,7 +4,10 @@
 H5Browser
 =========
 
-The h5 browser is an object that helps browsing of datas and metadatas. It asks you to select a h5 file
+Exploring data
+++++++++++++++
+
+The h5 browser is an object that helps browsing of data and metadata. It asks you to select a h5 file
 and then display a window such as :numref:`figure_h5browser`. Depending the element of the file you are
 selecting in the h5 file tree, various metadata can be displayed, such as *scan settings* or
 *module settings* at the time of saving. When double clicking on data type entries in the tree, the
@@ -39,3 +42,35 @@ Some options are available when right clicking on a node, see :numref:`figure_h5
 * Plot Nodes: plot data hanging from the same channel
 * Plot Node with Bkg: plot data with subtracted background (if present)
 * Plot Nodes with Bkg: plot data hanging from the same channel with subtracted background (if present)
+
+Associating H5Browser with .h5 files
++++++++++++++++++++++++++++++++++++++
+
+By default, the H5Browser always asks the user to select a file. One can instead open a specified .h5 file directly,
+using the --input optional command line argument as follows:
+
+``python h5browser.py --input my_h5_file.h5``.
+
+One can also associate H5Browser to all .h5 file so that it directly opens a file when double clicking on it. Here is
+how to do it on Windows. Let us assume that you have a conda environment named *my_env*, in which PyMoDAQ is installed.
+
+In Windows, the path to your conda executable will be something like:
+
+``C:\Miniconda\condabin\conda.bat``
+
+and the path to the H5Browser will be (note that we are going into the *my_env* folder):
+
+``C:\Miniconda\envs\my_env\Lib\site-packages\pymodaq\h5browser.py``
+
+Now that you have written down these two paths, open your favorite text editing tool (e.g. notepad) and create a file
+called *H5Opener.bat* (for instance) with the following contents:
+
+  .. code-block:: python
+
+    @ECHO OFF
+    call C:\Miniconda\condabin\conda.bat activate my_env
+    python "C:\Miniconda\envs\my_env\Lib\site-packages\pymodaq\h5browser.py" --input %1
+
+After creating the file, simply right click on any .h5 file, choose **Open with**, *Try an app on this PC*, you should see a list of programs, at the bottom
+you have to tick *Always use this app to open .h5 files* and then click *Look for another app on this PC*. You can browse to the location
+of *H5Opener.bat* and you are done. Double clicking any .h5 file will now open the H5Browser directly loading the selected file.

--- a/docs/src/extensions_folder/h5browser.rst
+++ b/docs/src/extensions_folder/h5browser.rst
@@ -58,18 +58,19 @@ In Windows, the path to your conda executable will be something like:
 
 ``C:\Miniconda3\condabin\conda.bat``
 
-and the path to the H5Browser will be (note that we are going into the *my_env* folder):
 
-``C:\Miniconda3\envs\my_env\Lib\site-packages\pymodaq\h5browser.py``
-
-Now that you have written down these two paths, open your favorite text editing tool (e.g. notepad) and create a file
+Now that you have written down this path, open your favorite text editing tool (e.g. notepad) and create a file
 called *H5Opener.bat* (for instance) with the following contents:
 
   .. code-block:: python
 
     @ECHO OFF
-    call C:\Miniconda\condabin\conda.bat activate my_env
+    call C:\Miniconda3\condabin\conda.bat activate my_env
     h5browser --input %1
+
+.. note::
+   The precise path of your environment may be different from the one we wrote just above. Check
+   your conda installation to verify this: `conda info` and `conda env list`
 
 After creating the file, simply right click on any .h5 file, choose **Open with**, *Try an app on this PC*, you should see a list of programs, at the bottom
 you have to tick *Always use this app to open .h5 files* and then click *Look for another app on this PC*. You can browse to the location

--- a/docs/src/extensions_folder/h5browser.rst
+++ b/docs/src/extensions_folder/h5browser.rst
@@ -49,18 +49,18 @@ Associating H5Browser with .h5 files
 By default, the H5Browser always asks the user to select a file. One can instead open a specified .h5 file directly,
 using the --input optional command line argument as follows:
 
-``python h5browser.py --input my_h5_file.h5``.
+``h5browser --input my_h5_file.h5``.
 
 One can also associate H5Browser to all .h5 file so that it directly opens a file when double clicking on it. Here is
 how to do it on Windows. Let us assume that you have a conda environment named *my_env*, in which PyMoDAQ is installed.
 
 In Windows, the path to your conda executable will be something like:
 
-``C:\Miniconda\condabin\conda.bat``
+``C:\Miniconda3\condabin\conda.bat``
 
 and the path to the H5Browser will be (note that we are going into the *my_env* folder):
 
-``C:\Miniconda\envs\my_env\Lib\site-packages\pymodaq\h5browser.py``
+``C:\Miniconda3\envs\my_env\Lib\site-packages\pymodaq\h5browser.py``
 
 Now that you have written down these two paths, open your favorite text editing tool (e.g. notepad) and create a file
 called *H5Opener.bat* (for instance) with the following contents:
@@ -69,7 +69,7 @@ called *H5Opener.bat* (for instance) with the following contents:
 
     @ECHO OFF
     call C:\Miniconda\condabin\conda.bat activate my_env
-    python "C:\Miniconda\envs\my_env\Lib\site-packages\pymodaq\h5browser.py" --input %1
+    h5browser --input %1
 
 After creating the file, simply right click on any .h5 file, choose **Open with**, *Try an app on this PC*, you should see a list of programs, at the bottom
 you have to tick *Always use this app to open .h5 files* and then click *Look for another app on this PC*. You can browse to the location

--- a/src/pymodaq/extensions/h5browser.py
+++ b/src/pymodaq/extensions/h5browser.py
@@ -1,16 +1,14 @@
+import argparse
+from pathlib import Path
 import sys
+
 from qtpy import QtWidgets
+
 from pymodaq.utils.h5modules.browsing import H5Browser
 from pymodaq.utils.config import Config
-from pathlib import Path
+
 
 config = Config()
-
-
-def main_without_qt(h5file_path: Path = None):
-    win = QtWidgets.QMainWindow()
-    prog = H5Browser(win, h5file_path=h5file_path)
-    win.show()
 
 
 def main(h5file_path: Path = None):
@@ -19,8 +17,20 @@ def main(h5file_path: Path = None):
         import qdarkstyle
         app.setStyleSheet(qdarkstyle.load_stylesheet())
 
+    h5file_path_tmp = None
+    parser = argparse.ArgumentParser(description="Opens HDF5 files and navigate their contents")
+    parser.add_argument("-i", "--input", help="specify path to the file to be opened")
+    args = parser.parse_args()
+
+    if args.input:
+        h5file_path_tmp = Path(args.input).resolve()  # Transform to absolute Path in case it is relative
+
+        if not h5file_path_tmp.exists():
+            print(f'Error: {args.input} does not exist. Opening h5browser without input file.')
+            h5file_path_tmp = h5file_path
+
     win = QtWidgets.QMainWindow()
-    prog = H5Browser(win, h5file_path=h5file_path)
+    prog = H5Browser(win, h5file_path=h5file_path_tmp)
     win.show()
     QtWidgets.QApplication.processEvents()
     sys.exit(app.exec_())


### PR DESCRIPTION
This branch recreate a previous commit from v3 that didn't go into v4 from @rgeneaux 

Allows adding input argument when callling h5browser over the command line. Doc also highlight how to specify the h5browser to open the h5 file by default!