### PR TITLE
Feature/starting coordinator

### DIFF
--- a/src/pymodaq/__init__.py
+++ b/src/pymodaq/__init__.py
@@ -39,7 +39,7 @@ try:
     # in a try statement for compilation on readthedocs server but if this fail, you cannot use the code
     from pymodaq.utils.plotting import data_viewers  # imported here as to avoid circular imports later on
     from pymodaq.utils.daq_utils import copy_preset, setLocale, set_qt_backend
-
+    from pymodaq.utils.daq_utils import get_instrument_plugins
     from pymodaq.utils.config import Config
 
 
@@ -83,9 +83,27 @@ try:
     Q_ = ureg.Quantity
     logger.info('')
     logger.info('')
-    logger.info('************************')
-    logger.info(f"Getting the list of instrument plugins...")
-    logger.info('************************')
+    # logger.info('************************')
+    # logger.info(f"Getting the list of instrument plugins...")
+    # logger.info('************************')
+    # get_instrument_plugins()
+
+    if config('network', 'leco-server', 'run_coordinator_at_startup'):
+        try:
+            from pymodaq.utils.leco.utils import start_coordinator
+            logger.info('')
+            logger.info('')
+            logger.info('************************')
+            logger.info(f"Starting the LECO Coordinator...")
+            logger.info('************************')
+            logger.info('')
+            logger.info('')
+            start_coordinator()
+        except ImportError:
+            pass
+
+
+
 
 except Exception as e:
     try:

--- a/src/pymodaq/__init__.py
+++ b/src/pymodaq/__init__.py
@@ -83,10 +83,10 @@ try:
     Q_ = ureg.Quantity
     logger.info('')
     logger.info('')
-    # logger.info('************************')
-    # logger.info(f"Getting the list of instrument plugins...")
-    # logger.info('************************')
-    # get_instrument_plugins()
+    logger.info('************************')
+    logger.info(f"Getting the list of instrument plugins...")
+    logger.info('************************')
+    get_instrument_plugins()
 
     if config('network', 'leco-server', 'run_coordinator_at_startup'):
         try:

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -101,7 +101,7 @@ class DAQ_Viewer(ParameterControlModule):
         self.logger = set_logger(f'{logger.name}.{title}')
         self.logger.info(f'Initializing DAQ_Viewer: {title}')
 
-        super().__init__(action_list = ('save','update'), **kwargs)
+        super().__init__(**kwargs)
 
         daq_type = enum_checker(DAQTypesEnum, daq_type)
         self._daq_type: DAQTypesEnum = daq_type

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -978,6 +978,7 @@ class DAQ_Viewer(ParameterControlModule):
 
             det_params, _class = get_viewer_plugins(self.daq_type.name, self.detector)
             self.settings.child('detector_settings').addChildren(det_params.children())
