### PR TITLE
Bugfix/leco move units

### DIFF
--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -715,6 +715,7 @@ class DAQ_Move(ParameterControlModule):
             self._command_tcpip.emit(ThreadCommand(LECOCommands.SET_SETTINGS,
                                                    ioxml.parameter_to_xml_string(self.settings.child('move_settings'))))
 
+
 class DAQ_Move_Hardware(QObject):
     """
         ================== ========================

--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -505,6 +505,9 @@ class DAQ_Move(ParameterControlModule):
             if self.ui is not None:
                 self.ui.set_abs_spinbox_properties(**status.attribute)
 
+        elif status.command == 'stop':
+            self.stop_motion()
+
         elif status.command == 'units':
             self.units = status.attribute
 

--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -671,10 +671,10 @@ class DAQ_Move(ParameterControlModule):
         if super().process_tcpip_cmds(status=status) is None:
             return
         if 'move_abs' in status.command:
-            self.move_abs(status.attribute[0], send_to_tcpip=True)
+            self.move_abs(status.attribute, send_to_tcpip=True)
 
         elif 'move_rel' in status.command:
-            self.move_rel(status.attribute[0], send_to_tcpip=True)
+            self.move_rel(status.attribute, send_to_tcpip=True)
 
         elif 'move_home' in status.command:
             self.move_home(send_to_tcpip=True)
@@ -690,12 +690,22 @@ class DAQ_Move(ParameterControlModule):
             self.get_actuator_value()
 
         elif status.command == 'set_info':
-            path_in_settings = status.attribute[0]
-            param_as_xml = status.attribute[1]
-            param_dict = ioxml.XML_string_to_parameter(param_as_xml)[0]
-            param_tmp = Parameter.create(**param_dict)
-            param = self.settings.child('move_settings', *path_in_settings[1:])
-            param.restoreState(param_tmp.saveState())
+            """ The Director sent a parameter to be updated"""
+            path_in_settings = status.attribute.path
+            try:
+                param = self.settings.child('move_settings', *path_in_settings[1:])
+                logger.debug(f'Param {path_in_settings[1:]} has been updated with'
+                             f' value {status.attribute.parameter.value()}')
+            except KeyError:
+                logger.debug(f'Param {path_in_settings[1:]} could not be updated')
+                try:
+                    param = self.settings.child('move_settings', *path_in_settings)
+                    logger.debug(f'Param {path_in_settings} has been updated with'
+                                 f' value {status.attribute.parameter.value()}')
+                except KeyError:
+                    param = None
+            if param is not None:
+                param.restoreState(status.attribute.parameter.saveState())
 
         elif status.command == LECOCommands.GET_SETTINGS:
             """ The Director requested the content of the actuator settings"""

--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -505,9 +505,6 @@ class DAQ_Move(ParameterControlModule):
             if self.ui is not None:
                 self.ui.set_abs_spinbox_properties(**status.attribute)
 
-        elif status.command == 'stop':
-            self.stop_motion()
-
         elif status.command == 'units':
             self.units = status.attribute
 
@@ -689,6 +686,9 @@ class DAQ_Move(ParameterControlModule):
             self._send_to_tcpip = True
             self.get_actuator_value()
 
+        elif status.command == 'stop_motion':
+            self.stop_motion()
+
         elif status.command == 'set_info':
             """ The Director sent a parameter to be updated"""
             path_in_settings = status.attribute.path
@@ -710,7 +710,7 @@ class DAQ_Move(ParameterControlModule):
         elif status.command == LECOCommands.GET_SETTINGS:
             """ The Director requested the content of the actuator settings"""
             self._command_tcpip.emit(ThreadCommand(LECOCommands.SET_SETTINGS,
-                                                   self.settings.child('move_settings')))
+                                                   ioxml.parameter_to_xml_string(self.settings.child('move_settings'))))
 
 class DAQ_Move_Hardware(QObject):
     """

--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -510,8 +510,6 @@ class DAQ_Move(ParameterControlModule):
 
         elif status.command == 'units':
             self.units = status.attribute
