### PR TITLE
Fix typing in serialize_object

### DIFF
--- a/src/pymodaq/utils/leco/utils.py
+++ b/src/pymodaq/utils/leco/utils.py
@@ -1,6 +1,6 @@
 import subprocess
 import sys
-from typing import Any, Union
+from typing import Any, Union, get_args
 
 # import also the DeSerializer for easier imports in dependents
 from pymodaq.utils.tcp_ip.serializer import SERIALIZABLE, Serializer, DeSerializer  # type: ignore  # noqa
@@ -14,9 +14,9 @@ JSON_TYPES = Union[str, int, float]
 
 def serialize_object(pymodaq_object: Union[SERIALIZABLE, Any]) -> Union[str, Any]:
     """Serialize a pymodaq object, if it is not JSON compatible."""
-    if isinstance(pymodaq_object, JSON_TYPES):
+    if isinstance(pymodaq_object, get_args(JSON_TYPES)):
         return pymodaq_object
-    elif isinstance(pymodaq_object, SERIALIZABLE):
+    elif isinstance(pymodaq_object, get_args(SERIALIZABLE)):
         return Serializer(pymodaq_object).to_b64_string()
     else:
         raise ValueError(f"{pymodaq_object} of type '{type(pymodaq_object).__name__}' is neither "


### PR DESCRIPTION
It seems, that `isinstance(obj, Union)` does not work in Python<3.10.

`typing.get_args` gets the simplified arguments and should work as an argument for `isinstance`.