### PR TITLE
feature/use_list_ordering_instead_of_value_in_config

### DIFF
--- a/docs/src/user_folder/configuration.rst
+++ b/docs/src/user_folder/configuration.rst
@@ -71,7 +71,6 @@ Below is a non exhaustive list of configuration entries stored in the *config_py
         pwd = "pymodaq"
 
     [general]
-    debug_level = "DEBUG" #either "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
     debug_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
     check_version = true  #automatically check version at startup
 
@@ -96,6 +95,8 @@ Below is a non exhaustive list of configuration entries stored in the *config_py
     default_preset_for_scan = "preset_default"
     default_preset_for_logger = "preset_default"
 
+For list entries, the default value used by PyMoDAQ is the first one. You can change it either by modifying the file
+ and placing the desired value as the first element or directly from the GUI by selecting it from the combo box.
 
 .. _plugins_configuration_files:
 

--- a/docs/src/user_folder/configuration.rst
+++ b/docs/src/user_folder/configuration.rst
@@ -97,8 +97,8 @@ Below is a non exhaustive list of configuration entries stored in the *config_py
 
 .. important::
 
-  For list entries, the default value used by PyMoDAQ is the first one. You can change it either by modifying the file
-  and placing the desired value as the first element or directly from the GUI by selecting it from the combo box.
+   For list entries, the default value used by PyMoDAQ is the first one. You can change it either by modifying the file
+   and placing the desired value as the first element or directly from the GUI by selecting it from the combo box.
 
 
 .. _plugins_configuration_files:

--- a/docs/src/user_folder/configuration.rst
+++ b/docs/src/user_folder/configuration.rst
@@ -95,8 +95,11 @@ Below is a non exhaustive list of configuration entries stored in the *config_py
     default_preset_for_scan = "preset_default"
     default_preset_for_logger = "preset_default"
 
-For list entries, the default value used by PyMoDAQ is the first one. You can change it either by modifying the file
- and placing the desired value as the first element or directly from the GUI by selecting it from the combo box.
+.. important::
+
+  For list entries, the default value used by PyMoDAQ is the first one. You can change it either by modifying the file
+  and placing the desired value as the first element or directly from the GUI by selecting it from the combo box.
+
 
 .. _plugins_configuration_files:
 

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -145,7 +145,7 @@ class DashBoard(CustomApp):
             "title": "Log level",
             "name": "log_level",
             "type": "list",
-            "value": config_utils("general", "debug_level"),
+            "value": config_utils("general", "debug_levels")[0],
             "limits": config_utils("general", "debug_levels"),
         },
         {


### PR DESCRIPTION
Related to https://github.com/PyMoDAQ/pymodaq_gui/pull/71
- use first value of lists for the debug entry in the config file
- Update the docs