### PR TITLE
Removed unused Slot decorator on DashBoard.stop_moves()

### DIFF
--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -1210,7 +1210,6 @@ class DashBoard(QObject):
                 QtWidgets.QApplication.processEvents()
             self.settings.child('detectors', name).setValue(det.initialized_state)
 
-    Slot(bool)
     def stop_moves(self, overshoot):
         """
             Foreach module of the move module object list, stop motion.


### PR DESCRIPTION
Minor fix more like a typo than a bug.
No real change to test or implement.