### PR TITLE
Leco name and rework

### DIFF
--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -35,7 +35,7 @@ from pymodaq.utils.h5modules import module_saving
 from pymodaq.utils.data import DataRaw, DataToExport, DataFromPlugins, DataActuator
 from pymodaq.utils.h5modules.backends import Node
 
-from pymodaq.utils.leco.pymodaq_listener import MoveActorListener
+from pymodaq.utils.leco.pymodaq_listener import MoveActorListener, LECOMoveCommands
 
 
 local_path = config_mod.get_set_local_dir()
@@ -452,7 +452,7 @@ class DAQ_Move(ParameterControlModule):
             if self.settings['main_settings', 'tcpip', 'tcp_connected'] and self._send_to_tcpip:
                 self._command_tcpip.emit(ThreadCommand('position_is', status.attribute))
             if self.settings['main_settings', 'leco', 'leco_connected'] and self._send_to_tcpip:
-                self._command_tcpip.emit(ThreadCommand('position_is', status.attribute))
+                self._command_tcpip.emit(ThreadCommand(LECOMoveCommands.POSITION, status.attribute))
 
         elif status.command == "move_done":
             data_act: DataActuator = status.attribute[0]
@@ -466,7 +466,7 @@ class DAQ_Move(ParameterControlModule):
             if self.settings.child('main_settings', 'tcpip', 'tcp_connected').value() and self._send_to_tcpip:
                 self._command_tcpip.emit(ThreadCommand('move_done', status.attribute))
             if self.settings.child('main_settings', 'leco', 'leco_connected').value() and self._send_to_tcpip:
-                self._command_tcpip.emit(ThreadCommand('move_done', status.attribute))
+                self._command_tcpip.emit(ThreadCommand(LECOMoveCommands.MOVE_DONE, status.attribute))
 
         elif status.command == 'outofbounds':
             self.bounds_signal.emit(True)

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -43,7 +43,7 @@ from pymodaq.utils.plotting.data_viewers.viewer import ViewerBase, ViewersEnum
 from pymodaq.utils.enums import enum_checker
 from pymodaq.control_modules.viewer_utility_classes import DAQ_Viewer_base
 
-from pymodaq.utils.leco.pymodaq_listener import ViewerActorListener, LECO_Client_Commands
+from pymodaq.utils.leco.pymodaq_listener import ViewerActorListener, LECOClientCommands
 
 logger = set_logger(get_module_name(__file__))
 config = Config()
@@ -1092,10 +1092,10 @@ class DAQ_Viewer(ParameterControlModule):
         if 'Send Data' in status.command:
             self.snapshot('', send_to_tcpip=True)
 
-        elif status.command == LECO_Client_Commands.LECO_CONNECTED:
+        elif status.command == LECOClientCommands.LECO_CONNECTED:
             self.settings.child('main_settings', 'leco', 'leco_connected').setValue(True)
 
-        elif status.command == LECO_Client_Commands.LECO_DISCONNECTED:
+        elif status.command == LECOClientCommands.LECO_DISCONNECTED:
             self.settings.child('main_settings', 'leco', 'leco_connected').setValue(False)
 
         elif status.command == 'get_axis':

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -22,9 +22,8 @@ from qtpy.QtCore import Qt, QObject, Slot, QThread, Signal
 
 from pymodaq.utils.data import DataFromPlugins, DataToExport, Axis, DataDistribution
 from pymodaq.utils.logger import set_logger, get_module_name
-from pymodaq.control_modules.utils import ControlModule
+from pymodaq.control_modules.utils import ParameterControlModule
 from pymodaq.utils.gui_utils.file_io import select_file
-from pymodaq.utils.tcp_ip.tcp_server_client import TCPClient
 from pymodaq.utils.gui_utils.widgets.lcd import LCD
 from pymodaq.utils.config import Config, get_set_local_dir
 from pymodaq.utils.h5modules.browsing import browse_data
@@ -32,13 +31,12 @@ from pymodaq.utils.h5modules.saving import H5Saver
 from pymodaq.utils.h5modules import module_saving
 from pymodaq.utils.h5modules.backends import Node
 from pymodaq.utils.daq_utils import ThreadCommand
