### PR TITLE
Hotfix/daq scan units

### DIFF
--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -810,7 +810,7 @@ class DAQ_Move_Hardware(QObject):
         position = check_units(position, self.hardware.axis_unit)
         self.hardware.move_is_done = False
         self.hardware.ispolling = polling
-        if self.hardware.data_actuator_type.name == 'float':
+        if self.hardware.data_actuator_type == self.hardware.data_actuator_type.float:
             self.hardware.move_abs(position.units_as(self.hardware.axis_unit).value()) # convert to plugin controller current axis units
         else:
             position.units = self.hardware.axis_unit  # convert to plugin controller current axis units

--- a/src/pymodaq/utils/scanner/scanner.py
+++ b/src/pymodaq/utils/scanner/scanner.py
@@ -119,7 +119,7 @@ class Scanner(QObject, ParameterManager):
         self.settings.child('n_steps').setValue(self._scanner.evaluate_steps())
 
     @property
-    def actuators(self):
+    def actuators(self) -> list[DAQ_Move]:
         """list of str: Returns as a list the name of the selected actuators to describe the actual scan"""
         return self._actuators
 
@@ -206,7 +206,8 @@ class Scanner(QObject, ParameterManager):
         """ Extract the actuators positions at a given index in the scan as a DataToExport of DataActuators"""
         dte = DataToExport('scanner')
         for ind, pos in enumerate(self.positions[index]):
-            dte.append(DataActuator(self.actuators[ind].title, data=float(pos)))
+            dte.append(DataActuator(self.actuators[ind].title, data=float(pos),
+                                    units=self.actuators[ind].units))
         return dte
 
     @property


### PR DESCRIPTION
this patch the behaviour where DataActuator without units (as it is until this patch from the daq_scan) are converted in units from the actuator.

In general, it cannot convert from no-units to actuator units so takes the magnitude and convert as is. However for angles the conversion is expressing the new DataActuator in degrees from angles as if they were in radians (radians, degree are not real units...). 

For instance, if I want to scan an actuator from 20 to 45 degrees, the conversion would try to go to rad2deg(20) to rad2deg(45)... most controller would complain...

Now the DAQ_Scan emits a DataActuator whose units is taken from the Actuator current base unit. At some point, the spinbox within the Daq_scan should be able to take in numbers with units...to make all this more explicit! 