-            if self.settings.child('main_settings', 'leco', 'leco_connected').value() and self._send_to_tcpip:
-                self._command_tcpip.emit(ThreadCommand(LECOMoveCommands.UNITS_CHANGED, self.units))
 
     def _check_data_type(self, data_act: Union[list[np.ndarray], float, DataActuator]) -> DataActuator:
         """ Make sure the data is a DataActuator

--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -695,20 +695,14 @@ class DAQ_Move(ParameterControlModule):
         elif status.command == 'set_info':
             """ The Director sent a parameter to be updated"""
             path_in_settings = status.attribute.path
-            try:
+            if 'move_settings' in path_in_settings:
+                param = self.settings.child(*path_in_settings)
+            elif 'settings_client' in path_in_settings:
                 param = self.settings.child('move_settings', *path_in_settings[1:])
-                logger.debug(f'Param {path_in_settings[1:]} has been updated with'
-                             f' value {status.attribute.parameter.value()}')
-            except KeyError:
-                logger.debug(f'Param {path_in_settings[1:]} could not be updated')
-                try:
-                    param = self.settings.child('move_settings', *path_in_settings)
-                    logger.debug(f'Param {path_in_settings} has been updated with'
-                                 f' value {status.attribute.parameter.value()}')
-                except KeyError:
-                    param = None
-            if param is not None:
-                param.setValue(status.attribute.parameter.value())
+            else:
+                param = self.settings.child('move_settings', *path_in_settings)
+
+            param.setValue(status.attribute.parameter.value())
 
         elif status.command == LECOCommands.GET_SETTINGS:
             """ The Director requested the content of the actuator settings"""

--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -708,7 +708,7 @@ class DAQ_Move(ParameterControlModule):
                 except KeyError:
                     param = None
             if param is not None:
-                param.restoreState(status.attribute.parameter.saveState())
+                param.setValue(status.attribute.parameter.value())
 
         elif status.command == LECOCommands.GET_SETTINGS:
             """ The Director requested the content of the actuator settings"""

--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -43,7 +43,7 @@ from pymodaq.control_modules.move_utility_classes import (MoveCommand, DAQ_Move_
 
 
 from pymodaq.control_modules.move_utility_classes import params as daq_move_params
-from pymodaq.utils.leco.pymodaq_listener import MoveActorListener, LECOMoveCommands
+from pymodaq.utils.leco.pymodaq_listener import MoveActorListener, LECOMoveCommands, LECOCommands
 
 from pymodaq.utils.daq_utils import get_plugins
 from pymodaq import Q_, Unit
@@ -510,6 +510,8 @@ class DAQ_Move(ParameterControlModule):
 
         elif status.command == 'units':
             self.units = status.attribute
+            if self.settings.child('main_settings', 'leco', 'leco_connected').value() and self._send_to_tcpip:
+                self._command_tcpip.emit(ThreadCommand(LECOMoveCommands.UNITS_CHANGED, self.units))
 
     def _check_data_type(self, data_act: Union[list[np.ndarray], float, DataActuator]) -> DataActuator:
         """ Make sure the data is a DataActuator
@@ -663,6 +665,9 @@ class DAQ_Move(ParameterControlModule):
         super().connect_tcp_ip(params_state=self.settings.child('move_settings'),
                                client_type="ACTUATOR")
 
+    def connect_leco(self, connect: bool) -> None:
+        super().connect_leco(connect)
+
     @Slot(ThreadCommand)
     def process_tcpip_cmds(self, status: ThreadCommand) -> None:
         if super().process_tcpip_cmds(status=status) is None:
@@ -679,11 +684,12 @@ class DAQ_Move(ParameterControlModule):
         elif 'check_position' in status.command:
             deprecation_msg('check_position is deprecated, you should use get_actuator_value')
             self._send_to_tcpip = True
-            self.command_hardware.emit(ThreadCommand('get_actuator_value', ))
+            self.get_actuator_value()
+
 
         elif 'get_actuator_value' in status.command:
             self._send_to_tcpip = True
-            self.command_hardware.emit(ThreadCommand('get_actuator_value', ))
+            self.get_actuator_value()
 
         elif status.command == 'set_info':
             path_in_settings = status.attribute[0]
@@ -693,6 +699,10 @@ class DAQ_Move(ParameterControlModule):
             param = self.settings.child('move_settings', *path_in_settings[1:])
             param.restoreState(param_tmp.saveState())
 
+        elif status.command == LECOCommands.GET_SETTINGS:
+            """ The Director requested the content of the actuator settings"""
+            self._command_tcpip.emit(ThreadCommand(LECOCommands.SET_SETTINGS,
+                                                   self.settings.child('move_settings')))
 
 class DAQ_Move_Hardware(QObject):
     """

--- a/src/pymodaq/control_modules/move_utility_classes.py
+++ b/src/pymodaq/control_modules/move_utility_classes.py
@@ -698,7 +698,8 @@ class DAQ_Move_base(QObject):
         --------
         DAQ_utils.ThreadCommand, move_done
         """
-        if 'TCPServer' not in self.__class__.__name__:
+        if not ('TCPServer' in self.__class__.__name__ or
+                'LECODirector' in self.__class__.__name__):
             self.start_time = perf_counter()
             if self.ispolling:
                 self.poll_timer.start()

--- a/src/pymodaq/control_modules/move_utility_classes.py
+++ b/src/pymodaq/control_modules/move_utility_classes.py
@@ -851,12 +851,14 @@ class DAQ_Move_base(QObject):
             except ValueError:
                 apply_settings = False
         elif change == 'parent':
-            children = putils.get_param_from_name(self.settings, param.name())
+            try:
+                children = putils.get_param_from_name(self.settings, param.name())
 
-            if children is not None:
-                path = putils.get_param_path(children)
-                self.settings.child(*path[1:-1]).removeChild(children)
-
+                if children is not None:
+                    path = putils.get_param_path(children)
+                    self.settings.child(*path[1:-1]).removeChild(children)
+            except IndexError:
+                logger.debug(f'Could not remove children from {param.name()}')
         self.settings.sigTreeStateChanged.connect(self.send_param_status)
         if apply_settings:
             self.commit_common_settings(param)

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -504,6 +504,7 @@ class ParameterControlModule(ParameterManager, ControlModule):
         elif status.command == 'Update_Status':
             self.thread_status(status)
 