-from pymodaq.utils.parameter import ioxml
+from pymodaq.utils.parameter import ioxml, Parameter
 from pymodaq.utils.parameter import utils as putils
 from pymodaq.control_modules.viewer_utility_classes import params as daq_viewer_params
 from pymodaq.utils import daq_utils as utils
 from pymodaq.utils.messenger import deprecation_msg
 from pymodaq.utils.gui_utils import DockArea, get_splash_sc, Dock
-from pymodaq.utils.managers.parameter_manager import ParameterManager, Parameter
 from pymodaq.control_modules.daq_viewer_ui import DAQ_Viewer_UI
 from pymodaq.control_modules.utils import DET_TYPES, get_viewer_plugins, DAQTypesEnum, DetectorError
 from pymodaq.utils.plotting.data_viewers.viewer import ViewerBase, ViewersEnum
@@ -53,7 +51,7 @@ config = Config()
 local_path = get_set_local_dir()
 
 
-class DAQ_Viewer(ParameterManager, ControlModule):
+class DAQ_Viewer(ParameterControlModule):
     """ Main PyMoDAQ class to drive detectors
 
     Qt object and generic UI to drive actuators. The class is giving you full functionality to select (daq_detector),
@@ -83,26 +81,27 @@ class DAQ_Viewer(ParameterManager, ControlModule):
     create if one want to receive infos from the ROI
     """
     settings_name = 'daq_viewer_settings'
-    custom_sig = Signal(ThreadCommand)  # particular case where DAQ_Viewer  is used for a custom module
+    custom_sig = Signal(ThreadCommand)  # particular case where DAQ_Viewer is used for a custom module
 
     grab_done_signal = Signal(DataToExport)
 
-    _update_settings_signal = Signal(edict)
     overshoot_signal = Signal(bool)
     data_saved = Signal()
     grab_status = Signal(bool)
 
     params = daq_viewer_params
 
+    listener_class = ViewerActorListener
+
     def __init__(self, parent=None, title="Testing",
                  daq_type=config('viewer', 'daq_type'),
-                 dock_settings=None, dock_viewer=None):
+                 dock_settings=None, dock_viewer=None,
+                 **kwargs):
 
         self.logger = set_logger(f'{logger.name}.{title}')
         self.logger.info(f'Initializing DAQ_Viewer: {title}')
 
-        ParameterManager.__init__(self, action_list = ('save','update'))
-        ControlModule.__init__(self)
+        super().__init__(action_list = ('save','update'), **kwargs)
 
         daq_type = enum_checker(DAQTypesEnum, daq_type)
         self._daq_type: DAQTypesEnum = daq_type
@@ -894,6 +893,8 @@ class DAQ_Viewer(ParameterManager, ControlModule):
         param: Parameter
             a given parameter whose value has been changed by user
         """
+        super().value_changed(param=param)
+
         path = self.settings.childPath(param)
         if param.name() == 'DAQ_type':
             self._h5saver_continuous.settings.child('do_save').setValue(False)
@@ -933,39 +934,7 @@ class DAQ_Viewer(ParameterManager, ControlModule):
         elif param.name() == 'wait_time':
             self.command_hardware.emit(ThreadCommand('update_wait_time', [param.value()]))
 
-        elif param.name() == 'connect_server':
-            if param.value():
-                self.connect_tcp_ip()
-            else:
-                self._command_tcpip.emit(ThreadCommand('quit', ))
-
-        elif param.name() == 'ip_address' or param.name == 'port':
-            self._command_tcpip.emit(
-                ThreadCommand('update_connection',
-                              dict(ipaddress=self.settings['main_settings', 'tcpip', 'ip_address'],
-                                   port=self.settings['main_settings', 'tcpip', 'port'])))
-
-        elif param.name() == 'connect_leco_server':
-            self.connect_leco(param.value())
-
-        elif param.name() == "name":
-            name = param.value()
-            try:
-                self._leco_client.name = name
-            except AttributeError:
-                pass
-
-        elif param.name() == 'plugin_config':
-            self.show_config(self.plugin_config)
-
-        if path is not None:
-            if 'main_settings' not in path:
-                self._update_settings_signal.emit(edict(path=path, param=param, change='value'))
-
-                if self.settings.child('main_settings', 'tcpip', 'tcp_connected').value():
-                    self._command_tcpip.emit(ThreadCommand('send_info', dict(path=path, param=param)))
-                if self.settings.child('main_settings', 'leco', 'leco_connected').value():
-                    self._command_tcpip.emit(ThreadCommand('send_info', dict(path=path, param=param)))
+        self._update_settings(param=param)
 
     def child_added(self, param, data):
         """ Adds a child in the settings attribute
