### PR TITLE
bugfix/using_class_attributes_instead_of_instances_attributes

### DIFF
--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -12,15 +12,13 @@ from typing import Tuple, List, Any, TYPE_CHECKING, Sequence
 
 
 from qtpy import QtGui, QtWidgets, QtCore
-from qtpy.QtCore import Qt, QObject, Slot, QThread, Signal, QSize
+from qtpy.QtCore import Qt, QThread, Signal, QSize
 from qtpy.QtWidgets import (
     QTableWidget,
     QTableWidgetItem,
-    QCheckBox,
-    QWidget,
     QLabel,
     QDialogButtonBox,
-    QDialog,
+    QMessageBox,
 )
 from time import perf_counter
 import numpy as np
@@ -144,7 +142,7 @@ class DashBoard(CustomApp):
             "title": "Log level",
             "name": "log_level",
             "type": "list",
-            "value": config_utils("general", "debug_level"),
+            "value": config_utils("general", "debug_levels")[0],
             "limits": config_utils("general", "debug_levels"),
         },
         {
@@ -968,7 +966,7 @@ class DashBoard(CustomApp):
                 if modified:
                     self.remove_preset_related_files(path.name)
                     if self.detector_modules:
-                        mssg = QtWidgets.QMessageBox()
+                        mssg = QMessageBox()
                         mssg.setText(
                             "You have to restart the application to take the modifications"
                             " into account!\n\n"
@@ -1052,14 +1050,14 @@ class DashBoard(CustomApp):
 
     def restart_fun(self, ask=False):
         ret = False
-        mssg = QtWidgets.QMessageBox()
+        mssg = QMessageBox()
         if ask:
             mssg.setText(
                 "You have to restart the application to take the"
                 " modifications into account!"
             )
             mssg.setInformativeText("Do you want to restart?")
-            mssg.setStandardButtons(mssg.StandardButton.Ok | mssg.StandardButton.Ok)
+            mssg.setStandardButtons(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel)
             ret = mssg.exec()
 
         if ret == mssg.StandardButton.Ok or not ask:
@@ -2054,7 +2052,7 @@ class DashBoard(CustomApp):
 
             else:
                 if show:
-                    msgBox = QtWidgets.QMessageBox()
+                    msgBox = QMessageBox()
                     msgBox.setWindowTitle("Update check")
                     msgBox.setText("Everything is up to date!")
                     ret = msgBox.exec()
@@ -2097,9 +2095,9 @@ class DashBoard(CustomApp):
 
         vlayout.addWidget(tree)
         dialog.setLayout(vlayout)
-        buttonBox = QtWidgets.QDialogButtonBox(parent=dialog)
-        buttonBox.addButton("Cancel", buttonBox.RejectRole)
-        buttonBox.addButton("Apply", buttonBox.AcceptRole)
+        buttonBox = QDialogButtonBox(parent=dialog)
+        buttonBox.addButton("Cancel", QDialogButtonBox.ButtonRole.RejectRole)
+        buttonBox.addButton("Apply", QDialogButtonBox.ButtonRole.AcceptRole)
         buttonBox.rejected.connect(dialog.reject)
         buttonBox.accepted.connect(dialog.accept)
 

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -1059,10 +1059,10 @@ class DashBoard(CustomApp):
                 " modifications into account!"
             )
             mssg.setInformativeText("Do you want to restart?")
-            mssg.setStandardButtons(mssg.Ok | mssg.Cancel)
+            mssg.setStandardButtons(mssg.StandardButton.Ok | mssg.StandardButton.Ok)
             ret = mssg.exec()
 
-        if ret == mssg.Ok or not ask:
+        if ret == mssg.StandardButton.Ok or not ask:
             self.quit_fun()
             subprocess.call([sys.executable, __file__])
 

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -142,7 +142,7 @@ class DashBoard(CustomApp):
             "title": "Log level",
             "name": "log_level",
             "type": "list",
-            "value": config_utils("general", "debug_levels")[0],
+            "value": config_utils("general", "debug_level"),
             "limits": config_utils("general", "debug_levels"),
         },
         {

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -1061,7 +1061,7 @@ class DashBoard(CustomApp):
             mssg.setStandardButtons(QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel)
             ret = mssg.exec()
 
-        if ret == mssg.StandardButton.Ok or not ask:
+        if ret == QMessageBox.StandardButton.Ok or not ask:
             self.quit_fun()
             subprocess.call([sys.executable, __file__])
 

--- a/src/pymodaq/extensions/daq_scan.py
+++ b/src/pymodaq/extensions/daq_scan.py
@@ -16,6 +16,7 @@ from typing import List, Tuple, TYPE_CHECKING
 
 import numpy as np
 from qtpy import QtWidgets, QtCore, QtGui
+from qtpy.QtWidgets import QDialogButtonBox
 from qtpy.QtCore import QObject, Slot, QThread, Signal, QDateTime, QDate, QTime
 
 from pymodaq_utils.logger import set_logger, get_module_name
@@ -383,9 +384,9 @@ class DAQScan(QObject, ParameterManager):
 
             vlayout.addWidget(tree)
             dialog.setLayout(vlayout)
-            buttonBox = QtWidgets.QDialogButtonBox(parent=dialog)
-            buttonBox.addButton('Cancel', buttonBox.RejectRole)
-            buttonBox.addButton('Apply', buttonBox.AcceptRole)
+            buttonBox = QDialogButtonBox(parent=dialog)
+            buttonBox.addButton("Cancel", QDialogButtonBox.ButtonRole.RejectRole)
+            buttonBox.addButton("Apply", QDialogButtonBox.ButtonRole.AcceptRole)
             buttonBox.rejected.connect(dialog.reject)
             buttonBox.accepted.connect(dialog.accept)
 

--- a/src/pymodaq/utils/gui_utils/loader_utils.py
+++ b/src/pymodaq/utils/gui_utils/loader_utils.py
@@ -29,7 +29,7 @@ def load_dashboard_with_preset(preset_name: str, extension_name: str) -> \
     -------
 
     """
-    win = QtWidgets.QMainWindow()
+    win = QMainWindow()
     area = DockArea()
     win.setCentralWidget(area)
     win.resize(1000, 500)

--- a/src/pymodaq/utils/gui_utils/loader_utils.py
+++ b/src/pymodaq/utils/gui_utils/loader_utils.py
@@ -62,6 +62,6 @@ def load_dashboard_with_preset(preset_name: str, extension_name: str) -> \
         msgBox.setText(f"The default file specified in the configuration file does not exists!\n"
                        f"{file}\n"
                        f"Impossible to load the {extension_name} extension")
-        msgBox.setStandardButtons(msgBox.Ok)
+        msgBox.setStandardButtons(msgBox.StandardButton.Ok)
         ret = msgBox.exec()
     return dashboard, extension, win

--- a/src/pymodaq/utils/gui_utils/loader_utils.py
+++ b/src/pymodaq/utils/gui_utils/loader_utils.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from qtpy import QtWidgets
+from qtpy.QtWidgets import QMessageBox, QMainWindow
 
 from pymodaq.dashboard import DashBoard
 from pymodaq.utils.gui_utils import DockArea
@@ -9,7 +9,7 @@ from pymodaq.extensions.utils import CustomExt
 
 
 def load_dashboard_with_preset(preset_name: str, extension_name: str) -> \
-        (DashBoard, CustomExt, QtWidgets.QMainWindow):
+        (DashBoard, CustomExt, QMainWindow):
     """ Load the Dashboard using a given preset then load an extension
 
     Parameters
@@ -58,10 +58,10 @@ def load_dashboard_with_preset(preset_name: str, extension_name: str) -> \
         else:
             extension = dashboard.load_extension_from_name(extension_name)
     else:
-        msgBox = QtWidgets.QMessageBox()
+        msgBox = QMessageBox()
         msgBox.setText(f"The default file specified in the configuration file does not exists!\n"
                        f"{file}\n"
                        f"Impossible to load the {extension_name} extension")
-        msgBox.setStandardButtons(msgBox.StandardButton.Ok)
+        msgBox.setStandardButtons(QMessageBox.StandardButton.Ok)
         ret = msgBox.exec()
     return dashboard, extension, win

--- a/src/pymodaq/utils/managers/batchscan_manager.py
+++ b/src/pymodaq/utils/managers/batchscan_manager.py
@@ -62,10 +62,12 @@ class BatchManager(ParameterManager):
             msgBox = QtWidgets.QMessageBox()
             msgBox.setText("Scan Batch Manager?")
             msgBox.setInformativeText("What do you want to do?")
-            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.Cancel)
-            new_button = msgBox.addButton("New", QtWidgets.QMessageBox.ActionRole)
-            modify_button = msgBox.addButton('Modify', QtWidgets.QMessageBox.AcceptRole)
-            msgBox.setDefaultButton(QtWidgets.QMessageBox.Cancel)
+            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+            new_button = msgBox.addButton("New", QtWidgets.QMessageBox.ButtonRole.ActionRole)
+            modify_button = msgBox.addButton(
+                "Modify", QtWidgets.QMessageBox.ButtonRole.AcceptRole
+            )
+            msgBox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Cancel)
             ret = msgBox.exec()
 
             if msgBox.clickedButton() == new_button:
@@ -161,9 +163,9 @@ class BatchManager(ParameterManager):
 
         dialog.layout().addWidget(widget_all_settings)
         buttonBox = QtWidgets.QDialogButtonBox(parent=dialog)
-        buttonBox.addButton('Save', buttonBox.AcceptRole)
+        buttonBox.addButton('Save', buttonBox.ButtonRole.AcceptRole)
         buttonBox.accepted.connect(dialog.accept)
-        buttonBox.addButton('Cancel', buttonBox.RejectRole)
+        buttonBox.addButton("Cancel", buttonBox.ButtonRole.RejectRole)
         buttonBox.rejected.connect(dialog.reject)
 
         dialog.layout().addWidget(buttonBox)

--- a/src/pymodaq/utils/managers/batchscan_manager.py
+++ b/src/pymodaq/utils/managers/batchscan_manager.py
@@ -4,6 +4,7 @@ import sys
 from typing import List
 
 from qtpy import QtWidgets, QtCore
+from qtpy.QtWidgets import QMessageBox, QDialog, QDialogButtonBox
 
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils import config as config_mod
@@ -59,15 +60,13 @@ class BatchManager(ParameterManager):
         self.batch_path = path
 
         if msgbox:
-            msgBox = QtWidgets.QMessageBox()
+            msgBox = QMessageBox()
             msgBox.setText("Scan Batch Manager?")
             msgBox.setInformativeText("What do you want to do?")
