### PR TITLE
popup settings given the config file entry: viewer/settings_as_popup

### DIFF
--- a/src/pymodaq/control_modules/daq_viewer_ui.py
+++ b/src/pymodaq/control_modules/daq_viewer_ui.py
@@ -152,13 +152,15 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
         self._detector_widget = QWidget()
         self._settings_widget = QWidget()
         self._settings_widget.setLayout(QtWidgets.QVBoxLayout())
+
         bkg_widget = QWidget()
         bkg_widget.setLayout(QtWidgets.QHBoxLayout())
 
         widget.layout().addWidget(info_ui)
         widget.layout().addWidget(self.toolbar)
         widget.layout().addWidget(self._detector_widget)
-        widget.layout().addWidget(self._settings_widget)
+        if not config('viewer', 'settings_as_popup'):
+            widget.layout().addWidget(self._settings_widget)
         widget.layout().addStretch(0)
 
         info_ui.setLayout(QtWidgets.QHBoxLayout())
@@ -218,7 +220,7 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
 
     def connect_things(self):
         self.connect_action('show_controls', lambda show: self._detector_widget.setVisible(show))
-        self.connect_action('show_settings', lambda show: self._settings_widget.setVisible(show))
+        self.connect_action('show_settings', self._show_settings)
         self.connect_action('quit', lambda: self.command_sig.emit(ThreadCommand(UiToMainViewer.QUIT, )))
         self.connect_action('show_config', lambda: self.command_sig.emit(ThreadCommand(UiToMainViewer.SHOW_CONFIG, )))
 
@@ -244,6 +246,10 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
 
         self._do_bkg_cb.clicked.connect(lambda checked: self.command_sig.emit(ThreadCommand(UiToMainViewer.DO_BKG, checked)))
         self._take_bkg_pb.clicked.connect(lambda: self.command_sig.emit(ThreadCommand(UiToMainViewer.TAKE_BKG)))
+
+    def _show_settings(self, show: bool = True):
+        self._settings_widget.setVisible(show)
+        self._settings_widget.closeEvent = lambda event: self.set_action_checked('show_settings', False)
 
     def update_viewers(self, viewers_type: List[ViewersEnum]):
         super().update_viewers(viewers_type)

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -1522,6 +1522,8 @@ class DashBoard(CustomApp):
                     area.window().setVisible(True)
                 messagebox(severity='critical', title="Preset loading error",
                          text=f"""
+                            <p>{error}<\p>
+                            <p>This error may be related to:</p>
                             <p>Saved preset file is not compatible anymore.</p>
                             <p>Please recreate the preset at <b>{filename}</b>.</p>
                  """)

--- a/src/pymodaq/resources/config_template.toml
+++ b/src/pymodaq/resources/config_template.toml
@@ -24,6 +24,7 @@ daq_type = 'DAQ0D' #either "DAQ0D", "DAQ1D", "DAQ2D", "DAQND"
 viewer_in_thread = true
 timeout = 10000  # default duration in ms to wait for data to be acquirred
 allow_settings_edition = false
+settings_as_popup = true
 
 [scan]
 scan_in_thread = true


### PR DESCRIPTION
I thought it would be nice to let you know of a recent feature introduced on the 5.1.x_dev branch (soon to be released) related to the size of the Dashboards. In this work, The UIs of the control modules have been reworked:

    For actuators, you can now use three types of UI. The one below is the new default, called Simple. It allows everything it did before with a design on a line for a more stackable design. All advanced features triggers popups such as the settings (see below)
    Other UIs includes: Original and Binary (specialized if you have only two values to trigger)
    You can set the defulat in the config file or within a preset for each actuator
    By default (as a boolean config), the settings of the viewer are also in a popup (see below) that you can close either using the closing cross button of the widget or clicking again on the settings button

![8In5iuCiMWFaA6yo](https://github.com/user-attachments/assets/dbcf340b-636d-4119-b577-f29c2f9c75e8)


Enjoy and let me know what you think of it!

Seb
-- 