### PR TITLE
updated import of pymodaq_gui config_saver_loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dependencies = [
     "pymodaq_utils==1.0.2", #use strictly this version (yanked) for the moment until we found a better way to handle versioning
-    "pymodaq_gui>=5.0.17",
+    "pymodaq_gui>=5.0.23",
     "pymodaq_data>=5.0.21",
     "easydict",
     "multipledispatch",

--- a/src/pymodaq/extensions/optimizers_base/optimizer.py
+++ b/src/pymodaq/extensions/optimizers_base/optimizer.py
@@ -25,7 +25,7 @@ from pymodaq_gui.utils import QLED
 from pymodaq_gui import utils as gutils
 from pymodaq_gui.parameter import utils as putils
 from pymodaq_gui.h5modules.saving import H5Saver
-from pymodaq_gui.config import ConfigSaverLoader
+from pymodaq_gui.config_saver_loader import ConfigSaverLoader
 
 from pymodaq.utils.data import DataToExport, DataToActuators, DataCalculated, DataActuator
 from pymodaq.post_treatment.load_and_plot import LoaderPlotter

--- a/src/pymodaq/utils/config.py
+++ b/src/pymodaq/utils/config.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from pymodaq_utils.config import (BaseConfig, ConfigError, get_set_config_dir,
                                   USER, CONFIG_BASE_PATH, get_set_local_dir)
-from pymodaq_gui.config import get_set_roi_path
+from pymodaq_gui.config_saver_loader import get_set_roi_path
 
 
 def get_set_preset_path():

--- a/src/pymodaq/utils/scanner/scan_factory.py
+++ b/src/pymodaq/utils/scanner/scan_factory.py
@@ -24,7 +24,7 @@ from pymodaq_gui.managers.parameter_manager import ParameterManager, Parameter
 from pymodaq_data.data import Axis, DataDistribution
 
 from pymodaq.utils.scanner.scan_config import ScanConfig
-from pymodaq_gui.config import ConfigSaverLoader
+from pymodaq_gui.config_saver_loader import ConfigSaverLoader
 from pymodaq.utils.config import Config as ControlModulesConfig
 
 


### PR DESCRIPTION
pymodaq_gui `config.py` file was renamed to `config_saver_loader.py` because of conflict in imports, so it need to be changed in pymodaq.

It needs a new release of pymodaq_gui