+
         else:
             # not handled
             return status

--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -19,6 +19,7 @@ from pymodaq_utils.logger import get_base_logger, set_logger, get_module_name
 
 from pymodaq_gui.utils.custom_app import CustomApp
 from pymodaq_gui.parameter import Parameter, ioxml
+from pymodaq_gui.parameter.utils import ParameterWithPath
 from pymodaq_gui.managers.parameter_manager import ParameterManager
 from pymodaq_gui.plotting.data_viewers import ViewersEnum
 
@@ -431,7 +432,9 @@ class ParameterControlModule(ParameterManager, ControlModule):
                 if self.settings.child('main_settings', 'tcpip', 'tcp_connected').value():
                     self._command_tcpip.emit(ThreadCommand('send_info', dict(path=path, param=param)))
                 if self.settings.child('main_settings', 'leco', 'leco_connected').value():
-                    self._command_tcpip.emit(ThreadCommand('send_info', dict(path=path, param=param)))
+                    self._command_tcpip.emit(
+                        ThreadCommand(LECOCommands.SEND_INFO,
+                                      ParameterWithPath(param, path)))
 
     def connect_tcp_ip(self, params_state=None, client_type: str = "GRABBER") -> None:
         """Init a TCPClient in a separated thread to communicate with a distant TCp/IP Server

--- a/src/pymodaq/utils/leco/daq_move_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_move_LECODirector.py
@@ -57,8 +57,6 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
         for method in (
             self.set_position,
             self.set_move_done,
-            self.set_x_axis,
-            self.set_y_axis,
         ):
             self.listener.register_binary_rpc_method(method, accept_binary_input=True)
 
@@ -169,11 +167,6 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
         pos = self._set_position_value(position=position, additional_payload=additional_payload)
         self.emit_status(ThreadCommand('move_done', [pos]))
 
-    def set_x_axis(self, data, label: str = "", units: str = "") -> None:
-        raise NotImplementedError("where is it handled?")
-
-    def set_y_axis(self, data, label: str = "", units: str = "") -> None:
-        raise NotImplementedError("where is it handled?")
 
 
 if __name__ == '__main__':

--- a/src/pymodaq/utils/leco/daq_move_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_move_LECODirector.py
@@ -19,6 +19,7 @@ from pymodaq_utils.serialize.factory import SerializableFactory
 from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.parameter import utils as putils
 from pymodaq_gui.parameter import ioxml
+from enum import StrEnum
 
 from pymodaq.utils.leco.leco_director import LECODirector, leco_parameters
 from pymodaq.utils.leco.director_utils import ActuatorDirector
@@ -26,6 +27,8 @@ from pymodaq.utils.leco.director_utils import ActuatorDirector
 from pymodaq_utils.logger import set_logger, get_module_name
 
 logger = set_logger(get_module_name(__file__))
+
+
 
 
 class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
@@ -73,7 +76,7 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
         ))
 
         self.register_binary_rpc_methods((
-            self.set_position,  # to display the actor position
+            self.send_position,  # to display the actor position
             self.set_move_done,  # to set the move as done
         ))
 
@@ -167,7 +170,7 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
         self._current_value = pos
         return pos
 
-    def set_position(self, position: Union[str, float, None], additional_payload=None) -> None:
+    def send_position(self, position: Union[str, float, None], additional_payload=None) -> None:
         pos = self._set_position_value(position=position, additional_payload=additional_payload)
         self.emit_status(ThreadCommand('get_actuator_value', [pos]))
 

--- a/src/pymodaq/utils/leco/daq_move_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_move_LECODirector.py
@@ -75,7 +75,9 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
         # copied, I think it is good:
         self.settings.child('bounds').hide()
         self.settings.child('scaling').hide()
-        self.settings.child('epsilon').setValue(1)
+        self.settings.child('units').hide()
+        self.settings.child('epsilon').hide()
+        self.settings.child('multiaxes').hide()
 
     def commit_settings(self, param) -> None:
         self.commit_leco_settings(param=param)
@@ -106,16 +108,11 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
         except TimeoutError:
             logger.warning("Timeout setting remote name.")
 
-
         self.controller.get_settings()
 
-        #self.settings.child('units').hide()
-        #self.settings.child('epsilon').hide()
-
-        self.status.info = "LECODirector"
-        self.status.controller = self.controller
-        self.status.initialized = True
-        return self.status
+        info = "LECODirector"
+        initialized = True
+        return info, initialized
 
     def move_abs(self, position: DataActuator) -> None:
         position = self.check_bound(position)

--- a/src/pymodaq/utils/leco/daq_move_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_move_LECODirector.py
@@ -14,6 +14,7 @@ from pymodaq.control_modules.move_utility_classes import (DAQ_Move_base, comon_p
                                                           DataActuatorType, DataActuator)
 
 from pymodaq_utils.utils import ThreadCommand
+from pymodaq_utils.utils import find_dict_in_list_from_key_val
 from pymodaq_utils.serialize.factory import SerializableFactory
 from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.parameter import utils as putils
@@ -57,18 +58,22 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
     socket_types = ["ACTUATOR"]
     params = comon_parameters_fun(axis_names=_axis_names, epsilon=_epsilon) + leco_parameters
 
+    for param_name in ('multiaxes', 'units', 'epsilon', 'bounds', 'scaling'):
+        param_dict = find_dict_in_list_from_key_val(params, 'name', param_name)
+        if param_dict is not None:
+            param_dict['visible'] = False
+
+
     def __init__(self, parent=None, params_state=None, **kwargs) -> None:
         super().__init__(parent=parent,
                          params_state=params_state, **kwargs)
         self.register_rpc_methods((
-            self.set_info,
-            self.set_units,
-            self.set_settings,
+            self.set_units,  # to set units accordingly to the one of the actor
+            self.set_settings, # to show actor settings
         ))
         for method in (
-            self.set_position,
-            self.set_move_done,
-
+            self.set_position,  # to display the actor position
+            self.set_move_done,  # to set the move as done
         ):
             self.listener.register_binary_rpc_method(method, accept_binary_input=True)
 
@@ -117,10 +122,8 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
     def move_abs(self, position: DataActuator) -> None:
         position = self.check_bound(position)
         position = self.set_position_with_scaling(position)
-
-        self.controller.move_abs(position=position)
-
         self.target_value = position
+        self.controller.move_abs(position=position)
 
     def move_rel(self, position: DataActuator) -> None:
         position = self.check_bound(self.current_value + position) - self.current_value  # type: ignore  # noqa
@@ -191,6 +194,8 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
 
         self.axis_unit = self.settings['settings_client', 'units']
 
+    def close(self) -> None:
+        self.settings.child('settings_client').clearChildren()
 
 
 if __name__ == '__main__':

--- a/src/pymodaq/utils/leco/daq_move_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_move_LECODirector.py
@@ -16,9 +16,15 @@ from pymodaq.control_modules.move_utility_classes import (DAQ_Move_base, comon_p
 from pymodaq_utils.utils import ThreadCommand
 from pymodaq_utils.serialize.factory import SerializableFactory
 from pymodaq_gui.parameter import Parameter
+from pymodaq_gui.parameter import utils as putils
+from pymodaq_gui.parameter import ioxml
 
 from pymodaq.utils.leco.leco_director import LECODirector, leco_parameters
 from pymodaq.utils.leco.director_utils import ActuatorDirector
+
+from pymodaq_utils.logger import set_logger, get_module_name
+
+logger = set_logger(get_module_name(__file__))
 
 
 class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
@@ -38,25 +44,31 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
     """
     settings: Parameter
     controller: ActuatorDirector
