### PR TITLE
Remove importlib from /docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,4 +11,3 @@ sphinx-datatables
 pymodaq_gui @ git+https://github.com/PyMoDAQ/pymodaq_gui.git@5.0.x_dev
 pymodaq_utils @ git+https://github.com/PyMoDAQ/pymodaq_utils.git@0.0.x_dev
 pymodaq_data @ git+https://github.com/PyMoDAQ/pymodaq_data.git@5.0.x_dev
-importlib


### PR DESCRIPTION
importlib included in the requirements make the build of an environment impossible to generate the documentation website.