### PR TITLE
Exclude folders from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,8 @@ fallback-version = '5.0.1'
 include = [
     "/src",
 ]
+
+[tool.coverage.run]
+omit = [
+    "*/examples/*",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,4 +79,5 @@ include = [
 [tool.coverage.run]
 omit = [
     "*/examples/*",
+    "*/resources/*"
 ]


### PR DESCRIPTION
Closes #505 

It removes `examples` and `resources` folder from the coverage test.