@@ -1096,54 +1065,8 @@ class DAQ_Viewer(ParameterManager, ControlModule):
             self.stop_grab()
 
     def connect_tcp_ip(self):
-        """Init a TCPClient in a separated thread to communicate with a distant TCp/IP Server
-
-        Use the settings: ip_address and port to specify the connection
-
-        See Also
-        --------
-        TCPServer
-        """
-        if self.settings.child('main_settings', 'tcpip', 'connect_server').value():
-            self._tcpclient_thread = QThread()
-
-            tcpclient = TCPClient(self.settings.child('main_settings', 'tcpip', 'ip_address').value(),
-                                  self.settings.child('main_settings', 'tcpip', 'port').value(),
-                                  self.settings.child('detector_settings'))
-            tcpclient.moveToThread(self._tcpclient_thread)
-            self._tcpclient_thread.tcpclient = tcpclient
-            tcpclient.cmd_signal.connect(self.process_tcpip_cmds)
-
-            self._command_tcpip[ThreadCommand].connect(tcpclient.queue_command)
-
-            self._tcpclient_thread.started.connect(tcpclient.init_connection)
-
-            self._tcpclient_thread.start()
-
-    def connect_leco(self, connect: bool) -> None:
-        if connect:
-            name = self.settings.child("main_settings", "leco", "name").value()
-            if not name:
-                # take the module name as alternative
-                name = self.settings.child("main_settings", "module_name").value()
-            if not name:
-                # a name is required, invent one
-                name = f"viewer_{randint(0, 10000)}"
-                name = self.settings.child("main_settings", "leco", "name").setValue(name)
-            try:
-                self._leco_client.name = name
-            except AttributeError:
-                self._leco_client = ViewerActorListener(name=name)
-                self._leco_client.cmd_signal.connect(self.process_tcpip_cmds)
-            self._command_tcpip[ThreadCommand].connect(self._leco_client.queue_command)
-            self._leco_client.start_listen()
-            # self._leco_client.cmd_signal.emit(ThreadCommand("set_info", attribute=["detector_settings", ""]))
-        else:
-            self._command_tcpip.emit(ThreadCommand('quit', ))
-            try:
-                self._command_tcpip[ThreadCommand].disconnect(self._leco_client.queue_command)
-            except TypeError:
-                pass  # already disconnected
+        super().connect_tcp_ip(params_state=self.settings.child('detector_settings'),
+                               client_type="GRABBER")
 
     @Slot(ThreadCommand)
     def process_tcpip_cmds(self, status: ThreadCommand) -> None:
@@ -1164,29 +1087,16 @@ class DAQ_Viewer(ParameterManager, ControlModule):
         connect_tcp_ip, TCPServer
 
         """
+        if super().process_tcpip_cmds(status=status) is None:
+            return
         if 'Send Data' in status.command:
             self.snapshot('', send_to_tcpip=True)
-        elif status.command == 'connected':
-            self.settings.child('main_settings', 'tcpip', 'tcp_connected').setValue(True)
-
-        elif status.command == 'disconnected':
-            self.settings.child('main_settings', 'tcpip', 'tcp_connected').setValue(False)
 
         elif status.command == LECO_Client_Commands.LECO_CONNECTED:
             self.settings.child('main_settings', 'leco', 'leco_connected').setValue(True)
 
         elif status.command == LECO_Client_Commands.LECO_DISCONNECTED:
             self.settings.child('main_settings', 'leco', 'leco_connected').setValue(False)
-
-        elif status.command == 'Update_Status':
-            self.thread_status(status)
-
-        elif status.command == 'set_info':
-            param_dict = ioxml.XML_string_to_parameter(status.attribute[1])[0]
-            param_tmp = Parameter.create(**param_dict)
-            param = self.settings.child('detector_settings', *status.attribute[0][1:])
-
-            param.restoreState(param_tmp.saveState())
 
         elif status.command == 'get_axis':
             raise DeprecationWarning('Do not use this, the axis are in the data objects')

--- a/src/pymodaq/control_modules/move_utility_classes.py
+++ b/src/pymodaq/control_modules/move_utility_classes.py
@@ -1,5 +1,5 @@
 from time import perf_counter
-from typing import Union, List, Dict, TYPE_CHECKING
+from typing import Union, List, Dict, TYPE_CHECKING, Optional
 from numbers import Number
 
 from easydict import EasyDict as edict
@@ -127,6 +127,7 @@ params = [
              {'title': 'Connect:', 'name': 'connect_leco_server', 'type': 'bool_push', 'label': 'Connect',
               'value': False},
              {'title': 'Connected?:', 'name': 'leco_connected', 'type': 'led', 'value': False},
+             {'title': 'Name', 'name': 'name', 'type': 'str', 'value': "", 'default': ""},
              {'title': 'Host:', 'name': 'host', 'type': 'str', 'value': config('network', "leco-server", "host"), "default": "localhost"},
              {'title': 'Port:', 'name': 'port', 'type': 'int', 'value': config('network', 'leco-server', 'port')},
          ]},
@@ -205,7 +206,8 @@ class DAQ_Move_base(QObject):
     data_actuator_type = DataActuatorType['float']
     data_shape = (1, )  # expected shape of the underlying actuator's value (in general a float so shape = (1, ))
 
-    def __init__(self, parent: 'DAQ_Move_Hardware' = None, params_state: dict = None):
+    def __init__(self, parent: Optional['DAQ_Move_Hardware'] = None,
+                 params_state: Optional[dict] = None):
         QObject.__init__(self)  # to make sure this is the parent class
         self.move_is_done = False
         self.parent = parent
@@ -446,7 +448,7 @@ class DAQ_Move_base(QObject):
     def commit_common_settings(self, param):
         pass
 
-    def move_done(self, position: DataActuator = None):  # the position argument is just there to match some signature of child classes
+    def move_done(self, position: Optional[DataActuator] = None):  # the position argument is just there to match some signature of child classes
         """
             | Emit a move done signal transmitting the float position to hardware.
             | The position argument is just there to match some signature of child classes.
@@ -502,7 +504,7 @@ class DAQ_Move_base(QObject):
             logger.debug(f'Check move_is_done: {self.move_is_done}')
             if self.move_is_done:
                 self.emit_status(ThreadCommand('Move has been stopped', ))
-                logger.info(f'Move has been stopped')
+                logger.info('Move has been stopped')
             self.current_value = self.get_actuator_value()
 
             self.emit_value(self._current_value)
@@ -511,7 +513,7 @@ class DAQ_Move_base(QObject):
             if perf_counter() - self.start_time >= self.settings['timeout']:
                 self.poll_timer.stop()
                 self.emit_status(ThreadCommand('raise_timeout', ))
-                logger.info(f'Timeout activated')
+                logger.info('Timeout activated')
         else:
             self.poll_timer.stop()
             logger.debug(f'Current value: {self._current_value}')
@@ -669,7 +671,7 @@ class DAQ_Move_TCP_server(DAQ_Move_base, TCPServer):
 
     def ini_stage(self, controller=None):
         """
-            | Initialisation procedure of the detector updating the status dictionnary.
+            | Initialisation procedure of the detector updating the status dictionary.
             |
             | Init axes from image , here returns only None values (to tricky to di it with the server and not really necessary for images anyway)
 

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -4,18 +4,24 @@ Created the 03/10/2022
 
 @author: Sebastien Weber
 """
+from random import randint
+from typing import Optional
+
 from easydict import EasyDict as edict
 
 from qtpy import QtCore
-from qtpy.QtCore import Signal, QObject, Qt
+from qtpy.QtCore import Signal, QObject, Qt, Slot, QThread
 from pymodaq.utils.gui_utils import CustomApp
 from pymodaq.utils.daq_utils import ThreadCommand, get_plugins, find_dict_in_list_from_key_val
 from pymodaq.utils.config import Config
