### PR TITLE
Bugfix/dashboard python3.13

### DIFF
--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -1800,7 +1800,7 @@ class DashBoard(CustomApp):
                     severity="critical",
                     title="Preset loading error",
                     text=f"""
-                            <p>{error}<\p>
+                            <p>{error}</p>
                             <p>This error may be related to:</p>
                             <p>Saved preset file is not compatible anymore.</p>
                             <p>Please recreate the preset at <b>{filename}</b>.</p>

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -259,12 +259,11 @@ class DashBoard(CustomApp):
             if self.check_update(show=False):
                 sys.exit(0)
 
-    @classmethod
     @property
-    def splash_sc(cls) -> QtWidgets.QSplashScreen:
-        if cls._splash_sc is None:
-            cls._splash_sc = get_splash_sc()
-        return cls._splash_sc
+    def splash_sc(self) -> QtWidgets.QSplashScreen:
+        if not hasattr(self, "_splash_sc") or self._splash_sc is None:
+            self._splash_sc = get_splash_sc()
+        return self._splash_sc
 
     def set_preset_path(self, path):
         self.preset_path = path


### PR DESCRIPTION
This PR is related to #668

The class method looks obsolete looking at its use in the dashboard. This PR removes it to make the use of the dashboard compatible with python 3.13
