### PR TITLE
Added confirmation overwrite if FileExists

### DIFF
--- a/src/pymodaq/utils/managers/preset_manager.py
+++ b/src/pymodaq/utils/managers/preset_manager.py
@@ -176,6 +176,7 @@ class PresetManager:
                                             os.path.join(path, filename_without_extension),
                                             overwrite=False)
             except FileExistsError as currenterror:
+                logger.warning(str(currenterror)+"File " + filename_without_extension + ".xml exists")
                 confirmation = QtWidgets.QMessageBox()
                 confirmation.setWindowTitle('Overwrite confirmation')
                 confirmation.setText("File exist do you want to overwrite it")
@@ -185,6 +186,7 @@ class PresetManager:
                 if result == QtWidgets.QMessageBox.Yes:
                     ioxml.parameter_to_xml_file(self.preset_params,
                                                 os.path.join(path, filename_without_extension))
+                    logger.warning("File " + filename_without_extension + ".xml overwriten at user request")
                 else:
                     logger.warning("File "+filename_without_extension+".xml wasn't saved at user request")
                     # emit status signal to dashboard to write : did not saved ?

--- a/src/pymodaq/utils/managers/preset_manager.py
+++ b/src/pymodaq/utils/managers/preset_manager.py
@@ -7,6 +7,7 @@ import sys
 import os
 from pymodaq.utils.parameter import ParameterTree, Parameter
 from pymodaq.utils.parameter import ioxml
+from pymodaq.utils.messenger import dialog as dialogbox
 from pymodaq.utils import daq_utils as utils
 from pathlib import Path
 import pymodaq.utils.managers.preset_manager_utils  # to register move and det types
@@ -177,19 +178,15 @@ class PresetManager:
                                             overwrite=False)
             except FileExistsError as currenterror:
                 logger.warning(str(currenterror)+"File " + filename_without_extension + ".xml exists")
-                confirmation = QtWidgets.QMessageBox()
-                confirmation.setWindowTitle('Overwrite confirmation')
-                confirmation.setText("File exist do you want to overwrite it")
-                confirmation.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.Cancel)
-                confirmation.setDefaultButton(QtWidgets.QMessageBox.Cancel)
-                result = confirmation.exec()
-                if result == QtWidgets.QMessageBox.Yes:
+                userchoice = dialogbox(title='Overwrite confirmation',
+                                       message="File exist do you want to overwrite it ?")
+                if userchoice == 1:
                     ioxml.parameter_to_xml_file(self.preset_params,
                                                 os.path.join(path, filename_without_extension))
                     logger.warning("File " + filename_without_extension + ".xml overwriten at user request")
                 else:
                     logger.warning("File "+filename_without_extension+".xml wasn't saved at user request")
-                    # emit status signal to dashboard to write : did not saved ?
+                    # emit status signal to dashboard to write : did not save ?
                 pass
 
             if not self.pid_type:

--- a/src/pymodaq/utils/managers/preset_manager.py
+++ b/src/pymodaq/utils/managers/preset_manager.py
@@ -177,15 +177,16 @@ class PresetManager:
                                             os.path.join(path, filename_without_extension),
                                             overwrite=False)
             except FileExistsError as currenterror:
-                logger.warning(str(currenterror)+"File " + filename_without_extension + ".xml exists")
-                userchoice = dialogbox(title='Overwrite confirmation',
-                                       message="File exist do you want to overwrite it ?")
-                if userchoice == 1:
+                # logger.warning(str(currenterror)+"File " + filename_without_extension + ".xml exists")
+                logger.warning(f"{currenterror} File {filename_without_extension}.xml exists")
+                user_agreed = dialogbox(title='Overwrite confirmation',
+                                        message="File exist do you want to overwrite it ?")
+                if user_agreed:
                     ioxml.parameter_to_xml_file(self.preset_params,
                                                 os.path.join(path, filename_without_extension))