-from pymodaq.utils.parameter import Parameter
+from pymodaq.utils.tcp_ip.tcp_server_client import TCPClient
+from pymodaq.utils.parameter import Parameter, ioxml
+from pymodaq.utils.managers.parameter_manager import ParameterManager
 from pymodaq.utils.enums import BaseEnum, enum_checker
 from pymodaq.utils.plotting.data_viewers.viewer import ViewersEnum
 from pymodaq.utils.exceptions import DetectorError
 from pymodaq.utils import config as configmod
+from pymodaq.utils.leco.pymodaq_listener import ActorListener, LECO_Client_Commands
 
 
 class DAQTypesEnum(BaseEnum):
@@ -116,7 +122,7 @@ class ControlModule(QObject):
         self._tcpclient_thread = None
         self._hardware_thread = None
         self.module_and_data_saver = None
-        self.plugin_config: configmod.Config = None
+        self.plugin_config: Optional[configmod.Config] = None
 
     def __repr__(self):
         return f'{self.__class__.__name__}: {self.title}'
@@ -253,7 +259,7 @@ class ControlModule(QObject):
         raise NotImplementedError
 
     def quit_fun(self):
-        """Programmatic entry to quit the controle module"""
+        """Programmatic entry to quit the control module"""
         raise NotImplementedError
 
     def init_hardware(self, do_init=True):
@@ -341,6 +347,143 @@ class ControlModule(QObject):
                         attr(value)
                     else:
                         attr = value
