### PR TITLE
Allow actor/director to connect to arbitrary coordinator host/port

### DIFF
--- a/src/pymodaq/control_modules/utils.py
+++ b/src/pymodaq/control_modules/utils.py
@@ -469,13 +469,25 @@ class ParameterControlModule(ParameterManager, ControlModule):
             name = self.settings.child("main_settings", "leco", "leco_name").setValue(name)
         return name
 
+    def get_leco_host_port(self) -> tuple:
+        host = self.settings["main_settings", "leco", "host"]
+        port = self.settings["main_settings", "leco", "port"]
+        if host == '':
+            # take the localhost as default
+            host = 'localhost'
+        if port == '':
+            # take the default port as 12300
+            port = 12300
+        return (host, port)    
+
     def connect_leco(self, connect: bool) -> None:
         if connect:
             name = self.get_leco_name()
+            host, port = self.get_leco_host_port()
             try:
                 self._leco_client.name = name
             except AttributeError:
-                self._leco_client = self.listener_class(name=name)
+                self._leco_client = self.listener_class(name=name, host=host, port=port)
                 self._leco_client.cmd_signal.connect(self.process_tcpip_cmds)
             self._command_tcpip[ThreadCommand].connect(self._leco_client.queue_command)
             self._leco_client.start_listen()

--- a/src/pymodaq/utils/leco/daq_move_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_move_LECODirector.py
@@ -46,11 +46,13 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
     socket_types = ["ACTUATOR"]
     params = comon_parameters_fun() + leco_parameters
 
-    def __init__(self, parent=None, params_state=None, host: str = None, **kwargs) -> None:
+    def __init__(self, parent=None, params_state=None, host: str = None, port : int = None, **kwargs) -> None:
         DAQ_Move_base.__init__(self, parent=parent, params_state=params_state)
         if host is not None:
             self.settings["host"] = host
-        LECODirector.__init__(self, host=self.settings["host"])
+        if port is not None:
+            self.settings["port"] = port
+        LECODirector.__init__(self, host=self.settings["host"], port=self.settings["port"])
         self.register_rpc_methods((
             self.set_info,
         ))

--- a/src/pymodaq/utils/leco/daq_move_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_move_LECODirector.py
@@ -46,9 +46,11 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
     socket_types = ["ACTUATOR"]
     params = comon_parameters_fun() + leco_parameters
 
-    def __init__(self, parent=None, params_state=None, **kwargs) -> None:
-        super().__init__(parent=parent,
-                         params_state=params_state, **kwargs)
+    def __init__(self, parent=None, params_state=None, host: str = None, **kwargs) -> None:
+        DAQ_Move_base.__init__(self, parent=parent, params_state=params_state)
+        if host is not None:
+            self.settings["host"] = host
+        LECODirector.__init__(self, host=self.settings["host"])
         self.register_rpc_methods((
             self.set_info,
         ))

--- a/src/pymodaq/utils/leco/daq_xDviewer_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_xDviewer_LECODirector.py
@@ -32,8 +32,11 @@ class DAQ_xDViewer_LECODirector(LECODirector, DAQ_Viewer_base):
     socket_types = ["GRABBER"]
     params = comon_parameters + leco_parameters
 
-    def __init__(self, parent=None, params_state=None, grabber_type: str = "0D", **kwargs) -> None:
-        super().__init__(parent=parent, params_state=params_state, **kwargs)
+    def __init__(self, parent=None, params_state=None, grabber_type: str = "0D", host: str = None, **kwargs) -> None:
+        DAQ_Viewer_base.__init__(self, parent=parent, params_state=params_state)
+        if host is not None:
+            self.settings["host"] = host
+        LECODirector.__init__(self, host=self.settings["host"])
         self.register_rpc_methods((
             self.set_x_axis,
             self.set_y_axis,

--- a/src/pymodaq/utils/leco/daq_xDviewer_LECODirector.py
+++ b/src/pymodaq/utils/leco/daq_xDviewer_LECODirector.py
@@ -32,15 +32,14 @@ class DAQ_xDViewer_LECODirector(LECODirector, DAQ_Viewer_base):
     socket_types = ["GRABBER"]
     params = comon_parameters + leco_parameters
 
-    def __init__(self, parent=None, params_state=None, grabber_type: str = "0D", host: str = None, **kwargs) -> None:
+    def __init__(self, parent=None, params_state=None, grabber_type: str = "0D", host: str = None, port: int = None, **kwargs) -> None:
         DAQ_Viewer_base.__init__(self, parent=parent, params_state=params_state)
         if host is not None:
             self.settings["host"] = host
-        LECODirector.__init__(self, host=self.settings["host"])
-        self.register_rpc_methods((
-            self.set_x_axis,
-            self.set_y_axis,
-        ))
+        if port is not None:
+            self.settings["port"] = port
+        LECODirector.__init__(self, host=self.settings["host"], port=self.settings["port"])
+
         for method in (
             self.set_data,
         ):

--- a/src/pymodaq/utils/leco/leco_director.py
+++ b/src/pymodaq/utils/leco/leco_director.py
@@ -1,6 +1,8 @@
 import random
 from typing import Callable, Sequence, List
 
+
+from pyleco.core import COORDINATOR_PORT
 from pymodaq_utils.enums import StrEnum
 from typing import Callable, Sequence, List, Optional, Union
 
@@ -48,12 +50,11 @@ class LECODirector:
     controller: GenericDirector
     settings: Parameter
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
+    def __init__(self, host: str = 'localhost', port : int = COORDINATOR_PORT, **kwargs) -> None:
 
         name = f'{self._title}_{random.randrange(0, 10000)}_director'
-        # TODO use the same Listener instance as the LECOActorModule
-        self.listener = PymodaqListener(name=name)
+
+        self.listener = PymodaqListener(name=name, host=host, port=port)
         self.listener.start_listen()
         self.communicator = self.listener.get_communicator()
         self.register_rpc_methods((

--- a/src/pymodaq/utils/leco/leco_director.py
+++ b/src/pymodaq/utils/leco/leco_director.py
@@ -5,6 +5,7 @@ from pymodaq_utils.enums import StrEnum
 from typing import Callable, Sequence, List, Optional, Union
 
 import pymodaq_gui.parameter.utils as putils
+from pymodaq_utils.config import Config
 # object used to send info back to the main thread:
 from pymodaq_utils.utils import ThreadCommand
 from pymodaq_gui.parameter import Parameter
@@ -12,10 +13,13 @@ from pymodaq_gui.parameter import Parameter
 from pymodaq.utils.leco.director_utils import GenericDirector
 from pymodaq.utils.leco.pymodaq_listener import PymodaqListener
 
+config = Config()
 
 leco_parameters = [
     {'title': 'Actor name:', 'name': 'actor_name', 'type': 'str', 'value': "actor_name",
      'tip': 'Name of the actor plugin to communicate with.'},
+    {'title': 'Coordinator Host:', 'name': 'host', 'type': 'str', 'value': config('network', "leco-server", "host")},
+    {'title': 'Coordinator Port:', 'name': 'port', 'type': 'int', 'value': config('network', "leco-server", "port")},     
 ]
 
 


### PR DESCRIPTION
I was having issues connecting my actor to a coordinator running on another computer or with an arbitrary port number. I found that we never actually passed the host and port that a user inputs in the GUI to the PymodaqListener during actor initialization. 

I added a function that will take these values and pass them to the listener class when the connect_leco() method is called.