### PR TITLE
Fix serialize imports in LECO and in deprecated pymodaq folder

### DIFF
--- a/src/pymodaq/utils/leco/daq_move_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_move_LECODirector.py
@@ -17,8 +17,7 @@ from pymodaq_gui.parameter import Parameter
 
 from pymodaq.utils.leco.leco_director import LECODirector, leco_parameters
 from pymodaq.utils.leco.director_utils import ActuatorDirector
-from pymodaq.utils.tcp_ip.serializer import DeSerializer
-
+from pymodaq_utils.serialize.serializer_legacy import DeSerializer
 
 class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
     """A control module, which in the dashboard, allows to control a remote Move module.

--- a/src/pymodaq/utils/leco/daq_xDviewer_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_xDviewer_LECODirector.py
@@ -7,7 +7,7 @@ from pymodaq.control_modules.viewer_utility_classes import DAQ_Viewer_base, como
 
 from pymodaq_utils.utils import ThreadCommand, getLineInfo
 from pymodaq_gui.parameter import Parameter
-from pymodaq.utils.tcp_ip.serializer import DeSerializer
+from pymodaq_utils.serialize.serializer_legacy import DeSerializer
 
 from pymodaq.utils.leco.leco_director import LECODirector, leco_parameters
 from pymodaq.utils.leco.director_utils import DetectorDirector

--- a/src/pymodaq/utils/tcp_ip/serializer.py
+++ b/src/pymodaq/utils/tcp_ip/serializer.py
@@ -7,7 +7,7 @@ Created the 20/10/2023
 
 from pymodaq_utils.utils import deprecation_msg
 
-from pymodaq_data.serialize.serializer_legacy import Serializer, DeSerializer, SocketString, Socket
+from pymodaq_utils.serialize.serializer_legacy import Serializer, DeSerializer, SocketString, Socket
 
 deprecation_msg('Importing Serializer, DeSerializer from pymodaq is deprecated in PyMoDAQ >= 5,'
                 'import them from pymodaq_data.serialize.serializer')


### PR DESCRIPTION
Ran into this when trying out LECO in v5.0