### PR TITLE
Fix daq_logger command

### DIFF
--- a/src/pymodaq/extensions/daq_logger/__init__.py
+++ b/src/pymodaq/extensions/daq_logger/__init__.py
@@ -1,0 +1,1 @@
+from .daq_logger import main


### PR DESCRIPTION
Closes #478

An equivalent way to fix it, would be to replace the import in the installed `daq_logger` executable itself:

```python
from pymodaq.extensions.daq_logger import main
```
with 

```python
from pymodaq.extensions.daq_logger.daq_logger import main
```