### PR TITLE
handle the actuator's close method

### DIFF
--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -713,7 +713,8 @@ class DAQ_Move_Hardware(QObject):
             Uninitialize the stage closing the hardware.
 
         """
-        self.hardware.close()
+        if self.hardware is not None:
+            self.hardware.close()
 
         return "Stage uninitialized"
 

--- a/src/pymodaq/control_modules/move_utility_classes.py
+++ b/src/pymodaq/control_modules/move_utility_classes.py
@@ -617,6 +617,10 @@ class DAQ_Move_base(QObject):
         else:
             raise NotImplementedError
 
+
+    def close(self):
+        raise NotImplementedError
+
     def move_abs(self, value: Union[float, DataActuator]):
         if hasattr(self, 'move_Abs'):
             deprecation_msg('move_Abs method in plugins is deprecated, use move_abs', 3)


### PR DESCRIPTION
check if the hardware is not None before calling a close add an abstract method raising an error if not implemented