### PR TITLE
add specific condition for displaying correct units

### DIFF
--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -595,16 +595,33 @@ class DAQ_Move(ParameterControlModule):
     def units(self, unit: str):
         self.settings.child('move_settings', 'units').setValue(unit)
         if self.ui is not None and config('actuator', 'display_units'):
-            if '°' in unit or 'degree' in unit:
-                # special cas as pint base unit for angles are radians
-                self.ui.set_unit_as_suffix('°')
-            elif 'W' in unit or 'watt' in unit:
-                self.ui.set_unit_as_suffix('W')
-            else:
-                # if the controller units are in mm the displayed unit will be m
-                # because m is the base unit
-                # then the user could ask for mm, km, µm...
-                self.ui.set_unit_as_suffix(str(Q_(1, unit).to_base_units().units))
+            self.ui.set_unit_as_suffix(self.get_unit_to_display(unit))
+
+    @staticmethod
+    def get_unit_to_display(unit: str) -> str:
+        """ Get the unit to be displayed in the UI
+
+        If the controller units are in mm the displayed unit will be m
+        because m is the base unit, then the user could ask for mm, km, µm...
+        only issue is when the usual displayed unit is not the base one, then add cases below
+
+        Parameters
+        ----------
+        unit: str
+
+        Returns
+        -------
+        str: the unit to be displayed on the ui
+        """
+        if ('°' in unit or 'degree' in unit) and not '°C' in unit:
+            # special cas as pint base unit for angles are radians
+            return '°'
+        elif 'W' in unit or 'watt' in unit:
+            return 'W'
+        elif '°C' in unit or 'Celsius' in unit:
+            return '°C'
+        else:
+            return str(Q_(1, unit).to_base_units().units)
 
     def update_settings(self):
 

--- a/src/pymodaq/control_modules/move_utility_classes.py
+++ b/src/pymodaq/control_modules/move_utility_classes.py
@@ -25,6 +25,7 @@ from pymodaq.utils.enums import BaseEnum, enum_checker
 from pymodaq.utils.tcp_ip.mysocket import Socket
 from pymodaq.utils.tcp_ip.serializer import DeSerializer, Serializer
 from pymodaq import Unit
+from pint.errors import OffsetUnitCalculusError
 
 if TYPE_CHECKING:
     from pymodaq.control_modules.daq_move import DAQ_Move_Hardware
@@ -438,7 +439,6 @@ class DAQ_Move_base(QObject):
             self.axis_unit = self.axis_unit
             self.settings.child('epsilon').setValue(self.epsilon)
 
-
     @property
     def axis_names(self) -> Union[List, Dict]:
         """ Get/Set the names of all axes controlled by this instrument plugin
@@ -728,6 +728,13 @@ class DAQ_Move_base(QObject):
             epsilon_calculated = abs(self._current_value.value() - self._target_value.value())
             logger.warning(f'Unit issue when calculating epsilon, units are not compatible between'
                            f'target and current values')
+        except OffsetUnitCalculusError as e:
+            if '°C' in self.axis_unit or 'celcius' in self.axis_unit.lower():
+                epsilon_calculated = (
+                        self._current_value.to_base_units() -
+                        self._target_value.to_base_units()).abs().value()
+            else:
+                raise e
 
         return (epsilon_calculated < self.epsilon) and self.user_condition_to_reach_target()
 

--- a/src/pymodaq/utils/data.py
+++ b/src/pymodaq/utils/data.py
@@ -648,6 +648,13 @@ class DataBase(DataLowLevel):
         """ Change immediately the units to whatever else. Use this with care!"""
         self._units = units
 
+    def to_base_units(self):
+        dwa = self.deepcopy()
+        data_quantities = [quantity.to_base_units() for quantity in self.quantities]
+        dwa.data = [quantity.magnitude for quantity in data_quantities]
+        dwa.force_units(str(data_quantities[0].units))
+        return dwa
+
     def units_as(self, units: str, inplace=True) -> 'DataBase':
         """ Set the object units to the new one (if possible)
 


### PR DESCRIPTION
daq_move has the get_unit_to_display method to set it right in the UI

particular issue when using °C as unit because it is not absolute (so diff/sum/mult between such data is tricky)

had to introduce the to_base_units in the data_base object