+
+
+class ParameterControlModule(ParameterManager, ControlModule):
+    """Base class for a control module with parameters."""
+
+    _update_settings_signal = Signal(edict)
+
+    listener_class: type[ActorListener] = ActorListener
+
+    def value_changed(self, param: Parameter) -> Optional[Parameter]:
+        """ParameterManager subclassed method. Process events from value changed by user in the UI Settings
+
+        Parameters
+        ----------
+        param: Parameter
+            a given parameter whose value has been changed by user
+        """
+        if param.name() == 'plugin_config':
+            self.show_config(self.plugin_config)
+
+        elif param.name() == 'connect_server':
+            if param.value():
+                self.connect_tcp_ip()
+            else:
+                self._command_tcpip.emit(ThreadCommand('quit', ))
+
+        elif param.name() == 'ip_address' or param.name == 'port':
+            self._command_tcpip.emit(
+                ThreadCommand('update_connection',
+                              dict(ipaddress=self.settings['main_settings', 'tcpip', 'ip_address'],
+                                   port=self.settings['main_settings', 'tcpip', 'port'])))
+
+        elif param.name() == 'connect_leco_server':
+            self.connect_leco(param.value())
+
+        elif param.name() == "name":
+            name = param.value()
+            try:
+                self._leco_client.name = name
+            except AttributeError:
+                pass
+
+        else:
+            # not handled
+            return param
+
+    def _update_settings(self, param: Parameter):
+        # I do not understand what it does
+        path = self.settings.childPath(param)
+        if path is not None:
+            if 'main_settings' not in path:
+                self._update_settings_signal.emit(edict(path=path, param=param, change='value'))
+                if self.settings.child('main_settings', 'tcpip', 'tcp_connected').value():
+                    self._command_tcpip.emit(ThreadCommand('send_info', dict(path=path, param=param)))
+                if self.settings.child('main_settings', 'leco', 'leco_connected').value():
+                    self._command_tcpip.emit(ThreadCommand('send_info', dict(path=path, param=param)))
+
+    def connect_tcp_ip(self, params_state=None, client_type: str = "GRABBER") -> None:
+        """Init a TCPClient in a separated thread to communicate with a distant TCp/IP Server
+
+        Use the settings: ip_address and port to specify the connection
+
+        See Also
+        --------
+        TCPServer
+        """
+        if self.settings.child('main_settings', 'tcpip', 'connect_server').value():
+            self._tcpclient_thread = QThread()
+
+            tcpclient = TCPClient(self.settings.child('main_settings', 'tcpip', 'ip_address').value(),
+                                  self.settings.child('main_settings', 'tcpip', 'port').value(),
+                                  params_state=params_state,
+                                  client_type=client_type)
+            tcpclient.moveToThread(self._tcpclient_thread)
+            self._tcpclient_thread.tcpclient = tcpclient
+            tcpclient.cmd_signal.connect(self.process_tcpip_cmds)
+
+            self._command_tcpip[ThreadCommand].connect(tcpclient.queue_command)
+            self._tcpclient_thread.started.connect(tcpclient.init_connection)
+
+            self._tcpclient_thread.start()
+
+    def get_leco_name(self) -> str:
+        name = self.settings.child("main_settings", "leco", "name").value()
+        if not name:
+            # take the module name as alternative
+            name = self.settings.child("main_settings", "module_name").value()
+        if not name:
+            # a name is required, invent one
+            name = f"viewer_{randint(0, 10000)}"
+            name = self.settings.child("main_settings", "leco", "name").setValue(name)
+        return name
+
+    def connect_leco(self, connect: bool) -> None:
+        if connect:
+            name = self.get_leco_name()
+            try:
+                self._leco_client.name = name
+            except AttributeError:
+                self._leco_client = self.listener_class(name=name)
+                self._leco_client.cmd_signal.connect(self.process_tcpip_cmds)
+            self._command_tcpip[ThreadCommand].connect(self._leco_client.queue_command)
+            self._leco_client.start_listen()
+            # self._leco_client.cmd_signal.emit(ThreadCommand("set_info", attribute=["detector_settings", ""]))
+        else:
+            self._command_tcpip.emit(ThreadCommand('quit', ))
+            try:
+                self._command_tcpip[ThreadCommand].disconnect(self._leco_client.queue_command)
+            except TypeError:
+                pass  # already disconnected
+
+    @Slot(ThreadCommand)
+    def process_tcpip_cmds(self, status: ThreadCommand) -> Optional[ThreadCommand]:
+        if status.command == 'connected':
+            self.settings.child('main_settings', 'tcpip', 'tcp_connected').setValue(True)
+
+        elif status.command == 'disconnected':
+            self.settings.child('main_settings', 'tcpip', 'tcp_connected').setValue(False)
+
+        elif status.command == LECO_Client_Commands.LECO_CONNECTED:
+            self.settings.child('main_settings', 'leco', 'leco_connected').setValue(True)
+
+        elif status.command == LECO_Client_Commands.LECO_DISCONNECTED:
+            self.settings.child('main_settings', 'leco', 'leco_connected').setValue(False)
+
+        elif status.command == 'Update_Status':
+            self.thread_status(status)
+
+        elif status.command == 'set_info':
+            param_dict = ioxml.XML_string_to_parameter(status.attribute[1])[0]
+            param_tmp = Parameter.create(**param_dict)
+            param = self.settings.child('move_settings', *status.attribute[0][1:])
+
+            param.restoreState(param_tmp.saveState())
+        else:
+            # not handled
+            return status
 
 
 class ControlModuleUI(CustomApp):

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -21,7 +21,7 @@ from pymodaq.utils.enums import BaseEnum, enum_checker
 from pymodaq.utils.plotting.data_viewers.viewer import ViewersEnum
 from pymodaq.utils.exceptions import DetectorError
 from pymodaq.utils import config as configmod
-from pymodaq.utils.leco.pymodaq_listener import ActorListener, LECO_Client_Commands
+from pymodaq.utils.leco.pymodaq_listener import ActorListener, LECOClientCommands, LECOCommands
 
 
 class DAQTypesEnum(BaseEnum):
@@ -452,7 +452,7 @@ class ParameterControlModule(ParameterManager, ControlModule):
             self._leco_client.start_listen()
             # self._leco_client.cmd_signal.emit(ThreadCommand("set_info", attribute=["detector_settings", ""]))
         else:
-            self._command_tcpip.emit(ThreadCommand('quit', ))
+            self._command_tcpip.emit(ThreadCommand(LECOCommands.QUIT, ))
             try:
                 self._command_tcpip[ThreadCommand].disconnect(self._leco_client.queue_command)
             except TypeError:
