### PR TITLE
Feature/dashboard add actuator UI type

### DIFF
--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -1168,6 +1168,7 @@ class DashBoard(CustomApp):
 
     def add_move_from_extension(
         self, name: str, instrument_name: str, instrument_controller: Any,
+            ui_identifier = None,
             **kwargs
     ):
         """Specific method to add a DAQ_Move within the Dashboard. This Particular actuator
@@ -1186,9 +1187,13 @@ class DashBoard(CustomApp):
         instrument_controller: object
             whatever object is used to communicate between the instrument module and the extension
             which created it
+        ui_identifier: str
+            One of the possible registered UI
         kwargs: named arguments to be passed to add_move
         """
-        actuator = self.add_move(name, None, instrument_name, [], [], [], **kwargs)
+        actuator = self.add_move(name, None, instrument_name, [], [], [],
+                                 ui_identifier=ui_identifier,
+                                 **kwargs)
         actuator.controller = instrument_controller
         actuator.master = False
         actuator.init_hardware_ui()

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -1099,15 +1099,19 @@ class DashBoard(CustomApp):
             self.save_layout_state(path)
 
     def add_move(
-        self,
-        plug_name: str = None,
-        plug_settings: Parameter = None,
-        plug_type: str = None,
-        move_docks: list[Dock] = [],
-        move_forms: list[QtWidgets.QWidget] = [],
-        actuators_modules: list[DAQ_Move] = [],
+            self,
+            plug_name: str = None,
+            plug_settings: Parameter = None,
+            plug_type: str = None,
+            move_docks: list[Dock] = [],
+            move_forms: list[QtWidgets.QWidget] = [],
+            actuators_modules: list[DAQ_Move] = [],
+            ui_identifier: str = None,
+            **kwargs
     ) -> DAQ_Move:
-        if plug_settings is None:
+        if ui_identifier is not None:
+            pass
+        elif plug_settings is None:
             ui_identifier = config("actuator", "ui")
         else:
             try:
@@ -1163,7 +1167,8 @@ class DashBoard(CustomApp):
         return mov_mod_tmp
 
     def add_move_from_extension(
-        self, name: str, instrument_name: str, instrument_controller: Any
+        self, name: str, instrument_name: str, instrument_controller: Any,
+            **kwargs
     ):
         """Specific method to add a DAQ_Move within the Dashboard. This Particular actuator
         should be defined in the plugin of the extension and is used to mimic an actuator while
@@ -1181,8 +1186,9 @@ class DashBoard(CustomApp):
         instrument_controller: object
             whatever object is used to communicate between the instrument module and the extension
             which created it
+        kwargs: named arguments to be passed to add_move
         """
-        actuator = self.add_move(name, None, instrument_name, [], [], [])
+        actuator = self.add_move(name, None, instrument_name, [], [], [], **kwargs)
         actuator.controller = instrument_controller
         actuator.master = False
         actuator.init_hardware_ui()


### PR DESCRIPTION
 allow to specify explicitly the ui_identifier for actuators

so in order, ui type is set from:

* the argument: ui_identifier
* if None, check if defined in the settings: (preset case)
* if None, use the default one set in the config