-            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
-            new_button = msgBox.addButton("New", QtWidgets.QMessageBox.ButtonRole.ActionRole)
-            modify_button = msgBox.addButton(
-                "Modify", QtWidgets.QMessageBox.ButtonRole.AcceptRole
-            )
-            msgBox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+            cancel_button = msgBox.addButton(QMessageBox.StandardButton.Cancel)
+            new_button = msgBox.addButton("New", QMessageBox.ButtonRole.AcceptRole)
+            modify_button = msgBox.addButton('Modify', QMessageBox.ButtonRole.AcceptRole)
+            msgBox.setDefaultButton(QMessageBox.StandardButton.Cancel)
             ret = msgBox.exec()
 
             if msgBox.clickedButton() == new_button:
@@ -156,16 +155,16 @@ class BatchManager(ParameterManager):
     def show_tree(self):
 
 
-        dialog = QtWidgets.QDialog()
+        dialog = QDialog()
         dialog.setLayout(QtWidgets.QVBoxLayout())
 
         widget_all_settings = QtWidgets.QWidget()
 
         dialog.layout().addWidget(widget_all_settings)
-        buttonBox = QtWidgets.QDialogButtonBox(parent=dialog)
-        buttonBox.addButton('Save', buttonBox.ButtonRole.AcceptRole)
+        buttonBox = QDialogButtonBox(parent=dialog)
+        buttonBox.addButton("Save", QDialogButtonBox.ButtonRole.AcceptRole)
         buttonBox.accepted.connect(dialog.accept)
