### PR TITLE
plugin listing

### DIFF
--- a/src/pymodaq/utils/daq_utils.py
+++ b/src/pymodaq/utils/daq_utils.py
@@ -583,7 +583,8 @@ def get_instrument_plugins():  # pragma: no cover
                                      'type': 'daq_move'}
                                     for mod in [mod[1] for mod in pkgutil.iter_modules([str(movemodule.path.parent)])]
                                     if 'daq_move' in mod])
-                logger.info(f"Found Move Instrument: {plugin_list[-1]['name']}")
+                if len(plugin_list) > 0:
+                    logger.info(f"Found Move Instrument: {plugin_list[-1]['name']}")
             except ModuleNotFoundError:
                 pass
 
@@ -598,7 +599,8 @@ def get_instrument_plugins():  # pragma: no cover
                                      'type': f'daq_{vtype}viewer'}
                                     for mod in [mod[1] for mod in pkgutil.iter_modules([str(viewer_modules[vtype].path.parent)])]
                                     if f'daq_{vtype}viewer' in mod])
-                    logger.info(f"Found Viewer Instrument: {plugin_list[-1]['name']}")
+                    if len(plugin_list) > 0:
+                        logger.info(f"Found Viewer Instrument: {plugin_list[-1]['name']}")
                 except ModuleNotFoundError:
                     pass
 


### PR DESCRIPTION
if no move or viewer instrument is found in a plugin the log info was accessing the index of an empty list, creating an error preventing the instruments to be used...