### PR TITLE
Added a section to provide optional development dependancies

### DIFF
--- a/docs/src/developer_folder/contributing.rst
+++ b/docs/src/developer_folder/contributing.rst
@@ -24,10 +24,13 @@ using git command line or GitHub Desktop. Then create a dedicated branch name fr
 
 Finally it is advised to create a dedicated virtual environment for this and install PyMoDAQ's package as a developer. For example, using mamba as an environment manager:
 
-* ``mamba create -n dev_env``
-* ``mamba activate dev_env``
-* ``cd`` to the location of the folder where you downloaded or cloned the repository.
-* install the package as a developer with test tools using the command ``pip install -e ".[dev]"``.
+- ``mamba create -n dev_env``
+- ``mamba activate dev_env``
+- ``cd`` to the location of the folder where you downloaded or cloned the repository.
+- install the package as a developer with test tools using the command ``pip install -e ".[dev]"``.
+    - the `-e` option tells pip to install the package in editable mode, meaning that any change done to the source will be reported to the installed package.
+    - the `".[dev]"` argument indicate to install the current folder as a package alongside its optional dependancies, declared as `dev` in the `pyproject.toml` file.
+    - the quotes around `[dev]` just allow to escape the sequence in order to not be interpreted by the shell.
 
 
 Then any change on the code will be *seen* by python interpreter so that you can see and test your modifications. Think about

--- a/docs/src/developer_folder/contributing.rst
+++ b/docs/src/developer_folder/contributing.rst
@@ -22,12 +22,12 @@ you should fork and clone the up-to-date GitHub repo: https://github.com/PyMoDAQ
 using git command line or GitHub Desktop. Then create a dedicated branch name from the change you want to work on
 (using git).
 
-Finally I advise to create a dedicated conda environment for this and install PyMoDAQ's package as a developer:
+Finally it is advised to create a dedicated virtual environment for this and install PyMoDAQ's package as a developer. For example, using conda as an environment manager:
 
 * ``conda create -n dev_env``
 * ``conda activate dev_env``
 * ``cd`` to the location of the folder where you downloaded or cloned the repository.
-* install the package as a developer using the command ``pip install -e .``.
+* install the package as a developer with test tools using the command ``pip install -e ".[dev]"``.
 
 Then any change on the code will be *seen* by python interpreter so that you can see and test your modifications. Think about
 writing tests that will make sure your code is sound and that modification elsewhere doesn't change the expected behavior.

--- a/docs/src/developer_folder/contributing.rst
+++ b/docs/src/developer_folder/contributing.rst
@@ -22,15 +22,18 @@ you should fork and clone the up-to-date GitHub repo: https://github.com/PyMoDAQ
 using git command line or GitHub Desktop. Then create a dedicated branch name from the change you want to work on
 (using git).
 
-Finally it is advised to create a dedicated virtual environment for this and install PyMoDAQ's package as a developer. For example, using conda as an environment manager:
+Finally it is advised to create a dedicated virtual environment for this and install PyMoDAQ's package as a developer. For example, using mamba as an environment manager:
 
-* ``conda create -n dev_env``
-* ``conda activate dev_env``
+* ``mamba create -n dev_env``
+* ``mamba activate dev_env``
 * ``cd`` to the location of the folder where you downloaded or cloned the repository.
 * install the package as a developer with test tools using the command ``pip install -e ".[dev]"``.
 
+
 Then any change on the code will be *seen* by python interpreter so that you can see and test your modifications. Think about
 writing tests that will make sure your code is sound and that modification elsewhere doesn't change the expected behavior.
+
+It also requires the installation of a QT backend and some system packages on Linux, like explained in :ref:`the installation tips page <installation_tips>` of the documentation.
 
 When ready, you can create a pull request from your code into the proper branch, as discussed in the next section.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,24 @@ dependencies = [
     "bayesian-optimization<2.0.0",
 ]
 
+
+[project.optional-dependencies]
+dev = [
+    "hatch", 
+    "flake8",
+    "h5py",
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+
+    "pyqt5",
+    "pyqt6",
+    "pyside6",
+    "pytest-qt",
+    "pytest-xvfb",
+]
+
+
 [project.scripts]
 daq_logger = "pymodaq.extensions.daq_logger:main"
 daq_move = "pymodaq.control_modules.daq_move:main"


### PR DESCRIPTION
The `pyproject.toml` file was modified to include the development dependencies so they can easily be installed with `pip install -e ".[dev]"`