### PR TITLE
Sliders now accept suffix and SIprefix if given in opts

### DIFF
--- a/src/pymodaq/examples/parameter_ex.py
+++ b/src/pymodaq/examples/parameter_ex.py
@@ -25,12 +25,15 @@ class ParameterEx(ParameterManager):
             {'title': 'Linear Slide float', 'name': 'linearslidefloat', 'type': 'slide', 'value': 50, 'default': 50,
              'min': 0,
              'max': 123, 'subtype': 'linear'},
-            {'title': 'Linear int Slide', 'name': 'linearslideint', 'type': 'slide', 'value': 50, 'default': 50,
+            {'title': 'Linear int Slide', 'name': 'linearslideint', 'type': 'slide', 'value': 50, 'default': 50, 'step':1,
              'min': 0,
              'max': 123, 'subtype': 'linear', 'int': True},
+            {'title': 'Linear Slide with suffix', 'name': 'linearslidewithsuffixandsiPrefix', 'type': 'slide', 'value': 50, 'default': 50,
+             'min': 0,
+             'max': 1e6, 'subtype': 'linear','suffix':'V','siPrefix':True},             
             {'title': 'Log Slide float', 'name': 'logslidefloat', 'type': 'slide', 'value': 50, 'default': 50,
              'min': 1e-5,
-             'max': 1e5, 'subtype': 'log'},
+             'max': 1e5, 'subtype': 'log','suffix':'V','siPrefix':True},
         ]},
 
         {'title': 'Booleans:', 'name': 'booleans', 'type': 'group', 'children': [

--- a/src/pymodaq/utils/parameter/pymodaq_ptypes/slide.py
+++ b/src/pymodaq/utils/parameter/pymodaq_ptypes/slide.py
@@ -50,6 +50,8 @@ class SliderSpinBox(QtWidgets.QWidget):
                 value = kwargs['bounds'][0]
             else:
                 value = 1
+        if value is None:
+            value = 0                
         self.spinbox = SpinBox(parent=None, value=value, **kwargs)
 
         self.vlayout.addWidget(self.slider)
@@ -60,13 +62,21 @@ class SliderSpinBox(QtWidgets.QWidget):
 
         self.slider.valueChanged.connect(self.update_spinbox)
         self.spinbox.valueChanged.connect(self.update_slide)
+        self.spinbox.valueChanged.emit(value) #Initializing slider from value
+
+    def get_bounds(self,):
+        """ Convert bounds from opts into list of floats
+
+        Returns:
+            list of floats
+        """
+        return [float(bound) for bound in self.opts['bounds']]
 
     def update_spinbox(self, val):
         """
         val is a percentage [0-100] used in order to set the spinbox value between its min and max
         """
-        min_val = float(self.opts['bounds'][0])
-        max_val = float(self.opts['bounds'][1])
+        min_val,max_val = self.get_bounds()
         if self.subtype == 'log':
             val_out = scroll_log(val, min_val, max_val)
         else:
@@ -85,9 +95,7 @@ class SliderSpinBox(QtWidgets.QWidget):
         """
         val is the spinbox value between its min and max
         """
-        min_val = float(self.opts['bounds'][0])
-        max_val = float(self.opts['bounds'][1])
-
+        min_val,max_val = self.get_bounds()
         try:
             self.slider.valueChanged.disconnect(self.update_spinbox)
             self.spinbox.valueChanged.disconnect(self.update_slide)
@@ -106,7 +114,7 @@ class SliderSpinBox(QtWidgets.QWidget):
 
     def value(self):
         return self.spinbox.value()
-
+    
 
 class SliderParameterItem(WidgetParameterItem):
     """Registered parameter type which displays a QLineEdit"""
@@ -115,13 +123,18 @@ class SliderParameterItem(WidgetParameterItem):
         opts = self.param.opts
         defs = {
             'value': 0, 'min': None, 'max': None,
-            'step': 1.0, 'dec': False,
+             'dec': False,
             'siPrefix': False, 'suffix': '', 'decimals': 12,
             'int': False
         }
+        #Update relevant opts
+        for k in defs:
+            if k in opts:
+                defs[k] = opts[k]    
+        #Additional changes according to user syntax
         if 'subtype' not in opts:
             opts['subtype'] = 'linear'
-        defs['bounds'] = [0., self.param.value()]  # max value set to default value when no max given
+        defs['bounds'] = [0., float(self.param.value() or 1)]  # max value set to default value when no max given or 1 if no default
         if 'limits' not in opts:
             if 'min' in opts:
                 defs['bounds'][0] = opts['min']
@@ -129,13 +142,21 @@ class SliderParameterItem(WidgetParameterItem):
                 defs['bounds'][1] = opts['max']
         else:
             defs['bounds'] = opts['limits']
-
-        if 'int' in opts:
-            defs['int'] = opts['int']
-
-        w = SliderSpinBox(subtype=opts['subtype'], bounds=defs['bounds'], value=defs['value'], int=defs['int'])
+                                
+        w = SliderSpinBox(subtype=opts['subtype'],**defs)
         self.setSizeHint(1, QtCore.QSize(50, 50))
         return w
+
+    def updateDisplayLabel(self, value=None):
+        # Reimplement display label to show the spinbox text with its suffix
+        if value is None:
+            value = self.widget.spinbox.text()
+        super().updateDisplayLabel(value)    
+
+    def showEditor(self):
+        # Reimplement show Editor to specifically select the numbers
+        super().showEditor()
+        self.widget.spinbox.setFocus()     
 
 
 class SliderParameter(SimpleParameter):


### PR DESCRIPTION
**Description**
Slider parameters can now display units with SIprefix
The syntax follows the NumericParameterItem format from pyqtgraph.

**Usage**
params =[ {'title': 'Linear Slide with suffix', 'name': 'linearslidewithsuffixandsiPrefix', 'type': 'slide', 'value': 50, 'default': 50, 'min': 0, 'max': 1e6, 'subtype': 'linear','suffix':'V','siPrefix':True}, ]

**Example**
Exemple of usage given in parameter_ex.py


https://github.com/PyMoDAQ/PyMoDAQ/assets/51032965/f94884d3-21e3-40e4-9528-8b29a769d52c