+            self.settings.child('main_settings', 'module_name').setValue(self._title)
         except Exception as e:
             self.logger.exception(str(e))
 

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -790,9 +790,9 @@ class DAQ_Viewer(ParameterControlModule):
         """
         try:
             dte = dte.deepcopy()
-            if self.settings.child('main_settings', 'tcpip', 'tcp_connected').value() and self._send_to_tcpip:
+            if self.settings['main_settings', 'tcpip', 'tcp_connected'] and self._send_to_tcpip:
                 self._command_tcpip.emit(ThreadCommand('data_ready', dte))
-            if self.settings.child('main_settings', 'leco', 'leco_connected').value() and self._send_to_tcpip:
+            if self.settings['main_settings', 'leco', 'leco_connected'] and self._send_to_tcpip:
                 self._command_tcpip.emit(ThreadCommand('data_ready', dte))
             if self.ui is not None:
                 self.ui.data_ready = True

--- a/src/pymodaq/control_modules/move_utility_classes.py
+++ b/src/pymodaq/control_modules/move_utility_classes.py
@@ -127,7 +127,7 @@ params = [
              {'title': 'Connect:', 'name': 'connect_leco_server', 'type': 'bool_push', 'label': 'Connect',
               'value': False},
              {'title': 'Connected?:', 'name': 'leco_connected', 'type': 'led', 'value': False},
-             {'title': 'Name', 'name': 'name', 'type': 'str', 'value': "", 'default': ""},
+             {'title': 'Name', 'name': 'leco_name', 'type': 'str', 'value': "", 'default': ""},
              {'title': 'Host:', 'name': 'host', 'type': 'str', 'value': config('network', "leco-server", "host"), "default": "localhost"},
              {'title': 'Port:', 'name': 'port', 'type': 'int', 'value': config('network', 'leco-server', 'port')},
          ]},

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -435,14 +435,14 @@ class ParameterControlModule(ParameterManager, ControlModule):
             self._tcpclient_thread.start()
 
     def get_leco_name(self) -> str:
-        name = self.settings["main_settings", "leco", "name"]
+        name = self.settings["main_settings", "leco", "leco_name"]
         if name == '':
             # take the module name as alternative
             name = self.settings["main_settings", "module_name"]
         if name == '':
             # a name is required, invent one
             name = f"viewer_{randint(0, 10000)}"
-            name = self.settings.child("main_settings", "leco", "name").setValue(name)
+            name = self.settings.child("main_settings", "leco", "leco_name").setValue(name)
         return name
 
     def connect_leco(self, connect: bool) -> None:

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -435,11 +435,11 @@ class ParameterControlModule(ParameterManager, ControlModule):
             self._tcpclient_thread.start()
 
     def get_leco_name(self) -> str:
-        name = self.settings.child("main_settings", "leco", "name").value()
-        if not name:
+        name = self.settings["main_settings", "leco", "name"]
+        if name == '':
             # take the module name as alternative
-            name = self.settings.child("main_settings", "module_name").value()
-        if not name:
+            name = self.settings["main_settings", "module_name"]
+        if name == '':
             # a name is required, invent one
             name = f"viewer_{randint(0, 10000)}"
             name = self.settings.child("main_settings", "leco", "name").setValue(name)

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -356,6 +356,11 @@ class ParameterControlModule(ParameterManager, ControlModule):
 
     listener_class: type[ActorListener] = ActorListener
 
+    def __init__(self, **kwargs):
+        QObject.__init__(self)
+        ParameterManager.__init__(self, action_list=('save', 'update'))
+        ControlModule.__init__(self)
+
     def value_changed(self, param: Parameter) -> Optional[Parameter]:
         """ParameterManager subclassed method. Process events from value changed by user in the UI Settings
 

--- a/src/pymodaq/control_modules/viewer_utility_classes.py
+++ b/src/pymodaq/control_modules/viewer_utility_classes.py
@@ -62,7 +62,7 @@ params = [
              {'title': 'Connect:', 'name': 'connect_leco_server', 'type': 'bool_push', 'label': 'Connect',
               'value': False},
              {'title': 'Connected?:', 'name': 'leco_connected', 'type': 'led', 'value': False},
-             {'title': 'Name', 'name': 'name', 'type': 'str', 'value': "", 'default': ""},
+             {'title': 'Name', 'name': 'leco_name', 'type': 'str', 'value': "", 'default': ""},
              {'title': 'Host:', 'name': 'host', 'type': 'str', 'value': config('network', "leco-server", "host"), "default": "localhost"},
              {'title': 'Port:', 'name': 'port', 'type': 'int', 'value': config('network', 'leco-server', 'port')},
          ]},

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -28,7 +28,7 @@ from pymodaq.utils.managers.roi_manager import ROISaver
 from pymodaq.utils.exceptions import DetectorError, ActuatorError, PIDError, MasterSlaveError
 from pymodaq.utils import config as configmod
 from pymodaq.utils.parameter import ParameterTree, Parameter
-
+from pymodaq.utils.leco.utils import start_coordinator
 from pymodaq.control_modules.daq_move import DAQ_Move
 from pymodaq.control_modules.daq_viewer import DAQ_Viewer
 
@@ -262,6 +262,8 @@ class DashBoard(QObject):
         restart_action.triggered.connect(self.restart_fun)
 
         self.settings_menu = menubar.addMenu('Settings')
+        action_leco = self.settings_menu.addAction('Run Leco Coordinator')
+        action_leco.triggered.connect(start_coordinator)
         docked_menu = self.settings_menu.addMenu('Docked windows')
         action_load = docked_menu.addAction('Load Layout')
         action_save = docked_menu.addAction('Save Layout')

--- a/src/pymodaq/resources/config_template.toml
+++ b/src/pymodaq/resources/config_template.toml
@@ -56,6 +56,7 @@ allow_settings_edition = false
     port = 6341
 
     [network.leco-server]
+    run_coordinator_at_startup = false
     host = "localhost"
     port = 12300  # pyleco default Coordinator port
 

