### PR TITLE
Parameter tree list fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "pymodaq_plugins_mock>=5.0.5",
     "pyqtgraph>=0.12",
     "python-dateutil",
-    "qdarkstyle",
     "qtpy",
     "scipy",
     "setuptools>=60",

--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -32,6 +32,7 @@ from pymodaq_data.h5modules.backends import Node
 
 from pymodaq_gui.parameter import ioxml, Parameter
 from pymodaq_gui.parameter import utils as putils
+from pymodaq_gui.utils import set_dark_palette
 
 from pymodaq.utils.h5modules import module_saving
 from pymodaq.control_modules.utils import ParameterControlModule
@@ -955,8 +956,7 @@ def main(init_qt=True):
     if init_qt:  # used for the test suite
         app = QtWidgets.QApplication(sys.argv)
         if config('style', 'darkstyle'):
-            import qdarkstyle
-            app.setStyleSheet(qdarkstyle.load_stylesheet(qdarkstyle.DarkPalette))
+            set_dark_palette(app)
 
     widget = QtWidgets.QWidget()
     prog = DAQ_Move(widget, title="test")

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -42,7 +42,7 @@ from pymodaq_gui.parameter import utils as putils
 from pymodaq.control_modules.viewer_utility_classes import params as daq_viewer_params
 from pymodaq_utils import utils
 from pymodaq_utils.warnings import deprecation_msg
-from pymodaq_gui.utils import DockArea, Dock
+from pymodaq_gui.utils import DockArea, Dock, set_dark_palette
 
 from pymodaq.utils.gui_utils import get_splash_sc
 from pymodaq.control_modules.daq_viewer_ui import DAQ_Viewer_UI
@@ -1461,8 +1461,7 @@ def main(init_qt=True, init_det=False):
     if init_qt:  # used for the test suite
         app = QtWidgets.QApplication(sys.argv)
         if config('style', 'darkstyle'):
-            import qdarkstyle
-            app.setStyleSheet(qdarkstyle.load_stylesheet(qdarkstyle.DarkPalette))
+            set_dark_palette(app)
 
     win = QtWidgets.QMainWindow()
     area = DockArea()

--- a/src/pymodaq/control_modules/move_utility_classes.py
+++ b/src/pymodaq/control_modules/move_utility_classes.py
@@ -19,6 +19,7 @@ from pymodaq_utils.logger import set_logger, get_module_name
 import pymodaq_gui.parameter.utils as putils
 from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.parameter import ioxml
+from pymodaq_gui.utils import set_dark_palette
 
 from pymodaq.utils.tcp_ip.tcp_server_client import TCPServer, tcp_parameters
 
@@ -213,8 +214,7 @@ def main(plugin_file, init=True, title='test'):
     from pathlib import Path
     app = QtWidgets.QApplication(sys.argv)
     if config('style', 'darkstyle'):
-        import qdarkstyle
-        app.setStyleSheet(qdarkstyle.load_stylesheet())
+        set_dark_palette(app)
 
     widget = QtWidgets.QWidget()
     prog = DAQ_Move(widget, title=title,)

--- a/src/pymodaq/control_modules/viewer_utility_classes.py
+++ b/src/pymodaq/control_modules/viewer_utility_classes.py
@@ -18,6 +18,8 @@ from pymodaq_utils.warnings import deprecation_msg
 from pymodaq_utils.serialize.mysocket import Socket
 from pymodaq_utils.serialize.serializer_legacy import DeSerializer, Serializer
 
+from pymodaq_gui.utils import set_dark_palette
+
 comon_parameters = [{'title': 'Controller Status:', 'name': 'controller_status', 'type': 'list', 'value': 'Master',
                      'limits': ['Master', 'Slave']}, ]
 
@@ -106,8 +108,7 @@ def main(plugin_file=None, init=True, title='Testing'):
 
     app = QtWidgets.QApplication(sys.argv)
     if config('style', 'darkstyle'):
-        import qdarkstyle
-        app.setStyleSheet(qdarkstyle.load_stylesheet())
+        set_dark_palette(app)
 
     win = QtWidgets.QMainWindow()
     area = DockArea()

--- a/src/pymodaq/extensions/bayesian/bayesian_optimisation.py
+++ b/src/pymodaq/extensions/bayesian/bayesian_optimisation.py
@@ -9,7 +9,7 @@ import numpy as np
 from pymodaq.utils.data import DataToExport, DataToActuators, DataCalculated, DataActuator
 from pymodaq.utils.managers.modules_manager import ModulesManager
 from pymodaq_utils import utils
-from pymodaq_utils import config as configmod
+from pymodaq_utils import config as config_mod
 from pymodaq_utils.enums import BaseEnum
 
 from pymodaq_gui.config import ConfigSaverLoader
@@ -17,7 +17,7 @@ from pymodaq_utils.logger import set_logger, get_module_name
 
 from pymodaq_gui.plotting.data_viewers.viewer0D import Viewer0D
 from pymodaq_gui.plotting.data_viewers.viewer import ViewerDispatcher, ViewersEnum
-from pymodaq_gui.utils import QLED
+from pymodaq_gui.utils import QLED, set_dark_palette
 from pymodaq_gui import utils as gutils
 from pymodaq_gui.parameter import utils as putils
 from pymodaq_gui.h5modules.saving import H5Saver
@@ -36,6 +36,7 @@ EXTENSION_NAME = 'BayesianOptimisation'
 CLASS_NAME = 'BayesianOptimisation'
 
 logger = set_logger(get_module_name(__file__))
+config = config_mod.Config()
 
 
 class DataNames(BaseEnum):
@@ -650,9 +651,8 @@ def main(init_qt=True):
 
     if init_qt:  # used for the test suite
         app = QtWidgets.QApplication(sys.argv)
-
-        import qdarkstyle
-        app.setStyleSheet(qdarkstyle.load_stylesheet())
+        if config('style', 'darkstyle'):
+            set_dark_palette(app)
 
     from pymodaq.dashboard import DashBoard
 


### PR DESCRIPTION
In combination with [PR from pymodaq_gui](https://github.com/PyMoDAQ/pymodaq_gui/pull/29), closes #416 by using a QPalette defined in `pymodaq_gui` for dark mode in `daq_move`, `daq_viewer`, and `bayesian_optimisation`. 

I also removed the references to `qdarkstyle` in `*_utility_classes`.

It needs a new release from pymodaq_gui with the PR in order to pass the tests in github actions.