+    _axis_names = ['']
+    _controller_units = ['']
+    _epsilon = 1
 
     params_client = []  # parameters of a client grabber
     data_actuator_type = DataActuatorType.DataActuator
 
     message_list = LECODirector.message_list + ["move_abs", 'move_home', 'move_rel',
                                                 'get_actuator_value', 'stop_motion', 'position_is',
-                                                'move_done']
+                                                'move_done', 'get_settings']
     socket_types = ["ACTUATOR"]
-    params = comon_parameters_fun() + leco_parameters
+    params = comon_parameters_fun(axis_names=_axis_names, epsilon=_epsilon) + leco_parameters
 
     def __init__(self, parent=None, params_state=None, **kwargs) -> None:
         super().__init__(parent=parent,
                          params_state=params_state, **kwargs)
         self.register_rpc_methods((
             self.set_info,
+            self.set_units,
+            self.set_settings,
         ))
         for method in (
             self.set_position,
             self.set_move_done,
+
         ):
             self.listener.register_binary_rpc_method(method, accept_binary_input=True)
 
@@ -84,18 +96,21 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
             False if initialization failed otherwise True
         """
         actor_name = self.settings.child("actor_name").value()
-        self.controller = self.ini_stage_init(  # type: ignore
-            old_controller=controller,
-            new_controller=ActuatorDirector(actor=actor_name, communicator=self.communicator),
-            )
+
+        if self.is_master:
+            self.controller = ActuatorDirector(actor=actor_name, communicator=self.communicator)
+        else:
+            self.controller = controller
         try:
             self.controller.set_remote_name(self.communicator.full_name)  # type: ignore
         except TimeoutError:
-            print("Timeout setting remote name.")  # TODO change to real logging
-        # self.settings.child('infos').addChildren(self.params_client)
+            logger.warning("Timeout setting remote name.")
 
-        self.settings.child('units').hide()
-        self.settings.child('epsilon').hide()
+
+        self.controller.get_settings()
+
+        #self.settings.child('units').hide()
+        #self.settings.child('epsilon').hide()
 
         self.status.info = "LECODirector"
         self.status.controller = self.controller
@@ -167,7 +182,19 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
         pos = self._set_position_value(position=position, additional_payload=additional_payload)
         self.emit_status(ThreadCommand('move_done', [pos]))
 
+    def set_units(self, units: str, additional_payload=None) -> None:
+        if units not in self.axis_units:
+            self.axis_units.append(units)
+        self.axis_unit = units
+
+    def set_settings(self, settings: bytes):
+        params = ioxml.XML_string_to_parameter(settings)
+        param_state = {'title': 'Infos Client:', 'name': 'settings_client', 'type': 'group', 'children': params}
+        self.settings.child('settings_client').restoreState(param_state)
+
+        self.axis_unit = self.settings['settings_client', 'units']
+
 
 
 if __name__ == '__main__':
-    main(__file__)
+    main(__file__, init=False)

--- a/src/pymodaq/utils/leco/daq_move_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_move_LECODirector.py
@@ -71,18 +71,11 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
             self.set_units,  # to set units accordingly to the one of the actor
             self.set_settings, # to show actor settings
         ))
-        for method in (
+
+        self.register_binary_rpc_methods((
             self.set_position,  # to display the actor position
             self.set_move_done,  # to set the move as done
-        ):
-            self.listener.register_binary_rpc_method(method, accept_binary_input=True)
-
-        # copied, I think it is good:
-        self.settings.child('bounds').hide()
-        self.settings.child('scaling').hide()
-        self.settings.child('units').hide()
-        self.settings.child('epsilon').hide()
-        self.settings.child('multiaxes').hide()
+        ))
 
     def commit_settings(self, param) -> None:
         self.commit_leco_settings(param=param)
@@ -189,8 +182,7 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
 
     def set_settings(self, settings: bytes):
         params = ioxml.XML_string_to_parameter(settings)
-        param_state = {'title': 'Infos Client:', 'name': 'settings_client', 'type': 'group', 'children': params}
-        self.settings.child('settings_client').restoreState(param_state)
+        self.settings.child('settings_client').addChildren(params)
 
         self.axis_unit = self.settings['settings_client', 'units']
 

--- a/src/pymodaq/utils/leco/daq_move_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_move_LECODirector.py
@@ -183,7 +183,6 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
     def set_settings(self, settings: bytes):
         params = ioxml.XML_string_to_parameter(settings)
         self.settings.child('settings_client').addChildren(params)
-
         self.axis_unit = self.settings['settings_client', 'units']
 
     def close(self) -> None:

--- a/src/pymodaq/utils/leco/director_utils.py
+++ b/src/pymodaq/utils/leco/director_utils.py
@@ -27,7 +27,7 @@ class GenericDirector(Director):
                           param_dict_str=ioxml.parameter_to_xml_string(param).decode())
 
     def set_info_str(self, path: List[str], param_dict_str: str) -> None:
-        self.ask_rpc(method="sef_info", path=path, param_dict_str=param_dict_str)
+        self.ask_rpc(method="set_info", path=path, param_dict_str=param_dict_str)
 
     def get_settings(self,) -> None:
         self.ask_rpc('get_settings')

--- a/src/pymodaq/utils/leco/director_utils.py
+++ b/src/pymodaq/utils/leco/director_utils.py
@@ -29,6 +29,10 @@ class GenericDirector(Director):
     def set_info_str(self, path: List[str], param_dict_str: str) -> None:
         self.ask_rpc(method="sef_info", path=path, param_dict_str=param_dict_str)
 
+    def get_settings(self,) -> None:
+        self.ask_rpc('get_settings')
+
+
 
 class DetectorDirector(GenericDirector):
     def send_data(self, grabber_type: str = "") -> None:
@@ -60,3 +64,4 @@ class ActuatorDirector(GenericDirector):
     def stop_motion(self,) -> None:
         # not implemented in DAQ_Move!
         self.ask_rpc("stop_motion")
+

--- a/src/pymodaq/utils/leco/director_utils.py
+++ b/src/pymodaq/utils/leco/director_utils.py
@@ -28,7 +28,7 @@ class GenericDirector(Director):
         # It removes the first two parts (main_settings and detector_settings?)
         pwp = ParameterWithPath(param, putils.get_param_path(param)[2:])
         self.ask_rpc(method="set_info",
-                     **binary_serialization_to_kwargs(pwp, 'parameter'))
+                     **binary_serialization_to_kwargs(pwp, data_key='parameter'))
 
     def get_settings(self,) -> None:
         self.ask_rpc('get_settings')

--- a/src/pymodaq/utils/leco/director_utils.py
+++ b/src/pymodaq/utils/leco/director_utils.py
@@ -11,7 +11,10 @@ from pyleco.directors.director import Director
 import pymodaq_gui.parameter.utils as putils
 from pymodaq_gui.parameter import Parameter, ioxml
 from pymodaq.control_modules.move_utility_classes import DataActuator
-from pymodaq.utils.leco.utils import binary_serialization_to_kwargs
+from pymodaq.utils.leco.utils import binary_serialization_to_kwargs, SerializableFactory
+
+from pymodaq_gui.parameter.utils import ParameterWithPath
+
 
 
 class GenericDirector(Director):
@@ -23,15 +26,12 @@ class GenericDirector(Director):
 
     def set_info(self, param: Parameter):
         # It removes the first two parts (main_settings and detector_settings?)
-        self.set_info_str(path=putils.get_param_path(param)[2:],
-                          param_dict_str=ioxml.parameter_to_xml_string(param).decode())
-
-    def set_info_str(self, path: List[str], param_dict_str: str) -> None:
-        self.ask_rpc(method="set_info", path=path, param_dict_str=param_dict_str)
+        pwp = ParameterWithPath(param, putils.get_param_path(param)[2:])
+        self.ask_rpc(method="set_info",
+                     **binary_serialization_to_kwargs(pwp, 'parameter'))
 
     def get_settings(self,) -> None:
         self.ask_rpc('get_settings')
-
 
 
 class DetectorDirector(GenericDirector):

--- a/src/pymodaq/utils/leco/leco_director.py
+++ b/src/pymodaq/utils/leco/leco_director.py
@@ -15,6 +15,7 @@ from pymodaq.utils.leco.pymodaq_listener import PymodaqListener
 leco_parameters = [
     {'title': 'Actor name:', 'name': 'actor_name', 'type': 'str', 'value': "actor_name",
      'tip': 'Name of the actor plugin to communicate with.'},
+    {'title': 'Settings PyMoDAQ Client:', 'name': 'settings_client', 'type': 'group', 'children': []},
 ]
 
 

--- a/src/pymodaq/utils/leco/leco_director.py
+++ b/src/pymodaq/utils/leco/leco_director.py
@@ -1,16 +1,18 @@
 
 import random
 
-from typing import Callable, Sequence, List
+from typing import Callable, Sequence, List, Optional, Union
 
 import pymodaq_gui.parameter.utils as putils
 # object used to send info back to the main thread:
 from pymodaq_utils.utils import ThreadCommand
 from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.parameter import ioxml
+from pymodaq_gui.parameter.utils import ParameterWithPath
 
 from pymodaq.utils.leco.director_utils import GenericDirector
 from pymodaq.utils.leco.pymodaq_listener import PymodaqListener
+from pymodaq_utils.serialize.factory import SerializableFactory
 
 
 leco_parameters = [
@@ -54,8 +56,14 @@ class LECODirector:
         self.listener.start_listen()
         self.communicator = self.listener.get_communicator()
         self.register_rpc_methods((
+        ))
+        self.register_binary_rpc_methods((
             self.set_info,
         ))
+
+    def register_binary_rpc_methods(self, methods: Sequence[Callable]) -> None:
+        for method in methods:
+            self.listener.register_binary_rpc_method(method, accept_binary_input=True)
 
     def register_rpc_methods(self, methods: Sequence[Callable]) -> None:
         for method in methods:
@@ -86,7 +94,9 @@ class LECODirector:
         super().emit_status(status=status)  # type: ignore
 
     # Methods accessible via remote calls
-    def set_info(self, path: List[str], param_dict_str: str) -> None:
-        param = Parameter.create(**ioxml.XML_string_to_parameter(param_dict_str)[0])
-        self.settings.child(*path[1:]).setValue(param.value())
-
+    def set_info(self,
+                 parameter: Optional[Union[float, str]],
+                 additional_payload: Optional[List[bytes]] = None,
+                 ) -> None:
+        param: ParameterWithPath = SerializableFactory().get_apply_deserializer(additional_payload[0])
+        self.settings.child(*param.path).setValue(param.value())

--- a/src/pymodaq/utils/leco/leco_director.py
+++ b/src/pymodaq/utils/leco/leco_director.py
@@ -1,6 +1,6 @@
 
 import random
-
+from enum import StrEnum
 from typing import Callable, Sequence, List, Optional, Union
 
 import pymodaq_gui.parameter.utils as putils
@@ -13,6 +13,15 @@ from pymodaq_gui.parameter.utils import ParameterWithPath
 from pymodaq.utils.leco.director_utils import GenericDirector
 from pymodaq.utils.leco.pymodaq_listener import PymodaqListener
 from pymodaq_utils.serialize.factory import SerializableFactory
+
+
+class DirectorImplementedMethods(StrEnum):
+    SET_SETTINGS = 'set_settings'
+    SET_INFO = 'set_info'
+
+    SEND_POSITION = 'send_position'  # to display the actor position
+    SET_MOVE_DONE = 'set_move_done'
+    SET_UNITS = 'set_units'  # to set units accordingly to the one of the actor
 
 
 leco_parameters = [
@@ -98,5 +107,16 @@ class LECODirector:
                  parameter: Optional[Union[float, str]],
                  additional_payload: Optional[List[bytes]] = None,
                  ) -> None:
+        """ Write the value of a param upfated from the actor to here in the
+        Parameter with path: ('move_settings', 'settings_client')
+        """
         param: ParameterWithPath = SerializableFactory().get_apply_deserializer(additional_payload[0])
-        self.settings.child(*param.path).setValue(param.value())
+
+        try:
+            path = ['settings_client']
+            path.extend(param.path[1:])
+
+            self.settings.child(*path).setValue(param.value())
+        except Exception as e:
+            print(f'could not set the param {param} in the director:\n'
+                  f'{str(e)}')

--- a/src/pymodaq/utils/leco/leco_director.py
+++ b/src/pymodaq/utils/leco/leco_director.py
@@ -7,6 +7,7 @@ import pymodaq_gui.parameter.utils as putils
 # object used to send info back to the main thread:
 from pymodaq_utils.utils import ThreadCommand
 from pymodaq_gui.parameter import Parameter
+from pymodaq_gui.parameter import ioxml
 
 from pymodaq.utils.leco.director_utils import GenericDirector
 from pymodaq.utils.leco.pymodaq_listener import PymodaqListener
@@ -86,4 +87,6 @@ class LECODirector:
 
     # Methods accessible via remote calls
     def set_info(self, path: List[str], param_dict_str: str) -> None:
-        self.emit_status(ThreadCommand("set_info", attribute=[path, param_dict_str]))
+        param = Parameter.create(**ioxml.XML_string_to_parameter(param_dict_str)[0])
+        self.settings.child(*path[1:]).setValue(param.value())
+

--- a/src/pymodaq/utils/leco/pymodaq_listener.py
+++ b/src/pymodaq/utils/leco/pymodaq_listener.py
@@ -31,11 +31,15 @@ class LECOClientCommands(StrEnum):
 class LECOCommands(StrEnum):
     CONNECT = "ini_connection"
     QUIT = "quit"
+    GET_SETTINGS = 'get_settings'
+    SET_SETTINGS = 'set_settings'
+    SET_SETTING = 'set_info'
 
 
 class LECOMoveCommands(StrEnum):
     POSITION = 'position_is'
     MOVE_DONE = 'move_done'
+    UNITS_CHANGED = 'units_changed'
 
 
 class LECOViewerCommands(StrEnum):
@@ -91,6 +95,7 @@ class ActorHandler(PymodaqPipeHandler):
         self.register_rpc_method(self.move_home)
         self.register_rpc_method(self.get_actuator_value)
         self.register_rpc_method(self.stop_motion)
+        self.register_rpc_method(self.get_settings)
 
     @staticmethod
     def extract_pymodaq_object(
@@ -108,6 +113,9 @@ class ActorHandler(PymodaqPipeHandler):
     # generic commands
     def set_info(self, path: List[str], param_dict_str: str) -> None:
         self.signals.cmd_signal.emit(ThreadCommand("set_info", attribute=[path, param_dict_str]))
+
+    def get_settings(self):
+        self.signals.cmd_signal.emit(ThreadCommand(LECOCommands.GET_SETTINGS))
 
     # detector commands
     def send_data(self, grabber_type: str = "") -> None:
@@ -295,6 +303,18 @@ class ActorListener(PymodaqListener):
                                       method="set_move_done",
                                       **binary_serialization_to_kwargs(value, data_key="position"),
                                       )
+
+        elif command.command == LECOMoveCommands.UNITS_CHANGED:
+            units: str = command.attribute
+            self.communicator.ask_rpc(receiver=self.remote_name,
+                                      method="set_units",
+                                      units=units.encode(),
+                                      )
+
+        elif command.command == LECOCommands.SET_SETTINGS:
+            self.communicator.ask_rpc(receiver=self.remote_name,
+                                      method='set_settings',
+                                      settings=ioxml.parameter_to_xml_string(command.attribute).decode())
 
         else:
             raise IOError('Unknown TCP client command')

--- a/src/pymodaq/utils/leco/pymodaq_listener.py
+++ b/src/pymodaq/utils/leco/pymodaq_listener.py
@@ -294,7 +294,7 @@ class ActorListener(PymodaqListener):
             if isinstance(value, (list, tuple)):
                 value = value[0]  # for backward compatibility with attributes list
             self.communicator.ask_rpc(receiver=self.remote_name,
-                                      method="set_position",
+                                      method="send_position",
                                       **binary_serialization_to_kwargs(pymodaq_object=value, data_key="position"),
                                       )
 

--- a/src/pymodaq/utils/leco/pymodaq_listener.py
+++ b/src/pymodaq/utils/leco/pymodaq_listener.py
@@ -90,7 +90,7 @@ class ActorHandler(PymodaqPipeHandler):
 
     def register_rpc_methods(self) -> None:
         super().register_rpc_methods()
-        self.register_rpc_method(self.set_info)
+        self.register_binary_rpc_method(self.set_info, accept_binary_input=True)
         self.register_rpc_method(self.send_data)
         self.register_binary_rpc_method(self.move_abs, accept_binary_input=True)
         self.register_binary_rpc_method(self.move_rel, accept_binary_input=True)
@@ -113,8 +113,12 @@ class ActorHandler(PymodaqPipeHandler):
         return res
 
     # generic commands
-    def set_info(self, path: List[str], param_dict_str: str) -> None:
-        self.signals.cmd_signal.emit(ThreadCommand("set_info", attribute=[path, param_dict_str]))
+    def set_info(self,
+                 parameter: Optional[Union[float, str]],
+                 additional_payload: Optional[List[bytes]] = None,
+                 ) -> None:
+        param: ParameterWithPath = SerializableFactory().get_apply_deserializer(additional_payload[0])
+        self.signals.cmd_signal.emit(ThreadCommand("set_info", attribute=param))
 
     def get_settings(self):
         self.signals.cmd_signal.emit(ThreadCommand(LECOCommands.GET_SETTINGS))
@@ -135,7 +139,7 @@ class ActorHandler(PymodaqPipeHandler):
         :param additional_payload: binary frames containing the position as PyMoDAQ `DataActuator`.
         """
         pos = self.extract_pymodaq_object(position, additional_payload)
