### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Testbase.yml
+++ b/.github/workflows/Testbase.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python ${{ inputs.python }}
         uses: actions/checkout@v4.2.2
       - name: Install dependencies
-        uses: actions/setup-python@v5.3.0
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: ${{ inputs.python }}
       - name: Install package
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo ${{ secrets.CODECOV_TOKEN }}
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v5.1.2
+        uses: codecov/codecov-action@v5.3.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/Testbase_win.yml
+++ b/.github/workflows/Testbase_win.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python ${{ inputs.python }}
         uses: actions/checkout@v4.2.2
       - name: Install dependencies
-        uses: actions/setup-python@v5.3.0
+        uses: actions/setup-python@v5.4.0
         with:
           python-version: ${{ inputs.python }}
       - name: Install package
@@ -38,7 +38,7 @@ jobs:
         run: |
           pytest --cov=pymodaq --cov-report=xml -n 1
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v5.1.2
+        uses: codecov/codecov-action@v5.3.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v5.3.0
+      uses: actions/setup-python@v5.4.0
       with:
         python-version: '3.11'
     - name: Install dependencies


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.4.0](https://github.com/actions/setup-python/releases/tag/v5.4.0)** on 2025-01-28T03:28:18Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.3.1](https://github.com/codecov/codecov-action/releases/tag/v5.3.1)** on 2025-01-24T16:13:50Z