@@ -466,10 +466,10 @@ class ParameterControlModule(ParameterManager, ControlModule):
         elif status.command == 'disconnected':
             self.settings.child('main_settings', 'tcpip', 'tcp_connected').setValue(False)
 
-        elif status.command == LECO_Client_Commands.LECO_CONNECTED:
+        elif status.command == LECOClientCommands.LECO_CONNECTED:
             self.settings.child('main_settings', 'leco', 'leco_connected').setValue(True)
 
-        elif status.command == LECO_Client_Commands.LECO_DISCONNECTED:
+        elif status.command == LECOClientCommands.LECO_DISCONNECTED:
             self.settings.child('main_settings', 'leco', 'leco_connected').setValue(False)
 
         elif status.command == 'Update_Status':

--- a/src/pymodaq/control_modules/viewer_utility_classes.py
+++ b/src/pymodaq/control_modules/viewer_utility_classes.py
@@ -62,6 +62,7 @@ params = [
              {'title': 'Connect:', 'name': 'connect_leco_server', 'type': 'bool_push', 'label': 'Connect',
               'value': False},
              {'title': 'Connected?:', 'name': 'leco_connected', 'type': 'led', 'value': False},
+             {'title': 'Name', 'name': 'name', 'type': 'str', 'value': "", 'default': ""},
              {'title': 'Host:', 'name': 'host', 'type': 'str', 'value': config('network', "leco-server", "host"), "default": "localhost"},
              {'title': 'Port:', 'name': 'port', 'type': 'int', 'value': config('network', 'leco-server', 'port')},
          ]},
@@ -198,17 +199,17 @@ class DAQ_Viewer_base(QObject):
 
     def _emit_dte(self, dte: Union[DataToExport, list]):
         if isinstance(dte, list):
-            deprecation_msg(f'Data emitted from the instrument plugins should be a DataToExport instance'
-                            f'See: http://pymodaq.cnrs.fr/en/latest/developer_folder/'
-                            f'instrument_plugins.html#emission-of-data')
+            deprecation_msg('Data emitted from the instrument plugins should be a DataToExport instance'
+                            'See: http://pymodaq.cnrs.fr/en/latest/developer_folder/'
+                            'instrument_plugins.html#emission-of-data')
             dte = DataToExport('temp', dte)
         self.dte_signal.emit(dte)
 
     def _emit_dte_temp(self, dte: Union[DataToExport, list]):
         if isinstance(dte, list):
-            deprecation_msg(f'Data emitted from the instrument plugins should be a DataToExport instance'
-                            f'See: http://pymodaq.cnrs.fr/en/latest/developer_folder/'
-                            f'instrument_plugins.html#emission-of-data')
+            deprecation_msg('Data emitted from the instrument plugins should be a DataToExport instance'
+                            'See: http://pymodaq.cnrs.fr/en/latest/developer_folder/'
+                            'instrument_plugins.html#emission-of-data')
             dte = DataToExport('temp', dte)
         self.dte_signal_temp.emit(dte)
 
@@ -221,7 +222,7 @@ class DAQ_Viewer_base(QObject):
     def ini_detector_init(self, old_controller=None, new_controller=None):
         """Manage the Master/Slave controller issue
 
-        First initialize the status dictionnary
+        First initialize the status dictionary
         Then check whether this stage is controlled by a multiaxe controller (to be defined for each plugin)
             if it is a multiaxes controller then:
             * if it is Master: init the controller here
@@ -252,28 +253,28 @@ class DAQ_Viewer_base(QObject):
         Mandatory
         To be reimplemented in subclass
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     def close(self):
         """
         Mandatory
         To be reimplemented in subclass
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     def grab_data(self, Naverage=1, **kwargs):
         """
         Mandatory
         To be reimplemented in subclass
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     def stop(self):
         """
         Mandatory
         To be reimplemented in subclass
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     def commit_settings(self, param):
         """
@@ -307,7 +308,7 @@ class DAQ_Viewer_base(QObject):
             print(status)
 
     def update_scanner(self, scan_parameters):
-        #todo check this because ScanParameters has been removed
+        # todo check this because ScanParameters has been removed
         self.scan_parameters = scan_parameters
 
     @Slot(edict)
@@ -318,7 +319,7 @@ class DAQ_Viewer_base(QObject):
 
             ========================== ============= =====================================================
             **Parameters**              **Type**      **Description**
-            *settings_parameter_dict*   dictionnnary  a dictionnary listing path and associated parameter
+            *settings_parameter_dict*   dictionnnary  a dictionary listing path and associated parameter
             ========================== ============= =====================================================
 
             See Also
@@ -389,7 +390,6 @@ class DAQ_Viewer_base(QObject):
             pass
 
 
-
 class DAQ_Viewer_TCP_server(DAQ_Viewer_base, TCPServer):
     """
         ================= ==============================
