### PR TITLE
Feature/daq move sizing

### DIFF
--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -479,6 +479,9 @@ class DAQ_Move(ParameterControlModule):
         elif status.command == 'stop':
             self.stop_motion()
 
+        elif status.command == 'units':
+            self.units = status.attribute
+
     def get_actuator_value(self):
         """Get the current actuator value via the "get_actuator_value" command send to the hardware
 
@@ -551,7 +554,14 @@ class DAQ_Move(ParameterControlModule):
 
     @property
     def units(self):
+        """Get/Set the units for the controller"""
         return self.settings['move_settings', 'units']
+
+    @units.setter
+    def units(self, unit: str):
+        self.settings.child('move_settings', 'units').setValue(unit)
+        if self.ui is not None and config('actuator', 'display_units'):
+            self.ui.set_unit_as_suffix(unit)
 
     def update_settings(self):
 

--- a/src/pymodaq/control_modules/daq_move_ui.py
+++ b/src/pymodaq/control_modules/daq_move_ui.py
@@ -211,7 +211,7 @@ class DAQ_Move_UI(ControlModuleUI):
         self.main_ui.layout().addWidget(LabelWithFont('Current value:'), 4, 0)
         self.move_done_led = QLED(readonly=True)
         self.main_ui.layout().addWidget(self.move_done_led, 4, 1)
-        self.current_value_sb = QSpinBox_ro(font_size=30, min_height=37,
+        self.current_value_sb = QSpinBox_ro(font_size=20, min_height=27,
                                             siPrefix=config('actuator', 'siprefix'),
                                             )
         self.main_ui.layout().addWidget(self.current_value_sb, 5, 0, 1, 2)
@@ -249,6 +249,14 @@ class DAQ_Move_UI(ControlModuleUI):
         self.statusbar = QtWidgets.QStatusBar()
         self.statusbar.setMaximumHeight(30)
         self.parent.layout().addWidget(self.statusbar)
+
+    def set_unit_as_suffix(self, unit: str):
+        """Will append the actuator units in the value display"""
+        self.current_value_sb.setOpts(suffix=unit)
+        self.abs_value_sb_bis.setOpts(suffix=unit)
+        self.abs_value_sb.setOpts(suffix=unit)
+        self.abs_value_sb_2.setOpts(suffix=unit)
+        self.rel_value_sb.setOpts(suffix=unit)
 
     def setup_actions(self):
         self.add_action('move_abs', 'Move Abs', 'go_to_1', "Move to the set absolute value",

--- a/src/pymodaq/control_modules/daq_move_ui.py
+++ b/src/pymodaq/control_modules/daq_move_ui.py
@@ -212,6 +212,7 @@ class DAQ_Move_UI(ControlModuleUI):
         self.move_done_led = QLED(readonly=True)
         self.main_ui.layout().addWidget(self.move_done_led, 4, 1)
         self.current_value_sb = QSpinBox_ro(font_size=30, min_height=37,
+                                            siPrefix=config('actuator', 'siprefix'),
                                             )
         self.main_ui.layout().addWidget(self.current_value_sb, 5, 0, 1, 2)
 

--- a/src/pymodaq/control_modules/daq_move_ui.py
+++ b/src/pymodaq/control_modules/daq_move_ui.py
@@ -9,7 +9,7 @@ from typing import List
 import sys
 
 from qtpy import QtWidgets
-from qtpy.QtCore import Signal
+from qtpy.QtCore import Signal, Qt
 from qtpy.QtWidgets import QHBoxLayout, QVBoxLayout, QGridLayout, QWidget, QToolBar, QComboBox
 
 from pymodaq.utils.daq_utils import ThreadCommand
@@ -19,6 +19,10 @@ from pymodaq.control_modules.utils import ControlModuleUI
 from pymodaq.utils.gui_utils import DockArea
 from pymodaq.utils.plotting.data_viewers.viewer import ViewerDispatcher
 from pymodaq.utils.data import DataWithAxes, DataToExport, DataActuator
+
+from pymodaq.utils.config import Config
+
+config = Config()
 
 
 class DAQ_Move_UI(ControlModuleUI):
@@ -151,11 +155,13 @@ class DAQ_Move_UI(ControlModuleUI):
 
     def setup_docks(self):
         self.parent.setLayout(QVBoxLayout())
-        self.parent.layout().setSizeConstraint(QHBoxLayout.SetFixedSize)
+        #self.parent.layout().setSizeConstraint(QHBoxLayout.SetFixedSize)
         self.parent.layout().setContentsMargins(2, 2, 2, 2)
 
         widget = QWidget()
         widget.setLayout(QHBoxLayout())
+        splitter_hor = QtWidgets.QSplitter(Qt.Orientation.Horizontal)
+        widget.layout().addWidget(splitter_hor)
         self.parent.layout().addWidget(widget)
 
         self.main_ui = QWidget()
@@ -174,9 +180,9 @@ class DAQ_Move_UI(ControlModuleUI):
         left_widget.layout().addWidget(self.control_ui)
         left_widget.layout().setContentsMargins(0, 0, 0, 0)
         left_widget.layout().addStretch()
-        widget.layout().addWidget(left_widget)
-        widget.layout().addWidget(self.settings_ui)
-        widget.layout().addStretch()
+        splitter_hor.addWidget(left_widget)
+        splitter_hor.addWidget(self.settings_ui)
+        #widget.layout().addStretch()
 
         # populate the main ui
         self.move_toolbar = QToolBar()
@@ -205,7 +211,8 @@ class DAQ_Move_UI(ControlModuleUI):
         self.main_ui.layout().addWidget(LabelWithFont('Current value:'), 4, 0)
         self.move_done_led = QLED(readonly=True)
         self.main_ui.layout().addWidget(self.move_done_led, 4, 1)
-        self.current_value_sb = QSpinBox_ro(font_size=30, min_height=35)
+        self.current_value_sb = QSpinBox_ro(font_size=30, min_height=37,
+                                            )
         self.main_ui.layout().addWidget(self.current_value_sb, 5, 0, 1, 2)
 
         # populate the control ui

--- a/src/pymodaq/control_modules/move_utility_classes.py
+++ b/src/pymodaq/control_modules/move_utility_classes.py
@@ -380,6 +380,7 @@ class DAQ_Move_base(QObject):
         self._controller_units = units
         try:
             self.settings.child('units').setValue(units)
+            self.emit_status(ThreadCommand('units', units))
         except Exception:
             pass
 

--- a/src/pymodaq/resources/config_template.toml
+++ b/src/pymodaq/resources/config_template.toml
@@ -75,6 +75,7 @@ default_preset_for_pid = "beam_steering_mock"
     refresh_timeout_ms = 500  # ms
     timeout = 10000  # default duration in ms to wait for data to be acquirred
     siprefix = true  # tell if printing of current value use a SI prefix or not (µ, m, k, M...)
+    display_units = true # display units in the SpinBoxes
 
 [scan]
     scan_in_thread = true

--- a/src/pymodaq/resources/config_template.toml
+++ b/src/pymodaq/resources/config_template.toml
@@ -74,6 +74,7 @@ default_preset_for_pid = "beam_steering_mock"
     polling_timeout_s = 20  # s
     refresh_timeout_ms = 500  # ms
     timeout = 10000  # default duration in ms to wait for data to be acquirred
+    siprefix = true  # tell if printing of current value use a SI prefix or not (µ, m, k, M...)
 
 [scan]
     scan_in_thread = true

--- a/src/pymodaq/utils/gui_utils/widgets/spinbox.py
+++ b/src/pymodaq/utils/gui_utils/widgets/spinbox.py
@@ -19,6 +19,6 @@ class SpinBox(SpinBox):
 class QSpinBox_ro(SpinBox):
     def __init__(self, *args, readonly=True, **kwargs):
         super().__init__(*args, **kwargs)
-        self.setMaximum(100000)
+        #self.setMaximum(100000)
         self.setReadOnly(readonly)
         self.setButtonSymbols(QtWidgets.QAbstractSpinBox.NoButtons)


### PR DESCRIPTION
Better handling of the DAQ_Move size/resizing in particular when opening the settings tree

Added SI notation for the displayed values
Added units as suffix in the displayed values

the last two can be deactivated in the configuration file

Closes [# actuator scroll bar issue](https://github.com/PyMoDAQ/pymodaq_plugins_template/issues/11)