### PR TITLE
Feature/si prefix dimensionless

### DIFF
--- a/docs/src/modules/DAQ_Move.rst
+++ b/docs/src/modules/DAQ_Move.rst
@@ -247,6 +247,7 @@ to tailor the module's behaviour. The various field are written below together w
     polling_timeout_s = 20  # s
     refresh_timeout_ms = 500  # ms
     siprefix = true
+    siprefix_even_without_units = false
     display_units = true
 
 * epsilon_default: default value for the actuator precision
@@ -254,6 +255,9 @@ to tailor the module's behaviour. The various field are written below together w
 * polling_timeout_s: Timeout in seconds during which the DAQ_Move tries to reach its target
 * refresh_timeout_ms: interval in millisecond for probing the actuator's value in continuous mode
 * siprefix: tell if printing of current value use a SI prefix or not (µ, m, k, M...)
+* siprefix_even_without_units: in case the controller is dimensionless (steps, ...) it could be misleading to include a
+  SI Prefix (as *m* could be understood either as meter or milli"nothing"). This boolean is False by default (no
+  SI Prefix when dimensionless) but this behaviour could be changed here
 * display_units: display units in the SpinBoxes
 
 

--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -632,7 +632,9 @@ class DAQ_Move(ParameterControlModule):
     def units(self, unit: str):
         self.settings.child('move_settings', 'units').setValue(unit)
         if self.ui is not None and config('actuator', 'display_units'):
-            self.ui.set_unit_as_suffix(self.get_unit_to_display(unit))
+            unit = self.get_unit_to_display(unit)
+            self.ui.set_unit_as_suffix(unit)
+            self.ui.set_unit_prefix(unit != '' or config('actuator', 'siprefix_even_without_units'))
 
     @staticmethod
     def get_unit_to_display(unit: str) -> str:

--- a/src/pymodaq/control_modules/daq_move_ui/ui_base.py
+++ b/src/pymodaq/control_modules/daq_move_ui/ui_base.py
@@ -188,6 +188,14 @@ class DAQ_Move_UI_Base(ControlModuleUI):
         self.abs_value_sb_2.setOpts(suffix=unit)
         self.rel_value_sb.setOpts(suffix=unit)
 
+    def set_unit_prefix(self, show=True):
+        """ Change the display status of the spinbox SI prefix"""
+        self.current_value_sb.setOpts(siPrefix=show)
+        self.abs_value_sb_bis.setOpts(siPrefix=show)
+        self.abs_value_sb.setOpts(siPrefix=show)
+        self.abs_value_sb_2.setOpts(siPrefix=show)
+        self.rel_value_sb.setOpts(siPrefix=show)
+
     def setup_docks(self):
         self.actuators_combo = QComboBox()
         self.abs_value_sb = QSpinBoxWithShortcut(step=0.1, dec=True, siPrefix=config('actuator', 'siprefix'))

--- a/src/pymodaq/resources/config_template.toml
+++ b/src/pymodaq/resources/config_template.toml
@@ -12,6 +12,7 @@ polling_timeout_s = 20  # s
 refresh_timeout_ms = 500  # ms
 timeout = 10000  # default duration in ms to wait for data to be acquirred
 siprefix = true  # tell if printing of current value use a SI prefix or not (µ, m, k, M...)
+siprefix_even_without_units = false
 display_units = true # display units in the SpinBoxes
 
 [actuator.binary]


### PR DESCRIPTION
in case the controller is dimensionless (steps, ...) it could be misleading to include a SI Prefix (as *m* could be understood either as meter or milli"nothing"). This PR is setting the SI prefix display to false by default and this can be tweaked by a configuration entry