### PR TITLE
Refresh repo list in github actions 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Create local pymodaq folder setup env (Linux)
         if: runner.os == 'Linux'
         run: |
+          sudo apt update
           sudo apt install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-cursor0 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 libegl1
           export QT_DEBUG_PLUGINS=1
           sudo mkdir -p /etc/.pymodaq


### PR DESCRIPTION
Tests were failing as dependencies couldn't be installed because of not up to date repositories.

Closes #480 