-        buttonBox.addButton("Cancel", buttonBox.ButtonRole.RejectRole)
+        buttonBox.addButton("Cancel", QDialogButtonBox.ButtonRole.RejectRole)
         buttonBox.rejected.connect(dialog.reject)
 
         dialog.layout().addWidget(buttonBox)
@@ -188,11 +187,11 @@ class BatchManager(ParameterManager):
 
         res = dialog.exec()
 
-        if res == dialog.Accepted:
+        if res == QDialog.DialogCode.Accepted:
             ioxml.parameter_to_xml_file(
                 self.settings, self.batch_path.joinpath(self.settings.child('filename').value()))
 
-        return res == dialog.Accepted
+        return res == QDialog.DialogCode.Accepted
 
     def set_scanner_settings(self, settings_tree: QtWidgets.QWidget):
         while True:

--- a/src/pymodaq/utils/managers/overshoot_manager.py
+++ b/src/pymodaq/utils/managers/overshoot_manager.py
@@ -124,10 +124,14 @@ class OvershootManager:
             msgBox = QtWidgets.QMessageBox()
             msgBox.setText("Overshoot Manager?")
             msgBox.setInformativeText("What do you want to do?")
-            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.Cancel)
-            new_button = msgBox.addButton("New", QtWidgets.QMessageBox.ActionRole)
-            modify_button = msgBox.addButton('Modify', QtWidgets.QMessageBox.AcceptRole)
-            msgBox.setDefaultButton(QtWidgets.QMessageBox.Cancel)
+            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+            new_button = msgBox.addButton(
+                "New", QtWidgets.QMessageBox.ButtonRole.ActionRole
+            )
+            modify_button = msgBox.addButton(
+                "Modify", QtWidgets.QMessageBox.ButtonRole.AcceptRole
+            )
+            msgBox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Cancel)
             ret = msgBox.exec()
 
             if msgBox.clickedButton() == new_button:

--- a/src/pymodaq/utils/managers/overshoot_manager.py
+++ b/src/pymodaq/utils/managers/overshoot_manager.py
@@ -1,4 +1,5 @@
 from qtpy import QtWidgets
+from qtpy.QtWidgets import QMessageBox, QDialogButtonBox, QDialog
 import sys
 import os
 
@@ -121,17 +122,13 @@ class OvershootManager:
         self._activated = False
 
         if msgbox:
-            msgBox = QtWidgets.QMessageBox()
+            msgBox = QMessageBox()
             msgBox.setText("Overshoot Manager?")
             msgBox.setInformativeText("What do you want to do?")
-            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
-            new_button = msgBox.addButton(
-                "New", QtWidgets.QMessageBox.ButtonRole.ActionRole
-            )
-            modify_button = msgBox.addButton(
-                "Modify", QtWidgets.QMessageBox.ButtonRole.AcceptRole
-            )
-            msgBox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+            cancel_button = msgBox.addButton(QMessageBox.StandardButton.Cancel)
+            new_button = msgBox.addButton("New", QMessageBox.ButtonRole.ActionRole)
+            modify_button = msgBox.addButton("Modify", QMessageBox.ButtonRole.AcceptRole)
+            msgBox.setDefaultButton(QMessageBox.StandardButton.Cancel)
             ret = msgBox.exec()
 
             if msgBox.clickedButton() == new_button:
@@ -177,7 +174,7 @@ class OvershootManager:
         """
 
         """