--- a/src/pymodaq/utils/daq_utils.py
+++ b/src/pymodaq/utils/daq_utils.py
@@ -611,8 +611,10 @@ def get_instrument_plugins():  # pragma: no cover
                                      'type': 'daq_move'}
                                     for mod in [mod[1] for mod in pkgutil.iter_modules([str(movemodule.path.parent)])]
                                     if 'daq_move' in mod])
+                logger.info(f"Found Move Instrument: {plugin_list[-1]['name']}")
             except ModuleNotFoundError:
                 pass
+
             viewer_modules = {}
             for vtype in viewer_types:
                 try:
@@ -624,6 +626,7 @@ def get_instrument_plugins():  # pragma: no cover
                                      'type': f'daq_{vtype}viewer'}
                                     for mod in [mod[1] for mod in pkgutil.iter_modules([str(viewer_modules[vtype].path.parent)])]
                                     if f'daq_{vtype}viewer' in mod])
+                    logger.info(f"Found Viewer Instrument: {plugin_list[-1]['name']}")
                 except ModuleNotFoundError:
                     pass
 
@@ -659,6 +662,7 @@ def get_instrument_plugins():  # pragma: no cover
         logger.debug(f'Impossible to import PID utility plugin: {str(e)}')
 
     return plugins_import
+
 
 def get_plugins(plugin_type='daq_0Dviewer'):  # pragma: no cover
     """

--- a/src/pymodaq/utils/factory.py
+++ b/src/pymodaq/utils/factory.py
@@ -27,8 +27,8 @@ class BuilderBase(ABCMeta):
 
 
 class ObjectFactory(metaclass=ABCMeta):
-    """Generic ObjectFactory with a decorator register to add object builders to the factory with a unique key
-    identifier
+    """Generic ObjectFactory with a decorator register to add object builders to the factory with a
+    unique key identifier
 
     See https://realpython.com/factory-method-python/ for some details
 

--- a/src/pymodaq/utils/leco/utils.py
+++ b/src/pymodaq/utils/leco/utils.py
@@ -21,5 +21,9 @@ def serialize_object(pymodaq_object: Union[SERIALIZABLE, Any]) -> Union[str, Any
 
 
 def start_coordinator():
-    command = [sys.executable, '-m', 'pyleco.coordinators.coordinator']
-    subprocess.run(command, shell=True)
+    from pyleco.directors.director import Director
+
+    with Director(actor="COORDINATOR") as director:
+        if director.communicator.namespace is None:
+            command = [sys.executable, '-m', 'pyleco.coordinators.coordinator']
+            subprocess.run(command, shell=True)

--- a/src/pymodaq/utils/leco/utils.py
+++ b/src/pymodaq/utils/leco/utils.py
@@ -4,7 +4,10 @@ from typing import Any, Union
 
 # import also the DeSerializer for easier imports in dependents
 from pymodaq.utils.tcp_ip.serializer import SERIALIZABLE, Serializer, DeSerializer  # type: ignore  # noqa
+from pymodaq.utils.logger import set_logger
 
+
+logger = set_logger('leco_utils')
 
 JSON_TYPES = Union[str, int, float]
 
@@ -20,10 +23,21 @@ def serialize_object(pymodaq_object: Union[SERIALIZABLE, Any]) -> Union[str, Any
                          "JSON serializable, nor via PyMoDAQ.")
 
 
-def start_coordinator():
-    from pyleco.directors.director import Director
+def run_coordinator():
+    command = [sys.executable, '-m', 'pyleco.coordinators.coordinator']
+    subprocess.Popen(command)
 
-    with Director(actor="COORDINATOR") as director:
-        if director.communicator.namespace is None:
-            command = [sys.executable, '-m', 'pyleco.coordinators.coordinator']
-            subprocess.run(command, shell=True)
+
+def start_coordinator():
+    # from pyleco.directors.director import Director
+    # try:
+    #     with Director(actor="COORDINATOR") as director:
+    #         if director.communicator.namespace is None:
+    #             run_coordinator()
+    #         else:
+    #             logger.info('Coordinator already running')
+    # except ConnectionRefusedError:
+    #     run_coordinator()
+    #     pass
+    run_coordinator()
+

--- a/src/pymodaq/utils/leco/utils.py
+++ b/src/pymodaq/utils/leco/utils.py
@@ -29,15 +29,10 @@ def run_coordinator():
 
 
 def start_coordinator():
-    # from pyleco.directors.director import Director
-    # try:
-    #     with Director(actor="COORDINATOR") as director:
-    #         if director.communicator.namespace is None:
-    #             run_coordinator()
-    #         else:
-    #             logger.info('Coordinator already running')
-    # except ConnectionRefusedError:
-    #     run_coordinator()
-    #     pass
-    run_coordinator()
+    from pyleco.directors.director import Director
+    with Director(actor="COORDINATOR") as director:
+        if director.communicator.namespace is None:
+            run_coordinator()
+        else:
+            logger.info('Coordinator already running')
 

--- a/src/pymodaq/utils/leco/utils.py
+++ b/src/pymodaq/utils/leco/utils.py
@@ -1,4 +1,5 @@
-
+import subprocess
+import sys
 from typing import Any, Union
 
 # import also the DeSerializer for easier imports in dependents
@@ -17,3 +18,8 @@ def serialize_object(pymodaq_object: Union[SERIALIZABLE, Any]) -> Union[str, Any
     else:
         raise ValueError(f"{pymodaq_object} of type '{type(pymodaq_object).__name__}' is neither "
                          "JSON serializable, nor via PyMoDAQ.")
+
+
+def start_coordinator():
+    command = [sys.executable, '-m', 'pyleco.coordinators.coordinator']
+    subprocess.run(command, shell=True)

--- a/src/pymodaq/utils/managers/parameter_manager.py
+++ b/src/pymodaq/utils/managers/parameter_manager.py
@@ -86,8 +86,7 @@ class ParameterManager:
 
     def __init__(self, settings_name: Optional[str] = None,
                  action_list: tuple = ('save', 'update', 'load'),
-                 **kwargs):
-        super().__init__(**kwargs)
+                 ):
         if settings_name is None:
             settings_name = self.settings_name
         # create a settings tree to be shown eventually in a dock

--- a/src/pymodaq/utils/parameter/ioxml.py
+++ b/src/pymodaq/utils/parameter/ioxml.py
@@ -466,6 +466,9 @@ def set_txt_from_elt(el, param_dict):
         else:
             param_value = val_text
         param_dict.update(dict(value=param_value))
+    else:
+        if param_type == 'str':
+            param_dict.update(dict(value=''))
 
 
 def XML_file_to_parameter(file_name: Union[str, Path]) -> list:
@@ -535,4 +538,5 @@ def XML_string_to_pobject(xml_string) -> Parameter:
     --------
     parameter_to_xml_string
     """
