### PR TITLE
ParameterControlModule was initializing twice a Qobject 

### DIFF
--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -358,7 +358,6 @@ class ParameterControlModule(ParameterManager, ControlModule):
     listener_class: Type[ActorListener] = ActorListener
 
     def __init__(self, **kwargs):
-        QObject.__init__(self)
         ParameterManager.__init__(self, action_list=('save', 'update'))
         ControlModule.__init__(self)
 


### PR DESCRIPTION
ParameterControlModule was initialiting a QObject in itself and in ControlModule

This results in an error with Pyside6.

This patch removes this line