-        dialog = QtWidgets.QDialog()
+        dialog = QDialog()
         vlayout = QtWidgets.QVBoxLayout()
         tree = ParameterTree()
         tree.setMinimumWidth(400)
@@ -186,18 +183,18 @@ class OvershootManager:
 
         vlayout.addWidget(tree)
         dialog.setLayout(vlayout)
-        buttonBox = QtWidgets.QDialogButtonBox(parent=dialog)
+        buttonBox = QDialogButtonBox(parent=dialog)
 
-        buttonBox.addButton('Save', buttonBox.AcceptRole)
+        buttonBox.addButton("Save", QDialogButtonBox.ButtonRole.AcceptRole)
         buttonBox.accepted.connect(dialog.accept)
-        buttonBox.addButton('Cancel', buttonBox.RejectRole)
+        buttonBox.addButton("Cancel", QDialogButtonBox.ButtonRole.RejectRole)
         buttonBox.rejected.connect(dialog.reject)
 
         vlayout.addWidget(buttonBox)
         dialog.setWindowTitle('Fill in information about this managers')
         res = dialog.exec()
 
-        if res == dialog.Accepted:
+        if res == QDialog.DialogCode.Accepted:
             # save managers parameters in a xml file
             # start = os.path.split(os.path.split(os.path.realpath(__file__))[0])[0]
             # start = os.path.join("..",'daq_scan')

--- a/src/pymodaq/utils/managers/preset_manager.py
+++ b/src/pymodaq/utils/managers/preset_manager.py
@@ -40,10 +40,14 @@ class PresetManager:
             msgBox = QtWidgets.QMessageBox()
             msgBox.setText("Preset Manager?")
             msgBox.setInformativeText("What do you want to do?")
-            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.Cancel)
-            new_button = msgBox.addButton("New", QtWidgets.QMessageBox.ActionRole)
-            modify_button = msgBox.addButton("Modify", QtWidgets.QMessageBox.AcceptRole)
-            msgBox.setDefaultButton(QtWidgets.QMessageBox.Cancel)
+            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+            new_button = msgBox.addButton(
+                "New", QtWidgets.QMessageBox.ButtonRole.ActionRole
+            )
+            modify_button = msgBox.addButton(
+                "Modify", QtWidgets.QMessageBox.ButtonRole.AcceptRole
+            )
+            msgBox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Cancel)
             ret = msgBox.exec()
 
             if msgBox.clickedButton() == new_button:

--- a/src/pymodaq/utils/managers/preset_manager.py
+++ b/src/pymodaq/utils/managers/preset_manager.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import sys
 
 from qtpy import QtWidgets
+from qtpy.QtWidgets import QMessageBox, QDialogButtonBox, QDialog
 
 import pymodaq_utils.config as config_mod
 from pymodaq_utils.logger import set_logger, get_module_name
@@ -37,17 +38,17 @@ class PresetManager:
         self.preset_params: Parameter = None
 
         if msgbox:
-            msgBox = QtWidgets.QMessageBox()
+            msgBox = QMessageBox()
             msgBox.setText("Preset Manager?")
             msgBox.setInformativeText("What do you want to do?")
-            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+            cancel_button = msgBox.addButton(QMessageBox.StandardButton.Cancel)
             new_button = msgBox.addButton(
-                "New", QtWidgets.QMessageBox.ButtonRole.ActionRole
+                "New", QMessageBox.ButtonRole.ActionRole
             )
             modify_button = msgBox.addButton(
-                "Modify", QtWidgets.QMessageBox.ButtonRole.AcceptRole
+                "Modify", QMessageBox.ButtonRole.AcceptRole
             )
-            msgBox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+            msgBox.setDefaultButton(QMessageBox.StandardButton.Cancel)
             ret = msgBox.exec()
 
             if msgBox.clickedButton() == new_button:
@@ -151,7 +152,7 @@ class PresetManager:
 
     def show_preset(self):
         """ """
