### PR TITLE
5.0.x feature/pid setp actuators

### DIFF
--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -175,6 +175,20 @@ class DAQ_Move(ParameterControlModule):
         elif cmd.command == 'rel_value':
             self._relative_value = cmd.attribute
 
+    @property
+    def master(self) -> bool:
+        """ Get/Set programmaticaly the Master/Slave status of an actuator"""
+        if self.initialized_state:
+            return self.settings['move_settings', 'multiaxes', 'multi_status'] == 'Master'
+        else:
+            return True
+
+    @master.setter
+    def master(self, is_master: bool):
+        if self.initialized_state:
+            self.settings.child('move_settings', 'multiaxes', 'multi_status').setValue(
+                'Master' if is_master else 'Slave')
+
     def append_data(self, dte: Optional[DataToExport] = None, where: Union[Node, str, None] = None):
         """Appends current DataToExport to an ActuatorEnlargeableSaver
 
@@ -362,8 +376,9 @@ class DAQ_Move(ParameterControlModule):
                 self._hardware_thread.hardware = hardware
                 self._hardware_thread.start()
                 self.command_hardware.emit(
-                    ThreadCommand(command="ini_stage", attribute=[self.settings.child('move_settings').saveState(),
-                                                                  self.controller]))
+                    ThreadCommand(command="ini_stage", attribute=[
+                        self.settings.child('move_settings').saveState(),
+                        self.controller]))
             except Exception as e:
                 self.logger.exception(str(e))
 
@@ -548,6 +563,11 @@ class DAQ_Move(ParameterControlModule):
                 self.update_settings()
         else:
             raise ActuatorError(f'{act_type} is an invalid actuator, should be within {ACTUATOR_TYPES}')
+
+    @property
+    def actuators(self) -> List[str]:
+        """ Get the list of possible actuators"""
+        return ACTUATOR_TYPES
 
     def update_plugin_config(self):
         parent_module = utils.find_dict_in_list_from_key_val(DAQ_Move_Actuators, 'name', self.actuator)

--- a/src/pymodaq/extensions/pid/__init__.py
+++ b/src/pymodaq/extensions/pid/__init__.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from pymodaq_utils.logger import set_logger, get_module_name
 
-
 logger = set_logger('move_plugins', add_to_console=False)
 
 

--- a/src/pymodaq/extensions/pid/actuator_controller.py
+++ b/src/pymodaq/extensions/pid/actuator_controller.py
@@ -1,0 +1,13 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .pid_controller import DAQ_PID
+
+
+class PIDController:
+    """ Fake controller object for the DAQ_Move_PID"""
+
+    def __init__(self, daq_pid: 'DAQ_PID'):
+        self.curr_point = daq_pid.curr_points_signal
+        self.setpoint = daq_pid.setpoints_signal
+        self.emit_curr_points = daq_pid.emit_curr_points_sig

--- a/src/pymodaq/extensions/pid/pid_controller.py
+++ b/src/pymodaq/extensions/pid/pid_controller.py
@@ -1,5 +1,7 @@
 import time
 from functools import partial  # needed for the button to sync setpoint with currpoint
+from typing import Dict
+
 import numpy as np
 
 from qtpy import QtGui, QtWidgets
@@ -368,10 +370,10 @@ class DAQ_PID(CustomApp):
         for ind, sp in enumerate(self.setpoints_sb):
             sp.setValue(values[ind])
 
-    def setpoints_external(self, values_dict):
+    def setpoints_external(self, values_dict: Dict[str, DataActuator]):
         for key in values_dict:
             index = self.model_class.setpoints_names.index(key)
-            self.setpoints_sb[index].setValue(values_dict[key])
+            self.setpoints_sb[index].setValue(values_dict[key].value())
 
     @property
     def curr_points(self):

--- a/src/pymodaq/extensions/pid/utils.py
+++ b/src/pymodaq/extensions/pid/utils.py
@@ -27,6 +27,7 @@ DAQ_2DViewer_Det_types = get_plugins('daq_2Dviewer')
 DAQ_NDViewer_Det_types = get_plugins('daq_NDviewer')
 
 
+
 class DataToActuatorPID(DataToActuators):
 
     def __init__(self, *args, **kwargs):

--- a/src/pymodaq/extensions/pid/utils.py
+++ b/src/pymodaq/extensions/pid/utils.py
@@ -182,8 +182,8 @@ def get_models(model_name=None):
     """
     from pymodaq.extensions.pid.utils import PIDModelGeneric
     models_import = []
-    discovered_models = get_entrypoints(group='pymodaq.pid_models')
-    discovered_models = get_entrypoints(group='pymodaq.models')
+    discovered_models = list(get_entrypoints(group='pymodaq.pid_models'))
+    discovered_models.extend(list(get_entrypoints(group='pymodaq.models')))
     if len(discovered_models) > 0:
         for pkg in discovered_models:
             try:

--- a/tests/extensions/pid/actuator_controller_test.py
+++ b/tests/extensions/pid/actuator_controller_test.py
@@ -1,0 +1,9 @@
+from pymodaq.extensions.pid.actuator_controller import PIDController
+from pymodaq.extensions.pid.pid_controller import DAQ_PID
+
+
+def test_PIDController_attributes():
+
+    assert hasattr(DAQ_PID, 'curr_points_signal')
+    assert hasattr(DAQ_PID, 'setpoints_signal')
+    assert hasattr(DAQ_PID, 'emit_curr_points_sig')

--- a/tests/extensions/pid/actuator_controller_test.py
+++ b/tests/extensions/pid/actuator_controller_test.py
@@ -1,4 +1,4 @@
-from pymodaq.extensions.pid.actuator_controller import PIDController
+
 from pymodaq.extensions.pid.pid_controller import DAQ_PID
 
 


### PR DESCRIPTION
Make sure the PID extension is working with pymodaq v5 before modifying stuff like, declaration and init of DAQ_Move_PID from within the extension in order to generalise the use of these kind of fake control modules (here actuators) to be able to use functionnalities of extensions within other extensions!