-    return Parameter.create(name='settings', type='group', children=XML_string_to_parameter(xml_string))
+    return Parameter.create(name='settings', type='group',
+                            children=XML_string_to_parameter(xml_string))

--- a/tests/utils/parameter_test/param_ioxml_test.py
+++ b/tests/utils/parameter_test/param_ioxml_test.py
@@ -109,3 +109,6 @@ class TestXMLbackForth:
             if 'limits' in child_back.opts:
                 assert child_back.opts['limits'] == child.opts['limits']
             assert child_back.opts['removable'] == child.opts['removable']
+
+
+

--- a/tests/utils/parameter_test/param_str_test.py
+++ b/tests/utils/parameter_test/param_str_test.py
@@ -1,0 +1,13 @@
+from pymodaq.utils.parameter import Parameter, ParameterTree
+from pymodaq.utils.parameter import ioxml
+
+def test_empty_string():
+
+    param_list = [{'name': 'strname', 'type': 'str', 'value': ''}]
+
+    settings = Parameter.create(name='settings', type='group', children=param_list)
+    xml_string = ioxml.parameter_to_xml_string(settings)
+    settings_back = ioxml.XML_string_to_pobject(xml_string)
+    #
+    assert settings_back['strname'] == ''
+    pass


### PR DESCRIPTION
add various options to start coordinator:

* from the Dashboard settings menu
* by configuring the pymodaq config file. If the entry:    
```
[network.leco-server]    
run_coordinator_at_startup = false
```
is set to true, then the coordinator will be started at first import of pymodaq (within the __init__)

Also patch a few thing:

* a critical fix about ParameterManager init adding kwargs to its super (object) was inducing a werid crash of the Dashboard when loading Viewers 
* fix the default leco name (modified its parameter id (name by leco_name) 
* make sure empty Parameter string are not restored from xml file with 'None'
* updating module_name setting from title after updating settings from xml files

