### PR TITLE
Feature/override detectors from extension

### DIFF
--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -121,6 +121,9 @@ class DAQ_Viewer(ParameterControlModule):
         self._viewer_types: List[ViewersEnum] = []
         self._viewers: List[ViewerBase] = []
 
+        self.override_grab_from_extension = False  # boolean allowing an extension to tell to init a grab or not
+        # (see DataMixer for reasons and use case in ModulesManager and dashboard method add_det_from_extension)
+
         if isinstance(parent, DockArea):
             self.dockarea = parent
         else:

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -8,7 +8,7 @@ import logging
 from pathlib import Path
 from importlib import import_module
 from packaging import version as version_mod
-from typing import Tuple, List, Any, TYPE_CHECKING
+from typing import Tuple, List, Any, TYPE_CHECKING, Sequence
 
 
 from qtpy import QtGui, QtWidgets, QtCore
@@ -65,13 +65,12 @@ roi_path = config_mod_pymodaq.get_set_roi_path()
 remote_path = config_mod_pymodaq.get_set_remote_path()
 
 
-
-
 class ManagerEnums(BaseEnum):
     preset = 0
     remote = 1
     overshoot = 2
     roi = 3
+
 
 class PymodaqUpdateTableWidget(QTableWidget):
     '''
@@ -114,10 +113,9 @@ class PymodaqUpdateTableWidget(QTableWidget):
         self.setItem(row, 2, QTableWidgetItem(str(current_version)))
         self.setItem(row, 3, QTableWidgetItem(str(available_version)))
 
-
     def get_checked_data(self):
-    	checked = list(map(lambda c : c.isChecked(), self._checkboxes))
-    	return list(np.array(self._package_versions)[checked])
+        checked = list(map(lambda c : c.isChecked(), self._checkboxes))
+        return list(np.array(self._package_versions)[checked])
 
     def sizeHint(self):
         self.resizeColumnsToContents()
@@ -133,6 +131,7 @@ class PymodaqUpdateTableWidget(QTableWidget):
         	   + sum([self.rowHeight(i) for i in range(self.rowCount())])
 
         return QSize(width, height)
+
 
 class DashBoard(CustomApp):
     """
@@ -967,13 +966,33 @@ class DashBoard(CustomApp):
         detector_modules.append(det_mod_tmp)
         return det_mod_tmp
 
+    def override_det_from_extension(self, overriden_grabbers: Sequence[str] = None):
+        """ (Experimental) If an extension adding detectors within the Dashboard need to, it could call this
+        method.
+
+        Then if some other extension trigger a grab from it, the request of a grab won't be done twice
+
+        Parameters
+        ----------
+        overriden_grabbers: Sequence[str]
+            sequence of detector names whose corresponding modules should set their
+            attribute override_grab_from_extension to True.
+        """
+        if overriden_grabbers is not None:
+            for mod_name in overriden_grabbers:
+                mod = self.modules_manager.get_mod_from_name(mod_name, 'det')
+                if mod is not None:
+                    mod.override_grab_from_extension = True
+
     def add_det_from_extension(self, name: str, daq_type: str, instrument_name: str,
                                instrument_controller: Any):
+
         """ Specific method to add a DAQ_Viewer within the Dashboard. This Particular detector
         should be defined in the plugin of the extension and is used to mimic a grab while data
         are actually coming from the extension which loaded it
 
         For an exemple, see the pymodaq_plugins_datamixer plugin and its DataMixer extension
+        or the DAQ_PID extension
 
         Parameters
         ----------

--- a/src/pymodaq/extensions/daq_scan.py
+++ b/src/pymodaq/extensions/daq_scan.py
@@ -1099,7 +1099,6 @@ class DAQScanAcquisition(QObject):
 
     def start_acquisition(self):
         try:
-            #todo hoaw to apply newlayout to adaptive mode? => cannot has to be a new extension
 
             self.modules_manager.connect_actuators()
             self.modules_manager.connect_detectors()
@@ -1124,20 +1123,6 @@ class DAQScanAcquisition(QObject):
                         positions = self.scanner.positions_at(self.ind_scan)  # get positions
                     else:
                         pass
-                        #todo update for v4
-                        # positions = learner.ask(1)[0][-1]  # next point to probe
-                        # if self.scanner.scan_type == 'Tabular':  # translate normalized curvilinear position to real coordinates
-                        #     self.curvilinear = positions
-                        #     length = 0.
-                        #     for v in self.scanner.vectors:
-                        #         length += v.norm()
-                        #         if length >= self.curvilinear:
-                        #             vec = v
-                        #             frac_curvilinear = (self.curvilinear - (length - v.norm())) / v.norm()
-                        #             break
-                        #
-                        #     position = (vec.vectorize() * frac_curvilinear).translate_to(vec.p1()).p2()
-                        #     positions = [position.x(), position.y()]
 
                     self.status_sig.emit(
                         utils.ThreadCommand("Update_scan_index",
@@ -1152,21 +1137,7 @@ class DAQScanAcquisition(QObject):
                     QThread.msleep(self.scan_settings['time_flow', 'wait_time_between'])
 
                     #grab datas and wait for grab completion
-                    self.det_done(self.modules_manager.grab_datas(positions=positions), positions)
-
-                    if self.isadaptive:
-                        #todo update for v4
-                        # det_channel = self.modules_manager.get_selected_probed_data()
-                        # det, channel = det_channel[0].split('/')
-                        # if self.scanner.scan_type == 'Tabular':
-                        #     self.curvilinear_array.append(np.array([self.curvilinear]))
-                        #     new_positions = self.curvilinear
-                        # elif self.scanner.scan_type == 'Scan1D':
-                        #     new_positions = positions[0]
-                        # else:
-                        #     new_positions = positions[:]
-                        # learner.tell(new_positions, self.modules_manager.det_done_datas[det]['data0D'][channel]['data'])
-                        pass
+                    self.det_done(self.modules_manager.grab_data(positions=positions), positions)
 
                     # daq_scan wait time
                     QThread.msleep(self.scan_settings.child('time_flow', 'wait_time').value())
@@ -1204,11 +1175,6 @@ class DAQScanAcquisition(QObject):
             self.status_sig.emit(
                 utils.ThreadCommand("add_data",
                                     dict(indexes=indexes, distribution=self.scanner.distribution)))
-
-            #todo related to adaptive (solution lies along the Enlargeable data saver)
-            if self.isadaptive:
-                for ind_ax, nav_axis in enumerate(self.navigation_axes):
-                    nav_axis.append(np.array(positions[ind_ax]))
 
             self.det_done_flag = True
 

--- a/src/pymodaq/utils/managers/modules_manager.py
+++ b/src/pymodaq/utils/managers/modules_manager.py
@@ -287,8 +287,15 @@ class ModulesManager(QObject, ParameterManager):
         """
         return self.settings.child('data_dimensions', f'det_data_list{dim.upper()}').value()['selected']
 
-    def grab_data(self, **kwargs):
-        """Do a single grab of connected and selected detectors"""
+    def grab_data(self, check_do_override=True, **kwargs):
+        """Do a single grab of connected and selected detectors
+
+        Parameter
+        ---------
+        check_do_override: bool
+            If this is True the signal emission to the DAQ_Viewers will be conditionned to the status of their internal
+            override_grab_from_extension attribute
+        """
         self.det_done_datas = DataToExport(name=__class__.__name__, control_module='DAQ_Viewer')
         self._received_data = 0
         self.det_done_flag = False
@@ -296,8 +303,9 @@ class ModulesManager(QObject, ParameterManager):
         tzero = time.perf_counter()
 
         for mod in self.detectors:
-            kwargs.update(dict(Naverage=mod.Naverage))
-            mod.command_hardware.emit(utils.ThreadCommand("single", kwargs))
+            if not (check_do_override and mod.override_grab_from_extension):
+                kwargs.update(dict(Naverage=mod.Naverage))
+                mod.command_hardware.emit(utils.ThreadCommand("single", kwargs))
 
         while not self.det_done_flag:
             # wait for grab done signals to end
@@ -493,7 +501,8 @@ class ModulesManager(QObject, ParameterManager):
             if len(data) != 0:
                 self.det_done_datas.append(data)
 
-            if self._received_data == len(self.detectors):
+            # if self._received_data == len(self.detectors):
+            if len(self.det_done_datas) == len(self.detectors):
                 self.det_done_flag = True
                 self.settings.child('det_done').setValue(self.det_done_flag)
 


### PR DESCRIPTION
This PR patch a problem with the fact that the output of the DataMixer extension can be added to the Dashboard to be used by other extensions such as the DAQ_Scan, hence calling twice a grab

Let's say I want to use the DataMixer to plot some interesting live data out of a detector call *mydet*. I'll have in the Dahsbord a real detector: *mydet* and a "fake" one: *mymixeddata*. If I do a scan of *mymixeddata* as a function of one or more parameters, the grab signal of *mydet* will be fired once by the datamixer. All is fine. **BUT** If I do a scan of *mymixeddata* and of *mydet* (to store the raw data) as a function of one or more parameters, the grab signal of *mydet* will be fired twice for each param. Once by the direct call of the daq_scan to *mydet* and once by  the datamixer. This is bad.

This PR introduces ways to correct for this effect.