-                    logger.warning("File " + filename_without_extension + ".xml overwriten at user request")
+                    logger.warning(f"File {filename_without_extension}.xml overwriten at user request")
                 else:
-                    logger.warning("File "+filename_without_extension+".xml wasn't saved at user request")
+                    logger.warning(f"File {filename_without_extension}.xml wasn't saved at user request")
                     # emit status signal to dashboard to write : did not save ?
                 pass
 

--- a/src/pymodaq/utils/managers/preset_manager.py
+++ b/src/pymodaq/utils/managers/preset_manager.py
@@ -169,8 +169,26 @@ class PresetManager:
             # save managers parameters in a xml file
             # start = os.path.split(os.path.split(os.path.realpath(__file__))[0])[0]
             # start = os.path.join("..",'daq_scan')
-            ioxml.parameter_to_xml_file(
-                self.preset_params, os.path.join(path, self.preset_params.child('filename').value()))
+            filename_without_extension = self.preset_params.child('filename').value()
+
+            try:
+                ioxml.parameter_to_xml_file(self.preset_params,
+                                            os.path.join(path, filename_without_extension),
+                                            overwrite=False)
+            except FileExistsError as currenterror:
+                confirmation = QtWidgets.QMessageBox()
+                confirmation.setWindowTitle('Overwrite confirmation')
+                confirmation.setText("File exist do you want to overwrite it")
+                confirmation.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.Cancel)
+                confirmation.setDefaultButton(QtWidgets.QMessageBox.Cancel)
+                result = confirmation.exec()
+                if result == QtWidgets.QMessageBox.Yes:
+                    ioxml.parameter_to_xml_file(self.preset_params,
+                                                os.path.join(path, filename_without_extension))
+                else:
+                    logger.warning("File "+filename_without_extension+".xml wasn't saved at user request")
+                    # emit status signal to dashboard to write : did not saved ?
+                pass
 
             if not self.pid_type:
                 # check if overshoot configuration and layout configuration with same name exists => delete them if yes

--- a/src/pymodaq/utils/parameter/ioxml.py
+++ b/src/pymodaq/utils/parameter/ioxml.py
@@ -1,5 +1,6 @@
 from typing import Union
 from pathlib import Path
+import os.path
 
 import importlib
 import json
@@ -324,7 +325,7 @@ def parameter_to_xml_string(param):
     return ET.tostring(xml_elt)
 
 
-def parameter_to_xml_file(param, filename: Union[str, Path]):
+def parameter_to_xml_file(param, filename: Union[str, Path], overwrite=True):
     """
         Convert the given parameter to XML element and update the given XML file.
 
@@ -348,7 +349,10 @@ def parameter_to_xml_file(param, filename: Union[str, Path]):
     fname = parent.joinpath(filename + ".xml")  # forcing the right extension on the filename
     xml_elt = walk_parameters_to_xml(param=param)
     tree = ET.ElementTree(xml_elt)
+    if not overwrite and os.path.isfile(str(fname)):
+        raise FileExistsError
     tree.write(str(fname))
+
 
 
 def walk_xml_to_parameter(params=[], XML_elt=None):

--- a/src/pymodaq/utils/parameter/ioxml.py
+++ b/src/pymodaq/utils/parameter/ioxml.py
@@ -333,6 +333,7 @@ def parameter_to_xml_file(param, filename: Union[str, Path], overwrite=True):
         **Parameters**    **Type**                          **Description**
         *param*           instance of pyqtgraph parameter   the parameter to be added
         *filename*        string                            the filename of the XML file
+        *overwrite*       boolean                           raise Error is False and file exists
         =============== ================================= ================================
 
         See Also

--- a/src/pymodaq/utils/parameter/ioxml.py
+++ b/src/pymodaq/utils/parameter/ioxml.py
@@ -1,6 +1,5 @@
 from typing import Union
 from pathlib import Path
-import os.path
 
 import importlib
 import json
@@ -350,7 +349,7 @@ def parameter_to_xml_file(param, filename: Union[str, Path], overwrite=True):
     fname = parent.joinpath(filename + ".xml")  # forcing the right extension on the filename
     xml_elt = walk_parameters_to_xml(param=param)
     tree = ET.ElementTree(xml_elt)
-    if not overwrite and os.path.isfile(str(fname)):
+    if not overwrite and fname.exists() and fname.is_file():
         raise FileExistsError
     tree.write(str(fname))
 

--- a/src/pymodaq/utils/parameter/ioxml.py
+++ b/src/pymodaq/utils/parameter/ioxml.py
@@ -355,7 +355,6 @@ def parameter_to_xml_file(param, filename: Union[str, Path], overwrite=True):
     tree.write(str(fname))
 
 
-
 def walk_xml_to_parameter(params=[], XML_elt=None):
     """ To convert an XML element (and children) to list of dict enabling creation of parameter object.
 

