### PR TITLE
backcompatibilty 

### DIFF
--- a/src/pymodaq/utils/parameter/__init__.py
+++ b/src/pymodaq/utils/parameter/__init__.py
@@ -1,7 +1,10 @@
 from pymodaq_gui.parameter import Parameter, ParameterTree, utils, ioxml, pymodaq_ptypes
-from pymodaq_gui.parameter.pymodaq_ptypes import registerParameterType, GroupParameter
-
+from sys import modules as sysmodules
 from pymodaq_utils.warnings import deprecation_msg
+
+
+sysmodules["pymodaq.utils.parameter.pymodaq_ptypes"] = pymodaq_ptypes
+
 
 deprecation_msg('Importing Parameter stuff from pymodaq is deprecated in pymodaq>5.0.0,'
                 'please use the pymodaq_gui package')


### PR DESCRIPTION
used sys.modules to expose pymodaq.utils.parameter.pymodaq_ptypes from pymodaq.utils.parameter for the plugins that don't use pymodaq_gui yet.
Tested on the pymodaq_plugins_daqmx