### PR TITLE
Fixed broken double-click for moving and init position in the daq_scan

### DIFF
--- a/src/pymodaq/extensions/daq_scan.py
+++ b/src/pymodaq/extensions/daq_scan.py
@@ -570,7 +570,12 @@ class DAQScan(QObject, ParameterManager):
             print(f'clicked at: {posx}, {posy}')
         positions = [posx, posy]
         positions = positions[:self.scanner.n_axes]
-        self.modules_manager.move_actuators(positions)
+        actuators = self.modules_manager.actuators
+        dte = DataToExport(name="move_at")
+        for ind, pos in enumerate(positions):
+            dte.append(DataActuator(actuators[ind].title, data=float(pos)))
+
+        self.modules_manager.move_actuators(dte)
 
     def value_changed(self, param):
         """


### PR DESCRIPTION
Hello from Montpellier!
We noticed that moving the scanners to a given position on an image in the Scan extension was broken in the stable version (and also in the dev version, we can do another PR there if necessary). 
Having a look at the code, we found that the `move_at` function was sending a list of positions (floats), but the `move_actuators` functions of the `modules_manager` now requires a DataToExport object. We modified the code of the `move_at` function of the `daq_scan` to fix this.
We tested it with the Mock instruments and with our physical scanners in the lab, it works well except when clicking on Init Position if no scan has been started before. We have no clue about this particular problem.
Aurore, Elias and Roméo