-        dialog = QtWidgets.QDialog()
+        dialog = QDialog()
         vlayout = QtWidgets.QVBoxLayout()
         tree = ParameterTree()
         # tree.setMinimumWidth(400)
@@ -161,11 +162,11 @@ class PresetManager:
 
         vlayout.addWidget(tree)
         dialog.setLayout(vlayout)
-        buttonBox = QtWidgets.QDialogButtonBox(parent=dialog)
+        buttonBox = QDialogButtonBox(parent=dialog)
 
-        buttonBox.addButton("Save", buttonBox.AcceptRole)
+        buttonBox.addButton("Save", QDialogButtonBox.ButtonRole.AcceptRole)
         buttonBox.accepted.connect(dialog.accept)
-        buttonBox.addButton("Cancel", buttonBox.RejectRole)
+        buttonBox.addButton("Cancel", QDialogButtonBox.ButtonRole.RejectRole)
         buttonBox.rejected.connect(dialog.reject)
 
         vlayout.addWidget(buttonBox)
@@ -175,7 +176,7 @@ class PresetManager:
         path = self.preset_path
         file = None
 
-        if res == dialog.Accepted:
+        if res == QDialog.DialogCode.Accepted:
             # save managers parameters in a xml file
             # start = os.path.split(os.path.split(os.path.realpath(__file__))[0])[0]
             # start = os.path.join("..",'daq_scan')
@@ -217,7 +218,7 @@ class PresetManager:
             layout_file = layout_path.joinpath(self.filename + ".dock")
             layout_file.unlink(missing_ok=True)
 
-        return res == dialog.Accepted
+        return res == QDialog.DialogCode.Accepted
 
 
 if __name__ == "__main__":

--- a/src/pymodaq/utils/managers/remote_manager.py
+++ b/src/pymodaq/utils/managers/remote_manager.py
@@ -3,6 +3,7 @@ import sys
 
 from qtpy.QtCore import QObject, Signal
 from qtpy import QtGui, QtWidgets
+from qtpy.QtWidgets import QMessageBox, QDialogButtonBox, QDialog
 
 
 from pymodaq.utils.config import get_set_remote_path
@@ -153,9 +154,9 @@ class ShortcutSelection(QtWidgets.QDialog):
         hor_layout.addWidget(label)
         hor_layout.addWidget(self.label)
 
-        buttonBox = QtWidgets.QDialogButtonBox()
-        buttonBox.addButton(QtWidgets.QDialogButtonBox.Ok)
-        buttonBox.addButton(QtWidgets.QDialogButtonBox.Cancel)
+        buttonBox = QDialogButtonBox()
+        buttonBox.addButton(QDialogButtonBox.StandardButton.Ok)
+        buttonBox.addButton(QDialogButtonBox.StandardButton.Cancel)
         layout.addWidget(self.label)
         layout.addWidget(buttonBox)
 
@@ -244,9 +245,9 @@ class JoystickButtonsSelection(QtWidgets.QDialog):
 
         layout.addWidget(self.settings_tree)
 
-        buttonBox = QtWidgets.QDialogButtonBox()
-        buttonBox.addButton(QtWidgets.QDialogButtonBox.Ok)
-        buttonBox.addButton(QtWidgets.QDialogButtonBox.Cancel)
+        buttonBox = QDialogButtonBox()
+        buttonBox.addButton(QDialogButtonBox.StandardButton.Ok)
+        buttonBox.addButton(QDialogButtonBox.StandardButton.Cancel)
         layout.addWidget(buttonBox)
 
         buttonBox.accepted.connect(self.accept)
@@ -261,17 +262,17 @@ class RemoteManager(QObject):
         self.actuators = actuators
         self.detectors = detectors
         if msgbox:
-            msgBox = QtWidgets.QMessageBox()
+            msgBox = QMessageBox()
             msgBox.setText("Preset Manager?")
             msgBox.setInformativeText("What do you want to do?")
