### PR TITLE
remove pyleco dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "toml",
     "qtconsole",
     "tables<3.9",  # issue with some version of required package blosc2>=2.2.8
-    "pyleco",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "toml",
     "qtconsole",
     "tables<3.9",  # issue with some version of required package blosc2>=2.2.8
+    "pyleco; python_version>\"3.8\"",
 ]
 
 [project.scripts]


### PR DESCRIPTION
pyleco is only compatible with python >=3.9 so the python3.8 CI tests failed because of the added dependency...