### PR TITLE
Add updater.yml for checking for GitHub actions updates

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions Version Updater
+
+# Controls when the action will run.
+on:
+  schedule:
+    # Automatically run at 00:00 on day-of-month 5.
+    - cron:  '0 0 5 * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # [Required] Access token with `workflow` scope.
+          token: ${{ secrets.WORKFLOW_SECRET }}
+
+      - name: Run GitHub Actions Version Updater
+        uses: saadmk11/github-actions-version-updater@v0.8.1
+        with:
+          # [Required] Access token with `workflow` scope.
+          token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
First added in [pymodaq_plugins_newport](https://github.com/PyMoDAQ/pymodaq_plugins_newport.git) (see related [pull request](https://github.com/PyMoDAQ/pymodaq_plugins_newport/pull/10)).

This updater checks every 5th of the month if any GitHub actions updates are available. It creates a pull request if so. The secret variable `WORKFLOW_SECRET` needs to be added with the scope **workflow** enabled.

I tried to add the updater.yml file on other repositories but couldn't fork pymodaq_utils, pymodaq_data and pymodaq_gui as they are already forks of the [PyMoDAQ](https://github.com/PyMoDAQ/PyMoDAQ.git) repository. Didn't find a workaround yet except having multiple GitHub accounts or teams, not very convenient I think.