-        self.signals.cmd_signal.emit(ThreadCommand("move_abs", attribute=[pos]))
+        self.signals.cmd_signal.emit(ThreadCommand("move_abs", attribute=pos))
 
     def move_rel(
         self,
@@ -148,7 +152,7 @@ class ActorHandler(PymodaqPipeHandler):
         :param additional_payload: binary frames containing the position as PyMoDAQ `DataActuator`.
         """
         pos = self.extract_pymodaq_object(position, additional_payload)
-        self.signals.cmd_signal.emit(ThreadCommand("move_rel", attribute=[pos]))
+        self.signals.cmd_signal.emit(ThreadCommand("move_rel", attribute=pos))
 
     def move_home(self) -> None:
         self.signals.cmd_signal.emit(ThreadCommand("move_home"))

--- a/src/pymodaq/utils/leco/pymodaq_listener.py
+++ b/src/pymodaq/utils/leco/pymodaq_listener.py
@@ -284,13 +284,10 @@ class ActorListener(PymodaqListener):
             )
 
         elif command.command == LECOCommands.SEND_INFO:
-            path = command.attribute['path']  # type: ignore
-            param = command.attribute['param']  # type: ignore
-            pwp = ParameterWithPath(param, path)
             self.communicator.ask_rpc(
                 receiver=self.remote_name,
                 method="set_info",
-                **binary_serialization_to_kwargs(pwp, data_key='parameter'))
+                **binary_serialization_to_kwargs(command.attribute, data_key='parameter'))
 
         elif command.command == LECOMoveCommands.POSITION:
             value = command.attribute

--- a/src/pymodaq/utils/leco/pymodaq_listener.py
+++ b/src/pymodaq/utils/leco/pymodaq_listener.py
@@ -320,7 +320,7 @@ class ActorListener(PymodaqListener):
         elif command.command == LECOCommands.SET_SETTINGS:
             self.communicator.ask_rpc(receiver=self.remote_name,
                                       method='set_settings',
-                                      settings=ioxml.parameter_to_xml_string(command.attribute).decode())
+                                      settings=command.attribute.decode())
 
         else:
             raise IOError('Unknown TCP client command')

--- a/src/pymodaq/utils/leco/pymodaq_listener.py
+++ b/src/pymodaq/utils/leco/pymodaq_listener.py
@@ -19,6 +19,7 @@ from pymodaq_data.data import DataWithAxes
 from pymodaq_utils.serialize.factory import SerializableFactory, SerializableBase
 from pymodaq_utils.utils import ThreadCommand
 from pymodaq_gui.parameter import ioxml
+from pymodaq_gui.parameter.utils import ParameterWithPath
 
 from pymodaq.utils.leco.utils import binary_serialization_to_kwargs
 
@@ -34,6 +35,7 @@ class LECOCommands(StrEnum):
     GET_SETTINGS = 'get_settings'
     SET_SETTINGS = 'set_settings'
     SET_INFO = 'set_info'
+    SEND_INFO = 'send_info'
 
 
 class LECOMoveCommands(StrEnum):
@@ -277,14 +279,14 @@ class ActorListener(PymodaqListener):
                 **binary_serialization_to_kwargs(value),
             )
 
-        elif command.command == 'send_info':
+        elif command.command == LECOCommands.SEND_INFO:
             path = command.attribute['path']  # type: ignore
             param = command.attribute['param']  # type: ignore
+            pwp = ParameterWithPath(param, path)
             self.communicator.ask_rpc(
                 receiver=self.remote_name,
                 method="set_info",
-                path=path,
-                param_dict_str=ioxml.parameter_to_xml_string(param).decode())
+                **binary_serialization_to_kwargs(pwp, data_key='parameter'))
 
         elif command.command == LECOMoveCommands.POSITION:
             value = command.attribute

--- a/src/pymodaq/utils/leco/pymodaq_listener.py
+++ b/src/pymodaq/utils/leco/pymodaq_listener.py
@@ -33,7 +33,7 @@ class LECOCommands(StrEnum):
     QUIT = "quit"
     GET_SETTINGS = 'get_settings'
     SET_SETTINGS = 'set_settings'
-    SET_SETTING = 'set_info'
+    SET_INFO = 'set_info'
 
 
 class LECOMoveCommands(StrEnum):


### PR DESCRIPTION
This PR solves three issues: #471 and #550  and #548 

The main issue was related to the fact the director never received the information about what are the actor's units. I recoded the same things as in the TCP/IP legacy, namely sending through the content of the actor settings from which the units are inferred. Once this has been done most issues with relative move and units where fine.

I nevertheless also added (or removed) the polling mechanism in the case of a director because the move_done signal is transmitted by the actor to the director so no need to poll (it would actually quite a bit of overwork)

Modifying settings of the actor from the Director is working and modifying the settings from the actor is updating the corresponding ones on the director