### PR TITLE
move_rel can now take a simple float  but still use axis unit (like move_abs)

### DIFF
--- a/src/pymodaq/control_modules/daq_move.py
+++ b/src/pymodaq/control_modules/daq_move.py
@@ -826,7 +826,7 @@ class DAQ_Move_Hardware(QObject):
         self.hardware.ispolling = polling
 
         if self.hardware.data_actuator_type.name == 'float':
-            self.hardware.move_rel(rel_position.value())
+            self.hardware.move_rel(rel_position.units_as(self.hardware.axis_unit).value())
         else:
             rel_position.units = self.hardware.axis_unit  # convert to plugin current axis units
             self.hardware.move_rel(rel_position)


### PR DESCRIPTION
Fixes #685 