### PR TITLE
extensions emiiting DataActuator without units

### DIFF
--- a/src/pymodaq/__init__.py
+++ b/src/pymodaq/__init__.py
@@ -51,6 +51,7 @@ try:
     ureg.default_format = '~'
     Q_ = ureg.Quantity
     Unit = ureg.Unit
+    ureg.define('whatever = 1  = wr')  # defining whatever as a dimensionless quantity
     logger.info('')
     logger.info('')
 

--- a/tests/control_modules/daq_move_test.py
+++ b/tests/control_modules/daq_move_test.py
@@ -83,3 +83,8 @@ class TestDAQMove:
 
         daq_move.quit_fun()
         QtWidgets.QApplication.processEvents() #make sure to properly terminate all the threads!
+
+    def test_axis_management(self, ini_daq_move_ui):
+        daq_move, qtbot, widget = ini_daq_move_ui
+        daq_move.actuator = 'Mock'
+        pass

--- a/tests/control_modules/move_utility_test.py
+++ b/tests/control_modules/move_utility_test.py
@@ -5,3 +5,13 @@ Created the 31/08/2023
 @author: Sebastien Weber
 """
 
+from pymodaq.control_modules.move_utility_classes import check_units
+from pymodaq.utils.data import DataActuator
+
+
+def test_check_units():
+
+    dwa = DataActuator('myact', data=24., units='km')
+
+    assert check_units(dwa, 'm') == dwa
+


### PR DESCRIPTION
extensions so far are emitting DataActuators without units related to their particular DAQ_Move

added a handling mechanism for this

at the end the extensions should handle those units