### PR TITLE
New pymodaq_updater

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
 ]
 
 [project.scripts]
+pymodaq_updater = "pymodaq.updater:main"
 daq_logger = "pymodaq.extensions.daq_logger:main"
 daq_move = "pymodaq.control_modules.daq_move:main"
 daq_scan = "pymodaq.extensions.daq_scan:main"

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -1599,6 +1599,8 @@ class DashBoard(CustomApp):
             available_versions = [version_mod.parse(get_pypi_pymodaq(p)['version']) for p in packages]
             new_versions = np.greater(available_versions, current_versions)
             # Combine package and version information and select only the ones with a newer version available
+            
+            
             packages_data = np.array(list(zip(packages, current_versions, available_versions)))[new_versions]
 
             #TODO: Remove `or True`
@@ -1642,7 +1644,7 @@ class DashBoard(CustomApp):
                         packages_to_update_str = ', '.join(packages_to_update)
                         logger.info("Trying to update:")
                         logger.info(f"\t {packages_to_update_str}")
-                        subprocess.Popen(['pymodaq_updater', '--wait', '--file', __file__] + packages_to_update)
+                        subprocess.Popen(['pymodaq_updater', '--wait', '--file', __file__] + packages_to_update, stdin=subprocess.PIPE)
                         self.quit_fun()
                         return True
                     logger.info("Update found but no packages checked for update.")

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -13,7 +13,7 @@ from typing import Tuple, List, Any, TYPE_CHECKING
 
 from qtpy import QtGui, QtWidgets, QtCore
 from qtpy.QtCore import Qt, QObject, Slot, QThread, Signal, QSize
-from qtpy.QtWidgets import QTableWidget, QTableWidgetItem, QCheckBox, QWidget, QHBoxLayout, QLabel, QDialogButtonBox, QDialog
+from qtpy.QtWidgets import QTableWidget, QTableWidgetItem, QCheckBox, QWidget, QLabel, QDialogButtonBox, QDialog
 from time import perf_counter
 import numpy as np
 
@@ -73,6 +73,10 @@ class ManagerEnums(BaseEnum):
     roi = 3
 
 class PymodaqUpdateTableWidget(QTableWidget):
+    '''
+        A class to represent PyMoDAQ and its subpackages'
+        available updates as a table.
+    '''
     def __init__(self):
         super().__init__()
 
@@ -112,12 +116,13 @@ class PymodaqUpdateTableWidget(QTableWidget):
 
     def get_checked_data(self):
     	checked = list(map(lambda c : c.isChecked(), self._checkboxes))
-    	return np.array(self._package_versions)[checked]
+    	return list(np.array(self._package_versions)[checked])
+
     def sizeHint(self):
         self.resizeColumnsToContents()
         self.resizeRowsToContents()
                 
-        # Compute the size to adapt the window
+        # Compute the size to adapt the window (header + borders + sum of all the elements)
         width  = self.verticalHeader().width()  \
         	   + self.frameWidth() * 2 \
         	   + sum([self.columnWidth(i) for i in range(self.columnCount())])
@@ -1592,13 +1597,12 @@ class DashBoard(CustomApp):
             packages = ['pymodaq_utils', 'pymodaq_data', 'pymodaq_gui', 'pymodaq']
             current_versions = [version_mod.parse(get_version(p)) for p in packages]
             available_versions = [version_mod.parse(get_pypi_pymodaq(p)['version']) for p in packages]
-            #new_versions = np.greater(available_versions, current_versions)
-            new_versions = np.array([True] * len(packages))
+            new_versions = np.greater(available_versions, current_versions)
             # Combine package and version information and select only the ones with a newer version available
             packages_data = np.array(list(zip(packages, current_versions, available_versions)))[new_versions]
 
             #TODO: Remove `or True`
-            if len(packages_data) > 0 or True:
+            if len(packages_data) > 0:
                 #Create a QDialog window and different graphical components
                 dialog = QtWidgets.QDialog()
                 dialog.setWindowTitle("Update check")
@@ -1645,8 +1649,7 @@ class DashBoard(CustomApp):
                 if show:
                     msgBox = QtWidgets.QMessageBox()
                     msgBox.setWindowTitle("Update check")
-                    msgBox.setText(f"Your version of PyMoDAQ,"
-                                   f" {str(current_version)}, is up to date!")
+                    msgBox.setText("Everything is up to date!")
                     ret = msgBox.exec()
         except Exception as e:
             logger.exception("Error while checking the available PyMoDAQ version")

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -1639,8 +1639,9 @@ class DashBoard(CustomApp):
                     # and send to the updater
                     packages_to_update = table.get_checked_data()
                     if len(packages_to_update) > 0:
+                        packages_to_update_str = ', '.join(packages_to_update)
                         logger.info("Trying to update:")
-                        logger.info(f"\t {', '.join(packages_to_update)}")
+                        logger.info(f"\t {packages_to_update_str}")
                         subprocess.Popen(['pymodaq_updater', '--wait', '--file', __file__] + packages_to_update)
                         self.quit_fun()
                         return True

--- a/src/pymodaq/updater.py
+++ b/src/pymodaq/updater.py
@@ -57,7 +57,9 @@ def main():
 	if args.wait:
 		wait_for_parent()
 
