### PR TITLE
Very basic handling of running presets directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ daq_logger = "pymodaq.extensions.daq_logger:main"
 daq_move = "pymodaq.control_modules.daq_move:main"
 daq_scan = "pymodaq.extensions.daq_scan:main"
 daq_viewer = "pymodaq.control_modules.daq_viewer:main"
-dashboard = "pymodaq.dashboard:main"
+dashboard = "pymodaq.dashboard_loader:main"
 h5browser = "pymodaq.extensions.h5browser:main"
 parameter_example = "pymodaq.examples.parameter_ex:main"
 

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -164,7 +164,7 @@ class DashBoard(CustomApp):
             {'title': 'Detectors Init.', 'name': 'detectors', 'type': 'group', 'children': []},
         ]
 
-    def __init__(self, dockarea, argv):
+    def __init__(self, dockarea, argv=[""]):
         """
 
         Parameters

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -164,7 +164,7 @@ class DashBoard(CustomApp):
             {'title': 'Detectors Init.', 'name': 'detectors', 'type': 'group', 'children': []},
         ]
 
-    def __init__(self, dockarea):
+    def __init__(self, dockarea, argv):
         """
 
         Parameters
@@ -210,7 +210,14 @@ class DashBoard(CustomApp):
 
         self.setup_ui()
 
-        self.mainwindow.setVisible(True)
+        # If a preset filename is given as command-line argument
+        # Start PyMoDAQ with the corresponding preset
+        if len(argv) > 1:
+            preset_filename = argv[1]
+            self.set_preset_mode(preset_filename)
+        # Else, start an empty dashboard
+        else:
+            self.mainwindow.setVisible(True)
 
         logger.info('Dashboard Initialized')
 
@@ -1747,7 +1754,7 @@ def main():
     win.resize(1000, 500)
     win.setWindowTitle('PyMoDAQ Dashboard')
 
-    prog = DashBoard(area)
+    prog = DashBoard(area, sys.argv)
 
     win.show()
 

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -164,7 +164,7 @@ class DashBoard(CustomApp):
             {'title': 'Detectors Init.', 'name': 'detectors', 'type': 'group', 'children': []},
         ]
 
