### PR TITLE
Replaced QApplication calls with mkQApp 

### DIFF
--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -32,7 +32,7 @@ from pymodaq_data.h5modules.backends import Node
 
 from pymodaq_gui.parameter import ioxml, Parameter
 from pymodaq_gui.parameter import utils as putils
-from pymodaq_gui.utils import set_dark_palette
+from pymodaq_gui.utils.utils import mkQApp
 
 from pymodaq.utils.h5modules import module_saving
 from pymodaq.control_modules.utils import ParameterControlModule
@@ -954,9 +954,7 @@ class DAQ_Move_Hardware(QObject):
 
 def main(init_qt=True):
     if init_qt:  # used for the test suite
-        app = QtWidgets.QApplication(sys.argv)
-        if config('style', 'darkstyle'):
-            set_dark_palette(app)
+        app = mkQApp("PyMoDAQ Move")
 
     widget = QtWidgets.QWidget()
     prog = DAQ_Move(widget, title="test")

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -42,7 +42,8 @@ from pymodaq_gui.parameter import utils as putils
 from pymodaq.control_modules.viewer_utility_classes import params as daq_viewer_params
 from pymodaq_utils import utils
 from pymodaq_utils.warnings import deprecation_msg
-from pymodaq_gui.utils import DockArea, Dock, set_dark_palette
+from pymodaq_gui.utils import DockArea, Dock
+from pymodaq_gui.utils.utils import mkQApp
 
 from pymodaq.utils.gui_utils import get_splash_sc
 from pymodaq.control_modules.daq_viewer_ui import DAQ_Viewer_UI
@@ -1459,15 +1460,12 @@ def main(init_qt=True, init_det=False):
     """ Method called to start the DAQ_Viewer in standalone mode"""
 
     if init_qt:  # used for the test suite
-        app = QtWidgets.QApplication(sys.argv)
-        if config('style', 'darkstyle'):
-            set_dark_palette(app)
+        app = mkQApp("PyMoDAQ Viewer")
 
     win = QtWidgets.QMainWindow()
     area = DockArea()
     win.setCentralWidget(area)
     win.resize(1000, 500)
-    win.setWindowTitle('PyMoDAQ Viewer')
     win.show()
 
     title = "Testing"

--- a/src/pymodaq/control_modules/move_utility_classes.py
+++ b/src/pymodaq/control_modules/move_utility_classes.py
@@ -19,7 +19,7 @@ from pymodaq_utils.logger import set_logger, get_module_name
 import pymodaq_gui.parameter.utils as putils
 from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.parameter import ioxml
-from pymodaq_gui.utils import set_dark_palette
+from pymodaq_gui.utils.utils import mkQApp
 
 from pymodaq.utils.tcp_ip.tcp_server_client import TCPServer, tcp_parameters
 
@@ -212,9 +212,7 @@ def main(plugin_file, init=True, title='test'):
     from qtpy import QtWidgets
     from pymodaq.control_modules.daq_move import DAQ_Move
     from pathlib import Path
-    app = QtWidgets.QApplication(sys.argv)
-    if config('style', 'darkstyle'):
-        set_dark_palette(app)
+    app = mkQApp("PyMoDAQ Viewer")
 
     widget = QtWidgets.QWidget()
     prog = DAQ_Move(widget, title=title,)

--- a/src/pymodaq/control_modules/viewer_utility_classes.py
+++ b/src/pymodaq/control_modules/viewer_utility_classes.py
@@ -18,7 +18,7 @@ from pymodaq_utils.warnings import deprecation_msg
 from pymodaq_utils.serialize.mysocket import Socket
 from pymodaq_utils.serialize.serializer_legacy import DeSerializer, Serializer
 
-from pymodaq_gui.utils import set_dark_palette
+from pymodaq_gui.utils.utils import mkQApp
 
 comon_parameters = [{'title': 'Controller Status:', 'name': 'controller_status', 'type': 'list', 'value': 'Master',
                      'limits': ['Master', 'Slave']}, ]
@@ -106,9 +106,7 @@ def main(plugin_file=None, init=True, title='Testing'):
     from pymodaq.control_modules.daq_viewer import DAQ_Viewer
     from pathlib import Path
 
-    app = QtWidgets.QApplication(sys.argv)
-    if config('style', 'darkstyle'):
-        set_dark_palette(app)
+    app = mkQApp("PyMoDAQ Viewer")
 
     win = QtWidgets.QMainWindow()
     area = DockArea()

--- a/src/pymodaq/extensions/bayesian/bayesian_optimisation.py
+++ b/src/pymodaq/extensions/bayesian/bayesian_optimisation.py
@@ -17,7 +17,8 @@ from pymodaq_utils.logger import set_logger, get_module_name
 
 from pymodaq_gui.plotting.data_viewers.viewer0D import Viewer0D
 from pymodaq_gui.plotting.data_viewers.viewer import ViewerDispatcher, ViewersEnum
-from pymodaq_gui.utils import QLED, set_dark_palette
+from pymodaq_gui.utils import QLED
+from pymodaq_gui.utils.utils import mkQApp
 from pymodaq_gui import utils as gutils
 from pymodaq_gui.parameter import utils as putils
 from pymodaq_gui.h5modules.saving import H5Saver
@@ -650,9 +651,7 @@ def main(init_qt=True):
     from pymodaq.utils.daq_utils import get_set_preset_path
 
     if init_qt:  # used for the test suite
-        app = QtWidgets.QApplication(sys.argv)
-        if config('style', 'darkstyle'):
-            set_dark_palette(app)
+        app = mkQApp("PyMoDAQ Dashboard")
 
     from pymodaq.dashboard import DashBoard
 
@@ -660,7 +659,6 @@ def main(init_qt=True):
     area = gutils.dock.DockArea()
     win.setCentralWidget(area)
     win.resize(1000, 500)
-    win.setWindowTitle('PyMoDAQ Dashboard')
 
     dashboard = DashBoard(area)
     daq_scan = None


### PR DESCRIPTION
I replaced the `QApplication` calls with `mkQApp` in the "main" files.

There are still some files using `QApplication` when called as a script but see #487 for more information about that