-            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+            cancel_button = msgBox.addButton(QMessageBox.StandardButton.Cancel)
             new_button = msgBox.addButton(
-                "New", QtWidgets.QMessageBox.ButtonRole.ActionRole
+                "New", QMessageBox.ButtonRole.ActionRole
             )
             modify_button = msgBox.addButton(
-                "Modify", QtWidgets.QMessageBox.ButtonRole.AcceptRole
+                "Modify", QMessageBox.ButtonRole.AcceptRole
             )
-            msgBox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+            msgBox.setDefaultButton(QMessageBox.StandardButton.Cancel)
             ret = msgBox.exec()
 
             if msgBox.clickedButton() == new_button:
@@ -447,7 +448,7 @@ class RemoteManager(QObject):
         """
 
         """
-        dialog = QtWidgets.QDialog()
+        dialog = QDialog()
         vlayout = QtWidgets.QVBoxLayout()
         tree = ParameterTree()
         # tree.setMinimumWidth(400)
@@ -456,18 +457,18 @@ class RemoteManager(QObject):
 
         vlayout.addWidget(tree)
         dialog.setLayout(vlayout)
-        buttonBox = QtWidgets.QDialogButtonBox(parent=dialog)
+        buttonBox = QDialogButtonBox(parent=dialog)
 
-        buttonBox.addButton('Save', buttonBox.AcceptRole)
+        buttonBox.addButton("Save", QDialogButtonBox.ButtonRole.AcceptRole)
         buttonBox.accepted.connect(dialog.accept)
-        buttonBox.addButton('Cancel', buttonBox.RejectRole)
+        buttonBox.addButton("Cancel", QDialogButtonBox.ButtonRole.RejectRole)
         buttonBox.rejected.connect(dialog.reject)
 
         vlayout.addWidget(buttonBox)
         dialog.setWindowTitle('Fill in information about the actions and their shortcuts')
         res = dialog.exec()
 
-        if res == dialog.Accepted:
+        if res == QDialog.DialogCode.Accepted:
             # save preset parameters in a xml file
             ioxml.parameter_to_xml_file(
                 self.remote_params, os.path.join(remote_path, self.remote_params.child('filename').value()))

--- a/src/pymodaq/utils/managers/remote_manager.py
+++ b/src/pymodaq/utils/managers/remote_manager.py
@@ -264,10 +264,14 @@ class RemoteManager(QObject):
             msgBox = QtWidgets.QMessageBox()
             msgBox.setText("Preset Manager?")
             msgBox.setInformativeText("What do you want to do?")
-            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.Cancel)
-            new_button = msgBox.addButton("New", QtWidgets.QMessageBox.ActionRole)
-            modify_button = msgBox.addButton('Modify', QtWidgets.QMessageBox.AcceptRole)
-            msgBox.setDefaultButton(QtWidgets.QMessageBox.Cancel)
+            cancel_button = msgBox.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
+            new_button = msgBox.addButton(
+                "New", QtWidgets.QMessageBox.ButtonRole.ActionRole
+            )
+            modify_button = msgBox.addButton(
+                "Modify", QtWidgets.QMessageBox.ButtonRole.AcceptRole
+            )
+            msgBox.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Cancel)
             ret = msgBox.exec()
 
             if msgBox.clickedButton() == new_button:


### PR DESCRIPTION
Restart function in dashboard is not working with PySide6 giving the error

Traceback (most recent call last):
  File "c:\Users\constant.schouder\Documents\PyMoDAQ\PyMoDAQ\src\pymodaq\dashboard.py", line 1065, in restart_fun
    if ret == mssg.Ok or not ask:
AttributeError: 'PySide6.QtWidgets.QMessageBox' object has no attribute 'Ok'


This PR changes the call by using the explicit path to the attribute
`mssg.Ok` == ) `mssg.StandardButton.Ok`
`mssg.Cancel` == ) `mssg.StandardButton.Cancel`




Edit:

After some discussions (https://github.com/PyMoDAQ/pymodaq_gui/pull/70), this PR now explicily adresses the use of class attributes instead of instances attributes. 