-    def __init__(self, dockarea, argv=[""]):
+    def __init__(self, dockarea):
         """
 
         Parameters
@@ -210,14 +210,7 @@ class DashBoard(CustomApp):
 
         self.setup_ui()
 
-        # If a preset filename is given as command-line argument
-        # Start PyMoDAQ with the corresponding preset
-        if len(argv) > 1:
-            preset_filename = argv[1]
-            self.set_preset_mode(preset_filename)
-        # Else, start an empty dashboard
-        else:
-            self.mainwindow.setVisible(True)
+        self.mainwindow.setVisible(True)
 
         logger.info('Dashboard Initialized')
 
@@ -1741,25 +1734,3 @@ class DashBoard(CustomApp):
                 logging.info(txt)
         except Exception as e:
             pass
-
-
-def main():
-    from pymodaq_gui.utils.utils import mkQApp
-
-    app = mkQApp('Dashboard')
-
-    win = QtWidgets.QMainWindow()
-    area = DockArea()
-    win.setCentralWidget(area)
-    win.resize(1000, 500)
-    win.setWindowTitle('PyMoDAQ Dashboard')
-
-    prog = DashBoard(area, sys.argv)
-
-    win.show()
-
-    app.exec()
-
-
-if __name__ == '__main__':
-    main()

--- a/src/pymodaq/dashboard_loader.py
+++ b/src/pymodaq/dashboard_loader.py
@@ -1,0 +1,37 @@
+from qtpy import QtGui, QtWidgets, QtCore
+
+from pymodaq.dashboard import DashBoard
+
+from pymodaq_gui.utils import DockArea
+from pymodaq_gui.utils.utils import mkQApp
+
+from pymodaq.utils.gui_utils.loader_utils import load_dashboard_with_preset
+
+import sys
+
+
+def main():
+
+    app = mkQApp('Dashboard')
+
+    win = QtWidgets.QMainWindow()
+    area = DockArea()
+    win.setCentralWidget(area)
+    win.resize(1000, 500)
+    win.setWindowTitle('PyMoDAQ Dashboard')
+
+    # If supplied with a command-line argument, start with preset
+    if len(sys.argv) > 1:
+        preset_name = sys.argv[1]
+        load_dashboard_with_preset(preset_name)
+
+    # If no command-line arguments are supplied, start empty
+    else:
+        prog = DashBoard(area)
+        win.show()
+
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pymodaq/dashboard_loader.py
+++ b/src/pymodaq/dashboard_loader.py
@@ -7,7 +7,7 @@ from pymodaq_gui.utils.utils import mkQApp
 
 from pymodaq.utils.gui_utils.loader_utils import load_dashboard_with_preset
 
-import sys
+import argparse
 
 
 def main():
@@ -20,10 +20,14 @@ def main():
     win.resize(1000, 500)
     win.setWindowTitle('PyMoDAQ Dashboard')
 
-    # If supplied with a command-line argument, start with preset
-    if len(sys.argv) > 1:
-        preset_name = sys.argv[1]
-        load_dashboard_with_preset(preset_name)
+    # Command-line argument parsing
+    parser = argparse.ArgumentParser(prog="dashboard", description="PyMoDAQ dashboard")
+    parser.add_argument("-p", "--preset", metavar="PRESET_NAME", help="preset name to load")
+    args = parser.parse_args()
+
+    # If preset name is supplied, load dashboard with this preset
+    if args.preset:
+        load_dashboard_with_preset(args.preset)
 
     # If no command-line arguments are supplied, start empty
     else:

--- a/src/pymodaq/utils/gui_utils/loader_utils.py
+++ b/src/pymodaq/utils/gui_utils/loader_utils.py
@@ -8,7 +8,7 @@ from pymodaq.utils.config import get_set_preset_path
 from pymodaq.extensions.utils import CustomExt
 
 
-def load_dashboard_with_preset(preset_name: str, extension_name: str="") -> \
+def load_dashboard_with_preset(preset_name: str, extension_name: str = "") -> \
         (DashBoard, CustomExt, QtWidgets.QMainWindow):
     """ Load the Dashboard using a given preset then load an extension
 

--- a/src/pymodaq/utils/gui_utils/loader_utils.py
+++ b/src/pymodaq/utils/gui_utils/loader_utils.py
@@ -8,7 +8,7 @@ from pymodaq.utils.config import get_set_preset_path
 from pymodaq.extensions.utils import CustomExt
 
 
-def load_dashboard_with_preset(preset_name: str, extension_name: str) -> \
+def load_dashboard_with_preset(preset_name: str, extension_name: str="") -> \
         (DashBoard, CustomExt, QtWidgets.QMainWindow):
     """ Load the Dashboard using a given preset then load an extension
 
@@ -45,16 +45,21 @@ def load_dashboard_with_preset(preset_name: str, extension_name: str) -> \
 
     if file is not None and file.exists():
         dashboard.set_preset_mode(file)
-        if extension_name == 'DAQScan':
-            extension = dashboard.load_scan_module()
-        elif extension_name == 'DAQLogger':
-            extension = dashboard.load_log_module()
-        elif extension_name == 'DAQ_PID':
-            extension = dashboard.load_pid_module()
-        elif extension_name == 'Bayesian':
-            extension = dashboard.load_bayesian()
+
+        if extension_name:
+            if extension_name == 'DAQScan':
+                extension = dashboard.load_scan_module()
+            elif extension_name == 'DAQLogger':
+                extension = dashboard.load_log_module()
+            elif extension_name == 'DAQ_PID':
+                extension = dashboard.load_pid_module()
+            elif extension_name == 'Bayesian':
+                extension = dashboard.load_bayesian()
+            else:
+                extension = dashboard.load_extension_from_name(extension_name)
         else:
-            extension = dashboard.load_extension_from_name(extension_name)
+            extension = None
+
     else:
         msgBox = QtWidgets.QMessageBox()
         msgBox.setText(f"The default file specified in the configuration file does not exists!\n"


### PR DESCRIPTION
Added basic command-line handling to `dashboard` : the (optional) first command-line argument can be used to specify a preset file:
`$ dashboard /etc/.pymodaq/preset_configs/preset_default.xml`