### PR TITLE
Bugfix/release hdf5 file ref

### DIFF
--- a/src/pymodaq/extensions/daq_scan.py
+++ b/src/pymodaq/extensions/daq_scan.py
@@ -43,7 +43,6 @@ from pymodaq.utils.h5modules.saving import H5Saver
 from pymodaq.utils.h5modules import module_saving, data_saving
 from pymodaq.utils.data import DataToExport, DataActuator
 
-import fcntl
 
 if TYPE_CHECKING:
     from pymodaq.dashboard import DashBoard
@@ -506,7 +505,7 @@ class DAQScan(QObject, ParameterManager):
             self._metada_dataset_set = False
             self.module_and_data_saver.forget_h5()
             self.h5saver.close_file()
-            fcntl.fcntl(self.h5saver.h5_file, fcntl.F_UNLCK)
+
         self.h5saver.init_file(update_h5=new_file)
         self.module_and_data_saver.h5saver = self.h5saver
         res = self.update_file_settings()

--- a/src/pymodaq/extensions/daq_scan.py
+++ b/src/pymodaq/extensions/daq_scan.py
@@ -515,7 +515,7 @@ class DAQScan(QObject, ParameterManager):
     @property
     def h5saver(self):
         if self._h5saver is None:
-            self._h5saver = H5Saver(backend='tables')
+            self._h5saver = H5Saver(backend=config('general', 'hdf5_backend'))
         if self._h5saver.h5_file is None:
             self._h5saver.init_file(update_h5=True)
             #self._h5saver.settings.child('current_h5_file').setValue(self._h5saver.filename)

--- a/src/pymodaq/extensions/h5browser.py
+++ b/src/pymodaq/extensions/h5browser.py
@@ -1,11 +1,12 @@
 import argparse
 from pathlib import Path
 import sys
-
+import os
 from qtpy import QtWidgets
-
+os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 from pymodaq.utils.h5modules.browsing import H5Browser
 from pymodaq.utils.config import Config
+
 
 
 config = Config()

--- a/src/pymodaq/resources/config_template.toml
+++ b/src/pymodaq/resources/config_template.toml
@@ -32,6 +32,8 @@ debug_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 check_version = true  # automatically check version at startup (or not if False)
 message_status_persistence = 1000  # ms
 
+hdf5_backend = 'tables'  # could be among ['tables', 'h5py', 'h5pyd'], mostly tested with tables
+
 [user]
 name = "User name"  # default name used as author in the hdf5 saving files
 

--- a/src/pymodaq/utils/h5modules/browsing.py
+++ b/src/pymodaq/utils/h5modules/browsing.py
@@ -293,7 +293,7 @@ class H5Browser(QObject, ActionManager):
         if h5file is None:
             if h5file_path is None:
                 h5file_path = select_file(save=False, ext=['h5', 'hdf5'])
-            if h5file_path != '':
+            if Path(h5file_path).is_file():
                 if self.h5utils.isopen():
                     self.h5utils.close_file()
 

--- a/src/pymodaq/utils/h5modules/module_saving.py
+++ b/src/pymodaq/utils/h5modules/module_saving.py
@@ -304,6 +304,12 @@ class ScanSaver(ModuleSaver):
             if hasattr(module, 'module_and_data_saver'):
                 module.module_and_data_saver.h5saver = self.h5saver
 
+    def forget_h5(self):
+        for module in self._module.modules_manager.modules_all:
+            if hasattr(module, 'module_and_data_saver'):
+                module.module_and_data_saver.h5saver = None
+        self.h5saver.flush()
+
     def get_set_node(self, where: Union[Node, str] = None, new=False) -> GROUP:
         """Get the last group scan node
 


### PR DESCRIPTION
This pull request closes #187 

The implementation moved all instance of the underlying hdf5 file into the main thread preventing the OS to lock files. It was this mechanism that prevented the opening/moving/deleting of the file while the main process was still active even if a new file/dataset was created and the old one properly closed.

The current implementation allows external opening/moving/deletion at any time except when the scan is in process. Each time a scan is done, the file is properly closed allowing the actions on it. When a new scan is started the file is just reopened or another one is created if the previous one has been moved/deleted.

This should be properly tested before releasing it!!