### PR TITLE
Pass exc_info instead of concatenating messages

### DIFF
--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -783,7 +783,7 @@ class DAQ_Move_Hardware(QObject):
             try:
                 infos = self.hardware.ini_stage(controller)  # return edict(info="", controller=, stage=)
             except Exception as e:
-                logger.exception('Hardware couldn\'t be initialized' + str(e))
+                logger.exception('Hardware couldn\'t be initialized', exc_info = e)
                 infos = str(e), False
 
             if isinstance(infos, edict):  # following old plugin templating

--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -783,7 +783,7 @@ class DAQ_Move_Hardware(QObject):
             try:
                 infos = self.hardware.ini_stage(controller)  # return edict(info="", controller=, stage=)
             except Exception as e:
-                logger.exception('Hardware couldn\'t be initialized', exc_info = e)
+                logger.exception('Hardware couldn\'t be initialized', exc_info=e)
                 infos = str(e), False
 
             if isinstance(infos, edict):  # following old plugin templating

--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -783,7 +783,7 @@ class DAQ_Move_Hardware(QObject):
             try:
                 infos = self.hardware.ini_stage(controller)  # return edict(info="", controller=, stage=)
             except Exception as e:
-                logger.exception('Hardware couldn\'t be initialized', exc_info=e)
+                logger.exception("Hardware couldn't be initialized", exc_info=e)
                 infos = str(e), False
 
             if isinstance(infos, edict):  # following old plugin templating

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -1309,7 +1309,7 @@ class DAQ_Detector(QObject):
                 status.controller = self.detector.controller
 
             except Exception as e:
-                logger.exception('Hardware couldn\'t be initialized', exc_info=e)
+                logger.exception("Hardware couldn't be initialized", exc_info=e)
                 infos = str(e), False
                 status.controller = None
 

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -1309,7 +1309,7 @@ class DAQ_Detector(QObject):
                 status.controller = self.detector.controller
 
             except Exception as e:
-                logger.exception('Hardware couldn\'t be initialized' + str(e))
+                logger.exception('Hardware couldn\'t be initialized', exc_info = e)
                 infos = str(e), False
                 status.controller = None
 

--- a/src/pymodaq/control_modules/daq_viewer.py
+++ b/src/pymodaq/control_modules/daq_viewer.py
@@ -1309,7 +1309,7 @@ class DAQ_Detector(QObject):
                 status.controller = self.detector.controller
 
             except Exception as e:
-                logger.exception('Hardware couldn\'t be initialized', exc_info = e)
+                logger.exception('Hardware couldn\'t be initialized', exc_info=e)
                 infos = str(e), False
                 status.controller = None
 


### PR DESCRIPTION
With this change the error logs are clearer.
In particular "initializeddevice" is gone.

### Before
```python
2025-06-20 16:46:36,218 - pymodaq.daq_viewer - ERROR - Hardware couldn't be initializeddevice has to be a `SeaBreezeDevice`
Traceback (most recent call last):
  File "/home/ederag/share/prog/python/pymodaq/src/pymodaq/control_modules/daq_viewer.py", line 1308, in ini_detector
    infos = self.detector.ini_detector(controller)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/build/miniforge3/envs/pymodaq_dev_env/lib/python3.11/site-packages/pymodaq_plugins_oceaninsight/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Seabreeze.py", line 67, in ini_detector
    self.controller = Spectrometer(dvc)
                      ^^^^^^^^^^^^^^^^^
  File "/usr/local/build/miniforge3/envs/pymodaq_dev_env/lib/python3.11/site-packages/seabreeze/spectrometers.py", line 115, in __init__
    raise TypeError("device has to be a `SeaBreezeDevice`")
TypeError: device has to be a `SeaBreezeDevice`
```

### After
```python
2025-06-20 16:48:15,890 - pymodaq.daq_viewer - ERROR - Hardware couldn't be initialized
Traceback (most recent call last):
  File "/home/ederag/share/prog/python/pymodaq/src/pymodaq/control_modules/daq_viewer.py", line 1308, in ini_detector
    infos = self.detector.ini_detector(controller)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/build/miniforge3/envs/pymodaq_dev_env/lib/python3.11/site-packages/pymodaq_plugins_oceaninsight/daq_viewer_plugins/plugins_1D/daq_1Dviewer_Seabreeze.py", line 67, in ini_detector
    self.controller = Spectrometer(dvc)
                      ^^^^^^^^^^^^^^^^^
  File "/usr/local/build/miniforge3/envs/pymodaq_dev_env/lib/python3.11/site-packages/seabreeze/spectrometers.py", line 115, in __init__
    raise TypeError("device has to be a `SeaBreezeDevice`")
TypeError: device has to be a `SeaBreezeDevice`
```

cf. https://docs.python.org/3/library/logging.html#logging.Logger.exception

Context: https://github.com/LMSC-NTappy/pymodaq_plugins_oceanoptics_seabreeze/issues/1