--- a/tests/utils/managers/preset_manager_test.py
+++ b/tests/utils/managers/preset_manager_test.py
@@ -1,0 +1,56 @@
+1# -*- coding: utf-8 -*-
+"""
+Created the 07/11/2023
+
+@author: Sebastien Weber
+"""
+from collections import OrderedDict
+import pytest
+from qtpy import QtWidgets
+
+# from pymodaq.examples.parameter_ex import ParameterEx, Parameter
+# from pymodaq.utils.parameter.utils import (iter_children_params, compareParameters,
+#                                            compareStructureParameter,
+#                                            compareValuesParameter)
+# from pymodaq.utils.gui_utils.widgets.table import TableModel
+# from pymodaq.utils.managers.parameter_manager import ParameterManager
+# from pymodaq.utils.managers.preset_manager import PresetManager
+import pymodaq.utils.managers.preset_manager as psm
+import pathlib
+import pymodaq.resources as rsc
+
+import os.path as ospath
+from unittest import TestCase
+from pymodaq.utils.parameter.ioxml import parameter_to_xml_file
+
+
+@pytest.fixture
+def ini_qt_widget(init_qt):
+    qtbot = init_qt
+    widget = QtWidgets.QWidget()
+    qtbot.addWidget(widget)
+    widget.show()
+    yield qtbot, widget
+    widget.close()
+
+
+# subtpe Testcase ?
+class TestPresetManager(psm.PresetManager):
+    pass
+
+
+def test_preset_manager(qtbot):
+    """
+    Testing the validity of the PresetManager object initialization.
+    Qt not tested
+    :param qtbot:
+    :return:
+    """
+    preset_manager = TestPresetManager(False)
+
+    assert psm.pid_path.is_dir()
+    assert psm.preset_path.is_dir()
+    assert psm.overshoot_path.is_dir()
+    assert psm.layout_path.is_dir()
+    # test yes/modify/cancel ?
+    assert preset_manager


### PR DESCRIPTION
L'implémentation est dans le PresetManager mais il n'y pas de méthode dédiée, c'est ajouté dans le if res == dialog.Accepted:

Modifications que ioxml.py :
La sauvegarde étant directement gérer dans ioxml, j'ai rajouté Overwrite=True dans les paramètres de ioxml.parameter_to_xml_file pour garder une compatibilité si il y a des appels sans spécifier celui-ci.
J'ai aussi rajouté l'import de os.path pour la methode isfile.

Modification de PresetManager:
J'utilise un try: ioxml.parameter_to_xml_file(..., overwrite=False) except pour gérer un retour d'information sur l'existence du fichier.
En cas de FileExistsError, on fait une boite de dialogue, on récupère le choix et on écrase ou log que le user veut pas puis on continue l'exécution.

A noter que sauvegarder un nouveau preset ou modifier un preset arrive dans la même méthode, c'est seulement un prechargement du preset.
Donc on a l'overwrite warning qu'on ait fait new ou modif.