@@ -424,7 +424,7 @@ class DAQ_Viewer_TCP_server(DAQ_Viewer_base, TCPServer):
         grabber_type: (str) either '0D', '1D' or '2D'
         """
         self.client_type = "GRABBER"
-        DAQ_Viewer_base.__init__(self, parent, params_state)  # initialize base class with commom attribute and methods
+        DAQ_Viewer_base.__init__(self, parent, params_state)  # initialize base class with common attribute and methods
         TCPServer.__init__(self, self.client_type)
 
         self.x_axis = None
@@ -480,7 +480,7 @@ class DAQ_Viewer_TCP_server(DAQ_Viewer_base, TCPServer):
 
     def data_ready(self, data: DataToExport):
         """
-            Send the grabed data signal.
+            Send the grabbed data signal.
         """
         self.dte_signal.emit(data)
 
@@ -516,7 +516,7 @@ class DAQ_Viewer_TCP_server(DAQ_Viewer_base, TCPServer):
 
     def ini_detector(self, controller=None):
         """
-            | Initialisation procedure of the detector updating the status dictionnary.
+            | Initialisation procedure of the detector updating the status dictionary.
             |
             | Init axes from image , here returns only None values (to tricky to di it with the server and not really
              necessary for images anyway)

--- a/src/pymodaq/utils/leco/leco_director.py
+++ b/src/pymodaq/utils/leco/leco_director.py
@@ -47,7 +47,6 @@ class LECODirector:
         super().__init__(**kwargs)
 
         name = f'{self._title}_{random.randrange(0, 10000)}_director'
-        print("name", name)
         # TODO use the same Listener instance as the LECOActorModule
         self.listener = PymodaqListener(name=name)
         self.listener.start_listen()

--- a/src/pymodaq/utils/leco/pymodaq_listener.py
+++ b/src/pymodaq/utils/leco/pymodaq_listener.py
@@ -136,6 +136,10 @@ class PymodaqListener(Listener):
 
     def stop_listen(self) -> None:
         super().stop_listen()
+        try:
+            del self.communicator
+        except AttributeError:
+            pass
         self.signals.cmd_signal.emit(ThreadCommand(LECO_Client_Commands.LECO_DISCONNECTED))
 
     def indicate_sign_in_out(self, full_name: str):

--- a/src/pymodaq/utils/managers/parameter_manager.py
+++ b/src/pymodaq/utils/managers/parameter_manager.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Union, Dict
+from typing import List, Union, Dict, Optional
 
 from qtpy import QtWidgets, QtCore
 from pymodaq.utils.managers.action_manager import ActionManager
@@ -84,7 +84,10 @@ class ParameterManager:
     settings_name = 'custom_settings'
     params = []
 
-    def __init__(self, settings_name: str = None, action_list: tuple = ('save', 'update', 'load')):
+    def __init__(self, settings_name: Optional[str] = None,
+                 action_list: tuple = ('save', 'update', 'load'),
+                 **kwargs):
+        super().__init__(**kwargs)
         if settings_name is None:
             settings_name = self.settings_name
         # create a settings tree to be shown eventually in a dock


### PR DESCRIPTION
I added the option to give a name to the ActorModules (just called `name`).
If that name is not given, it will take the name of the module.

You can change that name at any time (even while connected to the leco network: it will sign out, change the name and sign in again).

I also created a superclass for both Modules, such that some logic can be shared and does not have to be written twice.

As an example, how to use enums for ThreadCommands, I added a few ones for LECO