### PR TITLE
Binary transfer via PyLECO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "toml",
     "qtconsole",
     "tables<3.9",  # issue with some version of required package blosc2>=2.2.8
-    "pyleco; python_version>=\"3.8\"",
+    "pyleco>0.3; python_version>=\"3.8\"",
     "bayesian-optimization"
 ]
 

--- a/src/pymodaq/utils/leco/pymodaq_listener.py
+++ b/src/pymodaq/utils/leco/pymodaq_listener.py
@@ -17,7 +17,7 @@ from qtpy.QtCore import QObject, Signal  # type: ignore
 from pymodaq.utils.daq_utils import ThreadCommand
 from pymodaq.utils.parameter import ioxml
 from pymodaq.utils.tcp_ip.serializer import DataWithAxes, SERIALIZABLE, DeSerializer
-from pymodaq.utils.leco.utils import serialize_object
+from pymodaq.utils.leco.utils import binary_serialization_to_kwargs
 
 
 class LECOClientCommands(StrEnum):
@@ -220,7 +220,7 @@ class ActorListener(PymodaqListener):
             self.communicator.ask_rpc(
                 receiver=self.remote_name,
                 method="set_data",
-                data=serialize_object(value),
+                **binary_serialization_to_kwargs(value),
             )
 
         elif command.command == 'send_info':
@@ -236,14 +236,14 @@ class ActorListener(PymodaqListener):
             value = command.attribute[0]  # type: ignore
             self.communicator.ask_rpc(receiver=self.remote_name,
                                       method="set_position",
-                                      position=serialize_object(value),
+                                      **binary_serialization_to_kwargs(value, data_key="position"),
                                       )
 
         elif command.command == LECOMoveCommands.MOVE_DONE:
             value = command.attribute[0]  # type: ignore
             self.communicator.ask_rpc(receiver=self.remote_name,
                                       method="set_move_done",
-                                      position=serialize_object(value),
+                                      **binary_serialization_to_kwargs(value, data_key="position"),
                                       )
 
         elif command.command == 'x_axis':
@@ -251,7 +251,7 @@ class ActorListener(PymodaqListener):
             if isinstance(value, SERIALIZABLE):
                 self.communicator.ask_rpc(receiver=self.remote_name,
                                           method="set_x_axis",
-                                          data=serialize_object(value),
+                                          **binary_serialization_to_kwargs(value),
                                           )
             elif isinstance(value, dict):
                 self.communicator.ask_rpc(receiver=self.remote_name, method="set_x_axis", **value)
@@ -263,7 +263,7 @@ class ActorListener(PymodaqListener):
             if isinstance(value, SERIALIZABLE):
                 self.communicator.ask_rpc(receiver=self.remote_name,
                                           method="set_y_axis",
-                                          data=serialize_object(value),
+                                          **binary_serialization_to_kwargs(value),
                                           )
             elif isinstance(value, dict):
                 self.communicator.ask_rpc(receiver=self.remote_name, method="set_y_axis", **value)

--- a/src/pymodaq/utils/leco/utils.py
+++ b/src/pymodaq/utils/leco/utils.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
 import subprocess
 import sys
-from typing import Any, Union, get_args
+from typing import Any, Optional, Union, get_args
 
 # import also the DeSerializer for easier imports in dependents
 from pymodaq.utils.tcp_ip.serializer import SERIALIZABLE, Serializer, DeSerializer  # type: ignore  # noqa
@@ -21,6 +22,29 @@ def serialize_object(pymodaq_object: Union[SERIALIZABLE, Any]) -> Union[str, Any
     else:
         raise ValueError(f"{pymodaq_object} of type '{type(pymodaq_object).__name__}' is neither "
                          "JSON serializable, nor via PyMoDAQ.")
+
+
+def binary_serialization(
+    pymodaq_object: Union[SERIALIZABLE, Any],
+) -> tuple[Optional[Any], Optional[list[bytes]]]:
+    """Serialize (binary) a pymodaq object, if it is not JSON compatible."""
+    if isinstance(pymodaq_object, get_args(JSON_TYPES)):
+        return pymodaq_object, None
+    elif isinstance(pymodaq_object, get_args(SERIALIZABLE)):
+        return None, [Serializer(pymodaq_object).to_bytes()]
+    else:
+        raise ValueError(
+            f"{pymodaq_object} of type '{type(pymodaq_object).__name__}' is neither "
+            "JSON serializable, nor via PyMoDAQ."
+        )
+
+
+def binary_serialization_to_kwargs(
+    pymodaq_object: Union[SERIALIZABLE, Any], data_key: str = "data"
+) -> dict[str, Any]:
+    """Create a dictionary of data parameters and of additional payload to send."""
+    d, b = binary_serialization(pymodaq_object=pymodaq_object)
+    return {data_key: d, "additional_payload": b}
 
 
 def run_coordinator():


### PR DESCRIPTION
This PR switches the LECO communication from base64 to pure binary transport.
However, that it works requires https://github.com/pymeasure/pyleco/pull/82 to be merged and published (pyproject.toml is already adjusted)

Closes #308 

