### PR TITLE
Hotfix/list value

### DIFF
--- a/src/pymodaq/examples/parameter_ex.py
+++ b/src/pymodaq/examples/parameter_ex.py
@@ -51,11 +51,15 @@ class ParameterEx(ParameterManager):
         {'title': 'An action', 'name': 'action', 'type': 'action'},  # action whose displayed text corresponds to title
 
         {'title': 'Lists:', 'name': 'lists', 'type': 'group', 'children': [
-            {'title': 'Standard list:', 'name': 'alist', 'type': 'list', 'limits': ['a value', 'another one']},
-            {'title': 'List with add:', 'name': 'anotherlist', 'type': 'list', 'limits': ['a value', 'another one'],
+            {'title': 'Standard list:', 'name': 'alist', 'type': 'list',
+             'limits': ['a value', 'another one'], 'value': 'a value'},
+            {'title': 'List with add:', 'name': 'anotherlist', 'type': 'list',
+             'limits': ['a value', 'another one'], 'value': 'a value',
              'show_pb': True, 'tip': 'when using the "show_pb" option, displays a plus button to add elt to the list'},
             {'title': 'List defined from a dict:', 'name': 'dict_list', 'type': 'list',
-             'limits': {'xaxis': 0, 'yaxis': [0, 1, 2]}, 'tip': 'Such a parameter display text that are keys of a dict while'
+             'limits': {'xaxis': 0, 'yaxis': [0, 1, 2]},
+             'value': 'yaxis',
+             'tip': 'Such a parameter display text that are keys of a dict while'
                                                         'values could be any object'
              },
         ]},

--- a/src/pymodaq/utils/parameter/pymodaq_ptypes/__init__.py
+++ b/src/pymodaq/utils/parameter/pymodaq_ptypes/__init__.py
@@ -1,7 +1,8 @@
-from pyqtgraph.parametertree.parameterTypes.basetypes import SimpleParameter, GroupParameter, GroupParameterItem
-from .bool import BoolPushParameterItem
-from .pixmap import PixmapParameterItem, PixmapCheckParameterItem
-from .slide import SliderSpinBox, SliderParameterItem
+from pyqtgraph.parametertree.parameterTypes.basetypes import (SimpleParameter, GroupParameter,
+                                                              GroupParameterItem)
+from .bool import BoolPushParameter
+from .pixmap import PixmapParameter, PixmapCheckParameter
+from .slide import SliderSpinBox, SliderParameter
 from .led import LedPushParameter, LedParameter
 from .date import DateParameter, DateTimeParameter, TimeParameter
 from .list import ListParameter
@@ -12,14 +13,15 @@ from .filedir import FileDirParameter
 from .text import PlainTextPbParameter
 from .numeric import NumericParameter
 
-from pyqtgraph.parametertree.Parameter import registerParameterType, registerParameterItemType
+from pyqtgraph.parametertree.Parameter import registerParameterType, registerParameterItemType, Parameter
 
 registerParameterType('float', NumericParameter, override=True)
 registerParameterType('int',   NumericParameter, override=True)
-registerParameterItemType('bool_push', BoolPushParameterItem, SimpleParameter, override=True)
-registerParameterItemType('pixmap', PixmapParameterItem, SimpleParameter, override=True)
-registerParameterItemType('pixmap_check', PixmapCheckParameterItem, SimpleParameter, override=True)
-registerParameterItemType('slide', SliderParameterItem, SimpleParameter, override=True)
+registerParameterItemType('bool_push', BoolPushParameter, override=True)
+registerParameterType('pixmap', PixmapParameter, override=True)
+registerParameterType('pixmap_check', PixmapCheckParameter, override=True)
+
+registerParameterType('slide', SliderParameter, override=True)
 
 registerParameterType('led', LedParameter, override=True)
 registerParameterType('led_push', LedPushParameter, override=True)

--- a/src/pymodaq/utils/parameter/pymodaq_ptypes/bool.py
+++ b/src/pymodaq/utils/parameter/pymodaq_ptypes/bool.py
@@ -1,5 +1,5 @@
 from qtpy import QtWidgets
-from pyqtgraph.parametertree.parameterTypes.basetypes import WidgetParameterItem
+from pyqtgraph.parametertree.parameterTypes.basetypes import WidgetParameterItem, SimpleParameter
 
 
 class BoolPushParameterItem(WidgetParameterItem):
@@ -23,3 +23,6 @@ class BoolPushParameterItem(WidgetParameterItem):
         self.hideWidget = False
         return w
 
+
+class BoolPushParameter(SimpleParameter):
+    itemClass = BoolPushParameterItem

--- a/src/pymodaq/utils/parameter/pymodaq_ptypes/pixmap.py
+++ b/src/pymodaq/utils/parameter/pymodaq_ptypes/pixmap.py
@@ -111,6 +111,14 @@ class PixmapCheckParameterItem(WidgetParameterItem):
         return w
 
 
+class PixmapCheckParameter(SimpleParameter):
+    itemClass = PixmapCheckParameterItem
+
+
+class PixmapParameter(SimpleParameter):
+    itemClass = PixmapParameterItem
+
+
 def main_widget():
     import sys
     app = QtWidgets.QApplication(sys.argv)

--- a/src/pymodaq/utils/parameter/pymodaq_ptypes/slide.py
+++ b/src/pymodaq/utils/parameter/pymodaq_ptypes/slide.py
@@ -1,6 +1,6 @@
 from qtpy import QtWidgets, QtCore
 from pyqtgraph.widgets.SpinBox import SpinBox
-from pyqtgraph.parametertree.parameterTypes.basetypes import WidgetParameterItem
+from pyqtgraph.parametertree.parameterTypes.basetypes import WidgetParameterItem, SimpleParameter
 from pymodaq.utils.parameter.utils import scroll_log, scroll_linear
 import numpy as np
 
@@ -136,3 +136,7 @@ class SliderParameterItem(WidgetParameterItem):
         w = SliderSpinBox(subtype=opts['subtype'], bounds=defs['bounds'], value=defs['value'], int=defs['int'])
         self.setSizeHint(1, QtCore.QSize(50, 50))
         return w
+
+
+class SliderParameter(SimpleParameter):
+    itemClass = SliderParameterItem

--- a/tests/utils/managers/parameter_manager_test.py
+++ b/tests/utils/managers/parameter_manager_test.py
@@ -9,8 +9,9 @@ import pytest
 from qtpy import QtWidgets
 
 from pymodaq.examples.parameter_ex import ParameterEx, Parameter
-from pymodaq.utils.parameter.utils import iter_children_params, compareParameters, compareStructureParameter,\
-    compareValuesParameter
+from pymodaq.utils.parameter.utils import (iter_children_params, compareParameters,
+                                           compareStructureParameter,
+                                           compareValuesParameter, iter_get_values)
 from pymodaq.utils.gui_utils.widgets.table import TableModel
 from pymodaq.utils.managers.parameter_manager import ParameterManager
 
@@ -66,46 +67,7 @@ def test_load(qtbot, tmp_path):
     ptree.save_settings_slot(file_path)
 
     parameter_copy = Parameter.create(name='settings', type='group', children=ParameterEx.params)
-    assert compareValuesParameter(ptree.settings, parameter_copy)
-
-    parameters = iter_children_params(ptree.settings, childlist=[])
-    parameters_copy = iter_children_params(parameter_copy, childlist=[])
-
-    for parameter in parameters:
-        if not parameter.hasChildren() and 'group' not in parameter.opts['type']:
-            default_parameter = Parameter.create(name='settings', type=parameter.opts['type'])
-            if not 'table' in parameter.opts['type']:
-                item = default_parameter.makeTreeItem(0)
-                if hasattr(item, 'widget'):
-                    parameter.setValue(item.widget.value())
-            elif 'tablewidget' == parameter.opts['type']:
-                parameter.setValue(OrderedDict(key1='data10', key2='25'))
-            elif 'tabular_table' == parameter.opts['type']:
-                parameter.setValue(TableModel([[0.5, 0.2, 0.6]], ['value20', 'val2', '555']))
-
-    assert not compareValuesParameter(ptree.settings, parameter_copy)
-    assert compareStructureParameter(ptree.settings, parameter_copy)
-
-    ptree.load_settings_slot(file_path)
-    parameters = iter_children_params(ptree.settings, childlist=[])
-
-    for parameter, pcopy in zip(parameters, parameters_copy):
-        if parameter.value() != pcopy.value():
-            print(parameter)
-
-    assert compareValuesParameter(ptree.settings, parameter_copy)
-    assert compareStructureParameter(ptree.settings, parameter_copy)
-
-def test_load(qtbot, tmp_path):
-    ptree = ParameterEx()
-    ptree.settings_tree.show()
-    qtbot.addWidget(ptree.settings_tree)
-
-    file_path = tmp_path.joinpath('settings.xml')
-    ptree.save_settings_slot(file_path)
-
-    parameter_copy = Parameter.create(name='settings', type='group', children=ParameterEx.params)
-    assert compareValuesParameter(ptree.settings, parameter_copy)
+    compareValuesParameter(ptree.settings, parameter_copy)
 
     parameters = iter_children_params(ptree.settings, childlist=[])
     parameters_copy = iter_children_params(parameter_copy, childlist=[])

--- a/tests/utils/parameter_test/param_utils_test.py
+++ b/tests/utils/parameter_test/param_utils_test.py
@@ -167,7 +167,7 @@ def test_set_param_from_param(qtbot):
             {'title': 'DAQ type:', 'name': 'DAQ_type', 'type': 'list', 'limits': ['DAQ0D', 'DAQ1D', 'DAQ2D', 'DAQND'],
              'readonly': True},
             {'title': 'axis names:', 'name': 'axis', 'type': 'list',
-             'limits': {'DAQ0D': 0, 'DAQ1D': 1, 'DAQ2D': 2, 'DAQND': 3}, 'readonly': True},
+             'limits': {'DAQ0D': 0, 'DAQ1D': 1, 'DAQ2D': 2, 'DAQND': 3}, 'value': 'DAQ1D',' readonly': True},
             {'title': 'Detector type:', 'name': 'detector_type', 'type': 'str', 'value': '', 'readonly': True},
             {'title': 'Nviewers:', 'name': 'Nviewers', 'type': 'int', 'value': 1, 'min': 1, 'default': 1,
              'readonly': True},


### PR DESCRIPTION
with new version of pyqtgraph, list parameters should explicitly have their value defined otherwise they default to None and no more the first value in the list