### PR TITLE
fixing build error for tables version depending on python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ dependencies = [
     "simple_pid",
     "toml",
     "qtconsole",
-    "tables<3.9",  # issue with some version of required package blosc2>=2.2.8
+    "tables>=3.10; python_version>=\"3.10\"",  # issue with some version of required package blosc2>=2.2.8
+    "tables<3.9; python_version<\"3.10\"",  # issue with some version of required package blosc2>=2.2.8
     "pyleco>0.3; python_version>=\"3.8\"",
     "bayesian-optimization<2.0.0",
 ]


### PR DESCRIPTION
After talking with an old user reinstalling pymodaq and new users from dijon university, i investigated a small installation issue :
* tables < 3.9 doesn't install with python 3.12
* tables 3.10 fixed the blosc error that imposed tables < 3.9 in pyproject.toml

so modified pyproject.toml accordingly to conditionnally install the right version of tables.