### PR TITLE
bugfix load_ROI: 'filter' argument is a str, not list of str.

### DIFF
--- a/src/pymodaq/utils/gui_utils/file_io.py
+++ b/src/pymodaq/utils/gui_utils/file_io.py
@@ -70,8 +70,9 @@ def select_file(start_path=config('data_saving', 'h5file', 'save_path'), save=Tr
         if True, ask you to enter a filename (with or without extension)
     ext: str
         the extension string, e.g. xml, h5, png ...
-    filter: list of string
-        list of possible extensions, mostly valid for loading
+    filter: string
+        list of possible extensions, if you need several you can separate them by ;;
+        for example: "Images (*.png *.xpm *.jpg);;Text files (*.txt);;XML files (*.xml)"
     force_save_extension: bool
         if True force the extension of the saved file to be set to ext
 

--- a/src/pymodaq/utils/managers/roi_manager.py
+++ b/src/pymodaq/utils/managers/roi_manager.py
@@ -571,7 +571,7 @@ class ROIManager(QObject):
         try:
             if params is None:
                 if path is None:
-                    path = select_file(start_path=Path.home(), save=False, ext='xml', filter=['xml'])
+                    path = select_file(start_path=Path.home(), save=False, ext='xml', filter='XML files (*.xml)')
                     if path != '':
                         params = Parameter.create(title='Settings', name='settings', type='group',
                                                   children=ioxml.XML_file_to_parameter(path))


### PR DESCRIPTION
"Load ROI" in a Viewer wasn't working because 'filter' option of file_io.select_file needs to be a str, not list of str. 
[QtWidgets.QFileDialog.getOpenFileName](https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QFileDialog.html#PySide6.QtWidgets.QFileDialog.getOpenFileName)

Corrected and changed docstring of file_io.select_file. 
Didn't find any other call of file_io.select_file with list of str anywhere else so this should be ok!