-	logger.info(f'Updating packages: {', '.join(args.packages)}')
+	packages_str = ', '.join(args.packages)
+
+	logger.info(f'Updating packages: {packages_str}')
 	
 	with subprocess.Popen([sys.executable, '-m', 'pip', 'install'] + args.packages, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as pip:
 		for line in pip.stdout:
@@ -66,9 +68,9 @@ def main():
 	
 
 	if ret_code == 0:
-		logger.info(f'Succesfully updated {', '.join(args.packages)}')
+		logger.info(f'Succesfully updated {packages_str}')
 	else:
-		logger.error(f'Error while updating {', '.join(args.packages)}, pip returned {ret_code}')
+		logger.error(f'Error while updating {packages_str}, pip returned {ret_code}')
 
 	if args.file is not None:
 		logger.info(f"Restarting {args.file} script after update.")

--- a/src/pymodaq/updater.py
+++ b/src/pymodaq/updater.py
@@ -1,0 +1,80 @@
+import argparse
+import subprocess
+import sys
+import time
+
+from pymodaq_utils.logger import set_logger, get_module_name
+
+logger = set_logger(get_module_name(__file__))
+
+def wait_for_parent():
+	'''
+		A function to wait for its parent to terminate execution.
+
+		In order to achieve that, this process has to be started with
+		stdin replaced by a piped stream from its parent. When the
+		parent terminates, stdin will close and either return from read
+		or throw an exception. De facto creating a way to wait for its
+		parent's termination.
+
+		It then sleep for 2 seconds, to let the parent process complete
+		termination.
+
+		CAUTION: If the process was not started by piping stdin AND 
+		the --wait option is set, this function will hang forever.
+
+		We could use `psutil` or a similar lib to check for parent's process
+		existance with its pid. 
+	'''
+
+	logger.info("Waiting for parent process to stop.")
+	try:
+		sys.stdin.read()
+	except:
+		pass
+	logger.debug("Parent process closed stdin")
+	time.sleep(2)
+	logger.info("Parent process stopped.")
+
+def process_args():
+	'''
+		Declare arguments for updater.py, parse them and returns them in an object.
+		The arguments are:
+			--file <file> to request a python program to (re)start after update if needed (optional) 
+			--wait        to wait for the starting process to terminate before updating (optional, defaults to False)
+			packages      the package list to install/update (they should contain the version in a pip accepted format)
+	'''
+	parser = argparse.ArgumentParser(description='Update pymodaq using pip.')
+	parser.add_argument('--file', type=str,  help='the pymodaq script to restart after update')
+	parser.add_argument("--wait", action="store_true", help="enable waiting for pymodaq to finish mode (default is disabled).")
+	parser.add_argument('packages', type=str, nargs='+', help='package list')
+	return parser.parse_args()
+
+def main():
+	args = process_args()
+	logger.info(f"Arguments processed: {args}")
+
+	if args.wait:
+		wait_for_parent()
+
+	logger.info(f'Updating packages: {', '.join(args.packages)}')
+	
+	ret_code = 0
+	# with subprocess.Popen([sys.executable, '-m', 'pip', 'install'] + args.packages, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as pip:
+	# 	for line in pip.stdout:
+	# 		logger.info(line[:-1].decode('utf-8'))
+	# ret_code = pip.wait()
+	
+
+	if ret_code == 0:
+		logger.info(f'Succesfully updated {', '.join(args.packages)}')
+	else:
+		logger.error(f'Error while updating {', '.join(args.packages)}, pip returned {ret_code}')
+
+	if args.file is not None:
+		logger.info(f"Restarting {args.file} script after update.")
+		subprocess.Popen([sys.executable, args.file])
+
+
+if __name__ == "__main__":
+	main()

--- a/src/pymodaq/updater.py
+++ b/src/pymodaq/updater.py
@@ -54,7 +54,7 @@ def process_args():
 	parser.add_argument('packages', type=str, nargs='+', help='package list')
 	return parser.parse_args()
 
-def detect_launch_name_and_restart(args):
+def restart_if_command_launch(args):
 	'''
 		Try to detect if this process if launched using the declared command (i.e. `pymodaq_updater`)
 		or using the script file (`updater.py`). If it uses the command, it restart the process to
@@ -75,17 +75,15 @@ def detect_launch_name_and_restart(args):
 		sys.exit(0)
 
 def main():
-	print(sys.argv)
 	args = process_args()
 	logger.info(f"Arguments processed: {args}")
 
-	detect_launch_name_and_restart(args)
+	restart_if_command_launch(args)
 
 	if args.wait:
 		wait_for_parent()
 
 	packages_str = ', '.join(args.packages)
-
 	logger.info(f'Updating packages: {packages_str}')
 	
 	with subprocess.Popen([sys.executable, '-m', 'pip', 'install'] + args.packages, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as pip:

--- a/src/pymodaq/updater.py
+++ b/src/pymodaq/updater.py
@@ -59,11 +59,10 @@ def main():
 
 	logger.info(f'Updating packages: {', '.join(args.packages)}')
 	
-	ret_code = 0
-	# with subprocess.Popen([sys.executable, '-m', 'pip', 'install'] + args.packages, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as pip:
-	# 	for line in pip.stdout:
-	# 		logger.info(line[:-1].decode('utf-8'))
-	# ret_code = pip.wait()
+	with subprocess.Popen([sys.executable, '-m', 'pip', 'install'] + args.packages, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as pip:
+		for line in pip.stdout:
+			logger.info(line[:-1].decode('utf-8'))
+	ret_code = pip.wait()
 	
 
 	if ret_code == 0:


### PR DESCRIPTION
Closes #371. Closes #509.

Provides an updater that allows to select updates from pymodaq_utils, pymodaq_data, pymodaq_gui and pymodaq packages when available. 

It works by calling an updater script that waits for the dashboard to close. Then it checks if it was launched by the `pymodaq_updater` executable or by `python <path_to_install>/updater.py` and relaunch itself using python if needed to avoid file lock on windows. When everything is good, it launches `pip install` with the provided packages to update and restart the initial pymodaq window.

I guess that it could be improved by directly using `<path_to_install>/updater.py`  when calling the script but using `pymodaq_updater` first provides an easy way to get the path to install.