### PR TITLE
Feature/add units to scan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dependencies = [
     "pymodaq_utils >= 1.0.2", #use strictly this version (yanked) for the moment until we found a better way to handle versioning
-    "pymodaq_gui>=5.0.23",
+    "pymodaq_gui>=5.0.25",
     "pymodaq_data>=5.0.21",
     "easydict",
     "multipledispatch",

--- a/src/pymodaq/extensions/daq_scan.py
+++ b/src/pymodaq/extensions/daq_scan.py
@@ -604,7 +604,7 @@ class DAQScan(QObject, ParameterManager):
         actuators = self.modules_manager.actuators
         dte = data_mod.DataToExport(name="move_at")
         for ind, pos in enumerate(positions):
-            dte.append(DataActuator(actuators[ind].title, data=float(pos)))
+            dte.append(DataActuator(actuators[ind].title, data=float(pos), units=actuators[ind].units))
 
         self.modules_manager.move_actuators(dte, polling=False)
 

--- a/src/pymodaq/utils/scanner/scan_factory.py
+++ b/src/pymodaq/utils/scanner/scan_factory.py
@@ -87,11 +87,12 @@ class ScannerBase(ScanParameterManager, metaclass=ABCMeta):
     distribution: DataDistribution = abstract_attribute()
     save_settings = True
 
-    def __init__(self, actuators: List[DAQ_Move] = None):
+    def __init__(self, actuators: List[DAQ_Move] = None, display_units=True):
         super().__init__()
         self.positions: np.ndarray = None
         self.n_steps = 1
         self.config = ScanConfig()
+        self.display_units = display_units
         base_path = [act.title for act in actuators] + [self.scan_type, self.scan_subtype]
 
         self.config_saver_loader = ConfigSaverLoader(self.settings,
@@ -102,9 +103,16 @@ class ScannerBase(ScanParameterManager, metaclass=ABCMeta):
 
         self.set_settings_titles()
         self.set_settings_values()
+        if len(actuators) > 0:
+            self.set_units()
 
         if self.check_steps():
             self.set_scan()
+
+    @abstractmethod
+    def set_units(self):
+        """ Update settings units depending on the scanner type and the display_units boolean"""
+        ...
 
     def set_settings_titles(self):
         """Update the settings accordingly with the selected actuators"""

--- a/src/pymodaq/utils/scanner/scan_selector.py
+++ b/src/pymodaq/utils/scanner/scan_selector.py
@@ -311,9 +311,7 @@ class ScanSelector(ParameterManager, QObject):
         self.table_view.horizontalHeader().setStretchLastSection(True)
         self.table_view.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.table_view.setSelectionMode(QtWidgets.QTableView.SingleSelection)
-        styledItemDelegate = QtWidgets.QStyledItemDelegate()
-        styledItemDelegate.setItemEditorFactory(gutils.SpinBoxDelegate())
-        self.table_view.setItemDelegate(styledItemDelegate)
+        self.table_view.setItemDelegate(gutils.SpinBoxDelegate())
 
         self.table_view.setDragEnabled(False)
         self.table_view.setDropIndicatorShown(False)

--- a/src/pymodaq/utils/scanner/scanner.py
+++ b/src/pymodaq/utils/scanner/scanner.py
@@ -56,8 +56,8 @@ class Scanner(QObject, ParameterManager):
          'limits': scanner_factory.scan_sub_types(scanner_factory.scan_types()[0])},
         {'title': 'Units handling', 'name': 'units_handling', 'type': 'group', 'children': [
             {'title': 'Display units', 'name': 'display_units', 'type': 'bool', 'value': True},
-            {'title': 'Use same units', 'name': 'use_same_units', 'type': 'bool', 'value': False},
-            {'title': 'Common units', 'name': 'common_units', 'type': 'str', 'value': '', 'visible': False},
+            {'title': 'Default units', 'name': 'common_units', 'type': 'str', 'value': '', 'visible': False,
+             'readonly': True},
             ]},
 
     ]
@@ -128,21 +128,20 @@ class Scanner(QObject, ParameterManager):
             self.settings.child('scan_type').setOpts(tip=self._scanner.__doc__)
             self.settings.child('scan_sub_type').setOpts(tip=self._scanner.__doc__)
         elif param.name() == 'display_units':
-            self.settings.child('units_handling', 'use_same_units').setValue(not param.value())
-            self.set_scanner()
-        elif param.name() == 'use_same_units':
-            self.settings.child('units_handling', 'display_units').setValue(not param.value())
-            self.settings.child('units_handling', 'common_units').show(param.value())
-            if param.value() and len(self.actuators) > 0:
+            if not param.value() and len(self.actuators) > 0:
+
                 units = set([act.units for act in self.actuators])
                 if len(units) > 1:
                     messagebox(title='Info',
                                text='Could not use the same units for all settings as units are not compatible')
-                    param.setValue(False)
+                    param.setValue(True)
+                    self.settings.child('units_handling', 'common_units').show(False)
                 else:
                     self.settings.child('units_handling', 'common_units').setValue(list(units)[0])
-                    self.set_scanner()
-
+                    self.settings.child('units_handling', 'common_units').show(True)
+            else:
+                self.settings.child('units_handling', 'common_units').show(False)
+            self.set_scanner()
 
         self.settings.child('n_steps').setValue(self._scanner.evaluate_steps())
 

--- a/src/pymodaq/utils/scanner/scanner.py
+++ b/src/pymodaq/utils/scanner/scanner.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from qtpy.QtCore import QObject, Signal
 from qtpy import QtWidgets
 
+from pymodaq_gui.messenger import messagebox
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.config import Config
 import pymodaq_utils.utils as utils
@@ -54,9 +55,9 @@ class Scanner(QObject, ParameterManager):
         {'title': 'Scan subtype:', 'name': 'scan_sub_type', 'type': 'list',
          'limits': scanner_factory.scan_sub_types(scanner_factory.scan_types()[0])},
         {'title': 'Units handling', 'name': 'units_handling', 'type': 'group', 'children': [
-            {'title': 'Display units', 'name': 'display_units', 'type': 'bool', 'value': False},
-            {'title': 'Use same units', 'name': 'use_same_units', 'type': 'bool', 'value': True},
-            {'title': 'Common units', 'name': 'common_units', 'type': 'str', 'value': ''},
+            {'title': 'Display units', 'name': 'display_units', 'type': 'bool', 'value': True},
+            {'title': 'Use same units', 'name': 'use_same_units', 'type': 'bool', 'value': False},
+            {'title': 'Common units', 'name': 'common_units', 'type': 'str', 'value': '', 'visible': False},
             ]},
 
     ]
@@ -106,8 +107,6 @@ class Scanner(QObject, ParameterManager):
 
             self._scanner_settings_widget.layout().addWidget(self._scanner.settings_tree)
             self._scanner.settings.sigTreeStateChanged.connect(self._update_steps)
-            if len(self.actuators) > 0:
-                self.settings.child('units_handling', 'common_units').setValue(self.actuators[0].units)
 
         except ValueError as e:
             pass
@@ -124,7 +123,7 @@ class Scanner(QObject, ParameterManager):
         if param.name() == 'scan_type':
             self.settings.child('scan_sub_type').setOpts(
                 limits=scanner_factory.scan_sub_types(param.value()))
-        if param.name() in ['scan_type', 'scan_sub_type']:
+        if param.name() in ['scan_sub_type']:
             self.set_scanner()
             self.settings.child('scan_type').setOpts(tip=self._scanner.__doc__)
             self.settings.child('scan_sub_type').setOpts(tip=self._scanner.__doc__)
@@ -134,7 +133,16 @@ class Scanner(QObject, ParameterManager):
         elif param.name() == 'use_same_units':
             self.settings.child('units_handling', 'display_units').setValue(not param.value())
             self.settings.child('units_handling', 'common_units').show(param.value())
-            self.set_scanner()
+            if param.value() and len(self.actuators) > 0:
+                units = set([act.units for act in self.actuators])
+                if len(units) > 1:
+                    messagebox(title='Info',
+                               text='Could not use the same units for all settings as units are not compatible')
+                    param.setValue(False)
+                else:
+                    self.settings.child('units_handling', 'common_units').setValue(list(units)[0])
+                    self.set_scanner()
+
 
         self.settings.child('n_steps').setValue(self._scanner.evaluate_steps())
 
@@ -265,10 +273,12 @@ def main():
     from pymodaq.utils.parameter import ParameterTree
     app = QtWidgets.QApplication(sys.argv)
 
+    units = ['nm', 'kW', 'ms']
+
     class MoveMock:
         def __init__(self, ind: int = 0):
             self.title = f'act_{ind}'
-            self.units = f'units_{ind}'
+            self.units = units[ind]
 
     actuators = [MoveMock(ind) for ind in range(3)]
 

--- a/src/pymodaq/utils/scanner/scanner.py
+++ b/src/pymodaq/utils/scanner/scanner.py
@@ -53,6 +53,12 @@ class Scanner(QObject, ParameterManager):
          'limits': scanner_factory.scan_types()},
         {'title': 'Scan subtype:', 'name': 'scan_sub_type', 'type': 'list',
          'limits': scanner_factory.scan_sub_types(scanner_factory.scan_types()[0])},
+        {'title': 'Units handling', 'name': 'units_handling', 'type': 'group', 'children': [
+            {'title': 'Display units', 'name': 'display_units', 'type': 'bool', 'value': False},
+            {'title': 'Use same units', 'name': 'use_same_units', 'type': 'bool', 'value': True},
+            {'title': 'Common units', 'name': 'common_units', 'type': 'str', 'value': ''},
+            ]},
+
     ]
 
     def __init__(self, parent_widget: QtWidgets.QWidget = None, scanner_items=OrderedDict([]),
@@ -85,9 +91,11 @@ class Scanner(QObject, ParameterManager):
 
     def set_scanner(self):
         try:
-            self._scanner: ScannerBase = scanner_factory.get(self.settings['scan_type'],
-                                                             self.settings['scan_sub_type'],
-                                                             actuators=self.actuators)
+            self._scanner: ScannerBase = scanner_factory.get(
+                self.settings['scan_type'],
+                self.settings['scan_sub_type'],
+                actuators=self.actuators,
+                display_units=self.settings['units_handling', 'display_units'])
 
             while True:
                 child = self._scanner_settings_widget.layout().takeAt(0)
@@ -98,6 +106,8 @@ class Scanner(QObject, ParameterManager):
 
             self._scanner_settings_widget.layout().addWidget(self._scanner.settings_tree)
             self._scanner.settings.sigTreeStateChanged.connect(self._update_steps)
+            if len(self.actuators) > 0:
+                self.settings.child('units_handling', 'common_units').setValue(self.actuators[0].units)
 
         except ValueError as e:
             pass
@@ -118,6 +128,13 @@ class Scanner(QObject, ParameterManager):
             self.set_scanner()
             self.settings.child('scan_type').setOpts(tip=self._scanner.__doc__)
             self.settings.child('scan_sub_type').setOpts(tip=self._scanner.__doc__)
+        elif param.name() == 'display_units':
+            self.settings.child('units_handling', 'use_same_units').setValue(not param.value())
+            self.set_scanner()
+        elif param.name() == 'use_same_units':
+            self.settings.child('units_handling', 'display_units').setValue(not param.value())
+            self.settings.child('units_handling', 'common_units').show(param.value())
+            self.set_scanner()
 
         self.settings.child('n_steps').setValue(self._scanner.evaluate_steps())
 

--- a/src/pymodaq/utils/scanner/scanners/_1d_scanners.py
+++ b/src/pymodaq/utils/scanner/scanners/_1d_scanners.py
@@ -32,8 +32,14 @@ class Scan1DBase(ScannerBase):
     n_axes = 1
     distribution = DataDistribution['uniform']
 
-    def __init__(self, actuators: List = None, **_ignored):
-        super().__init__(actuators=actuators)
+    def __init__(self, actuators: List = None, display_units=True, **_ignored):
+        super().__init__(actuators=actuators, display_units=display_units)
+
+    def set_units(self):
+        """ Update settings units depending on the scanner type and the display_units boolean"""
+        for child in self.settings.children():
+            child.setOpts(
+                suffix='' if not self.display_units else self.actuators[0].units)
 
     def get_nav_axes(self) -> List[Axis]:
         return [Axis(label=f'{self.actuators[0].title}',
@@ -64,8 +70,9 @@ class Scan1DLinear(Scan1DBase):
     n_axes = 1
     distribution = DataDistribution['uniform']
 
-    def __init__(self, actuators: List['DAQ_Move'] = None, **_ignored):
-        super().__init__(actuators=actuators)
+    def __init__(self, actuators: List['DAQ_Move'] = None, display_units=True, **_ignored):
+        super().__init__(actuators=actuators, display_units=display_units)
+
 
     def set_scan(self):
         self.positions = mutils.linspace_step(self.settings['start'], self.settings['stop'],
@@ -96,8 +103,8 @@ class Scan1DRandom(Scan1DLinear):
 
     scan_subtype = 'Random'
 
-    def __init__(self, actuators: List = None, **_ignored):
-        super().__init__(actuators=actuators)
+    def __init__(self, actuators: List = None, display_units=True, **_ignored):
+        super().__init__(actuators=actuators, display_units=display_units)
 
     def set_scan(self):
         self.positions = mutils.linspace_step(self.settings['start'], self.settings['stop'],
@@ -128,8 +135,8 @@ class Scan1DSparse(Scan1DBase):
     distribution = DataDistribution['uniform']  # because in 1D it doesn't matter is spread or
     # uniform, one can easily plot both types on a regulat 1D plot
 
-    def __init__(self, actuators: List['DAQ_Move'] = None, **_ignored):
-        super().__init__(actuators=actuators)
+    def __init__(self, actuators: List['DAQ_Move'] = None, display_units=True, **_ignored):
+        super().__init__(actuators=actuators, display_units=display_units)
         self.settings.child('parsed_string').setOpts(tip=self.__doc__)
 
     def set_scan(self):

--- a/src/pymodaq/utils/scanner/scanners/_2d_scanners.py
+++ b/src/pymodaq/utils/scanner/scanners/_2d_scanners.py
@@ -69,9 +69,14 @@ class Scan2DLinear(Scan2DBase):
 
     def set_units(self):
         """ Update settings units depending on the scanner type and the display_units boolean"""
-        for ind_child, child in enumerate(self.settings.children()):
-            child.setOpts(
-                suffix='' if not self.display_units else self.actuators[ind_child//3].units)
+        if len(self.actuators) > 0:
+            for child in self.settings.child('axis1').children():
+                child.setOpts(
+                    suffix='' if not self.display_units else self.actuators[0].units)
+        if len(self.actuators) > 1:
+            for child in self.settings.child('axis2').children():
+                child.setOpts(
+                    suffix='' if not self.display_units else self.actuators[1].units)
 
     def get_pos(self):
         starts = np.array([self.settings[ax, f'start_{ax}'] for ax in self.axes])

--- a/src/pymodaq/utils/scanner/scanners/_2d_scanners.py
+++ b/src/pymodaq/utils/scanner/scanners/_2d_scanners.py
@@ -32,8 +32,8 @@ class Scan2DBase(ScannerBase):
                 ]
     axes = ('axis1','axis2')    
     n_axes = 2
-    def __init__(self, actuators: List['DAQ_Move'] = None, **_ignored):
-        super().__init__(actuators=actuators)
+    def __init__(self, actuators: List['DAQ_Move'] = None, display_units=True, **_ignored):
+        super().__init__(actuators=actuators, display_units=display_units)
         self.axes_unique = []
 
         
@@ -64,8 +64,14 @@ class Scan2DLinear(Scan2DBase):
     scan_type = 'Scan2D'
     scan_subtype = 'Linear'
 
-    def __init__(self, actuators: List['DAQ_Move'] = None, **_ignored):
-        super().__init__(actuators=actuators)
+    def __init__(self, actuators: List['DAQ_Move'] = None, display_units=True, **_ignored):
+        super().__init__(actuators=actuators, display_units=display_units)
+
+    def set_units(self):
+        """ Update settings units depending on the scanner type and the display_units boolean"""
+        for ind_child, child in enumerate(self.settings.children()):
+            child.setOpts(
+                suffix='' if not self.display_units else self.actuators[ind_child//3].units)
 
     def get_pos(self):
         starts = np.array([self.settings[ax, f'start_{ax}'] for ax in self.axes])
@@ -133,8 +139,8 @@ class Scan2DLinear(Scan2DBase):
 class Scan2DLinearBF(Scan2DLinear):
     scan_subtype = 'LinearBackForce'
 
-    def __init__(self, actuators: List['DAQ_Move'] = None, **_ignored):
-        super().__init__(actuators=actuators)
+    def __init__(self, actuators: List['DAQ_Move'] = None, display_units=True, **_ignored):
+        super().__init__(actuators=actuators, display_units=display_units)
 
     def set_scan(self):
         starts, stops, steps = self.get_pos()
@@ -163,8 +169,8 @@ class Scan2DLinearBF(Scan2DLinear):
 class Scan2DRandom(Scan2DLinear):
     scan_subtype = 'Random'
 
-    def __init__(self, actuators: List['DAQ_Move'] = None, **_ignored):
-        super().__init__(actuators=actuators)
+    def __init__(self, actuators: List['DAQ_Move'] = None, display_units=True, **_ignored):
+        super().__init__(actuators=actuators, display_units=display_units)
 
     def set_scan(self):
         super().set_scan()
@@ -197,8 +203,8 @@ class Scan2DSpiral(Scan2DLinear):
                ]},
               ]  
    
-    def __init__(self, actuators: List['DAQ_Move'] = None, **_ignored):
-        super().__init__(actuators=actuators)
+    def __init__(self, actuators: List['DAQ_Move'] = None, display_units=True, **_ignored):
+        super().__init__(actuators=actuators, display_units=display_units)
 
     def set_settings_titles(self):
         if len(self.actuators) == 2:

--- a/src/pymodaq/utils/scanner/scanners/sequential.py
+++ b/src/pymodaq/utils/scanner/scanners/sequential.py
@@ -4,7 +4,7 @@ Created the 05/12/2022
 
 @author: Sebastien Weber
 """
-from typing import List, Tuple, TYPE_CHECKING
+from typing import List, Tuple, TYPE_CHECKING, Iterable
 
 import numpy as np
 
@@ -38,7 +38,7 @@ class TableModelSequential(gutils.TableModel):
         editable = [False, True, True, True]
         if 'editable' in kwargs:
             editable = kwargs.pop('editable')
-        super().__init__(data, header, editable=editable, **kwargs)
+        super().__init__(data, header, editable=editable, cast=str, **kwargs)
 
     def __repr__(self):
         return f'{self.__class__.__name__} from module {self.__class__.__module__}'
@@ -98,6 +98,7 @@ class SequentialScanner(ScannerBase):
         self.table_model: TableModelSequential = None
         self.table_view: TableViewCustom = None
         super().__init__(actuators, display_units=display_units)
+        self.delegates: Iterable[gutils.SpinBoxDelegate] = []
         self.update_model()
 
     def set_units(self):
@@ -170,9 +171,13 @@ class SequentialScanner(ScannerBase):
         #self.table_view.horizontalHeader().setStretchLastSection(True)
         self.table_view.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.table_view.setSelectionMode(QtWidgets.QTableView.SingleSelection)
+        self.delegates = []  # ItemDelegates should have parents and be instance attribute to work with setItemDelegateForColumn
         for ind_actuator, actuator in enumerate(self.actuators):
-            styledItemDelegate = gutils.SpinBoxDelegate(units=actuator.units if self.display_units else None)
-            self.table_view.setItemDelegateForRow(ind_actuator, styledItemDelegate)
+
+            self.delegates.append(gutils.SpinBoxDelegate(self.table_view,
+                                                         units=actuator.units if self.display_units else None))
+            self.table_view.setItemDelegateForRow(
+                ind_actuator, self.delegates[-1])
 
         self.table_view.setDragEnabled(True)
         self.table_view.setDropIndicatorShown(True)

--- a/src/pymodaq/utils/scanner/scanners/sequential.py
+++ b/src/pymodaq/utils/scanner/scanners/sequential.py
@@ -13,6 +13,8 @@ from pymodaq_data.data import Axis, DataDistribution
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils import math_utils as mutils
 from pymodaq_utils import config as configmod
+from pymodaq_data import Q_
+
 from pymodaq_gui import utils as gutils
 from ..scan_factory import ScannerFactory, ScannerBase, ScanParameterManager
 from pymodaq_gui.parameter import utils as putils
@@ -54,9 +56,9 @@ class TableModelSequential(gutils.TableModel):
         -------
         bool: True is the new value is fine (change some other values if needed) otherwise False
         """
-        start = self.data(self.index(row, 1), QtCore.Qt.DisplayRole)
-        stop = self.data(self.index(row, 2), QtCore.Qt.DisplayRole)
-        step = self.data(self.index(row, 3), QtCore.Qt.DisplayRole)
+        start = Q_(self.data(self.index(row, 1), QtCore.Qt.DisplayRole))
+        stop = Q_(self.data(self.index(row, 2), QtCore.Qt.DisplayRole))
+        step = Q_(self.data(self.index(row, 3), QtCore.Qt.DisplayRole))
         isstep = False
         if col == 1:  # the start
             start = value
@@ -65,14 +67,16 @@ class TableModelSequential(gutils.TableModel):
         elif col == 3:  # the step
             isstep = True
             step = value
-
-        if np.abs(step) < 1e-12 or start == stop:
+        try:
+            if np.abs(step) < 1e-12 or start == stop:
+                return False
+            if np.sign(stop - start) != np.sign(step):
+                if isstep:
+                    self._data[row][2] = -stop
+                else:
+                    self._data[row][3] = -step
+        except (TypeError, ValueError):
             return False
-        if np.sign(stop - start) != np.sign(step):
-            if isstep:
-                self._data[row][2] = -stop
-            else:
-                self._data[row][3] = -step
         return True
 
 
@@ -88,12 +92,15 @@ class SequentialScanner(ScannerBase):
     distribution = DataDistribution['uniform']
     n_axes = 1
 
-    def __init__(self, actuators: List['DAQ_Move']):
+    def __init__(self, actuators: List['DAQ_Move'], display_units=True, **_ignored):
 
         self.table_model: TableModelSequential = None
         self.table_view: TableViewCustom = None
-        super().__init__(actuators)
+        super().__init__(actuators, display_units=display_units)
         self.update_model()
+
+    def set_units(self):
+        pass
 
     @property
     def actuators(self):
@@ -116,9 +123,9 @@ class SequentialScanner(ScannerBase):
                         ind_row = names.index(act.title)
                         init_data.append(self.table_model.get_data_all()[ind_row])
                     else:
-                        init_data.append([act.title, 0., 1., 0.1])
+                        init_data.append([act.title, '0.', '1.', '0.1'])
             else:
-                init_data = [[act.title, 0., 1., 0.1] for act in self._actuators]
+                init_data = [[act.title, '0.', '1.', '0.1'] for act in self._actuators]
         self.table_model = TableModelSequential(init_data, )
         self.table_view = putils.get_widget_from_tree(self.settings_tree, TableViewCustom)[0]
         self.settings.child('seq_table').setValue(self.table_model)
@@ -126,19 +133,19 @@ class SequentialScanner(ScannerBase):
         self.update_table_view()
 
     def get_pos(self):
-        starts = np.array([self.table_model.get_data(ind, 1)
-                           for ind in range(self.table_model.rowCount(None))])
-        stops = np.array([self.table_model.get_data(ind, 2)
-                          for ind in range(self.table_model.rowCount(None))])
-        steps = np.array([self.table_model.get_data(ind, 3)
-                          for ind in range(self.table_model.rowCount(None))])
+        starts = [Q_(self.table_model.get_data(ind, 1))
+                           for ind in range(self.table_model.rowCount(None))]
+        stops = [Q_(self.table_model.get_data(ind, 2))
+                          for ind in range(self.table_model.rowCount(None))]
+        steps = [Q_(self.table_model.get_data(ind, 3))
+                          for ind in range(self.table_model.rowCount(None))]
         return starts, stops, steps
 
     def evaluate_steps(self) -> int:
         starts, stops, steps = self.get_pos()
         n_steps = 1
-        for ind in range(starts.size):
-            n_steps *= np.abs((stops[ind] - starts[ind]) / steps[ind]) + 1
+        for ind in range(len(starts)):
+            n_steps *= (np.abs((stops[ind] - starts[ind]) / steps[ind]) + 1).magnitude
         return int(n_steps)
 
     @staticmethod
@@ -152,13 +159,13 @@ class SequentialScanner(ScannerBase):
         return state
 
     def update_table_view(self):
-        self.table_view.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
-        self.table_view.horizontalHeader().setStretchLastSection(True)
+        self.table_view.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.Stretch)
+        #self.table_view.horizontalHeader().setStretchLastSection(True)
         self.table_view.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.table_view.setSelectionMode(QtWidgets.QTableView.SingleSelection)
-        styledItemDelegate = QtWidgets.QStyledItemDelegate()
-        styledItemDelegate.setItemEditorFactory(gutils.SpinBoxDelegate())
-        self.table_view.setItemDelegate(styledItemDelegate)
+        for ind_actuator, actuator in enumerate(self.actuators):
+            styledItemDelegate = gutils.SpinBoxDelegate(units=actuator.units)
+            self.table_view.setItemDelegateForRow(ind_actuator, styledItemDelegate)
 
         self.table_view.setDragEnabled(True)
         self.table_view.setDropIndicatorShown(True)

--- a/src/pymodaq/utils/scanner/scanners/sequential.py
+++ b/src/pymodaq/utils/scanner/scanners/sequential.py
@@ -59,6 +59,7 @@ class TableModelSequential(gutils.TableModel):
         start = Q_(self.data(self.index(row, 1), QtCore.Qt.DisplayRole))
         stop = Q_(self.data(self.index(row, 2), QtCore.Qt.DisplayRole))
         step = Q_(self.data(self.index(row, 3), QtCore.Qt.DisplayRole))
+        value = Q_(value)
         isstep = False
         if col == 1:  # the start
             start = value
@@ -68,13 +69,13 @@ class TableModelSequential(gutils.TableModel):
             isstep = True
             step = value
         try:
-            if np.abs(step) < 1e-12 or start == stop:
+            if np.abs(step).magnitude < 1e-12 or start == stop:
                 return False
             if np.sign(stop - start) != np.sign(step):
                 if isstep:
-                    self._data[row][2] = -stop
+                    self._data[row][2] = str(-stop)
                 else:
-                    self._data[row][3] = -step
+                    self._data[row][3] = str(-step)
         except (TypeError, ValueError):
             return False
         return True
@@ -123,9 +124,15 @@ class SequentialScanner(ScannerBase):
                         ind_row = names.index(act.title)
                         init_data.append(self.table_model.get_data_all()[ind_row])
                     else:
-                        init_data.append([act.title, '0.', '1.', '0.1'])
+                        if self.display_units:
+                            init_data = [[act.title, f'0. {act.units}', f'1. {act.units}', f'0.1 {act.units}'] for act in self._actuators]
+                        else:
+                            init_data.append([act.title, '0.', '1.', '0.1'])
             else:
-                init_data = [[act.title, '0.', '1.', '0.1'] for act in self._actuators]
+                if self.display_units:
+                    init_data = [[act.title, f'0. {act.units}', f'1. {act.units}', f'0.1 {act.units}'] for act in self._actuators]
+                else:
+                    init_data = [[act.title, '0.', '1.', '0.1'] for act in self._actuators]
         self.table_model = TableModelSequential(init_data, )
         self.table_view = putils.get_widget_from_tree(self.settings_tree, TableViewCustom)[0]
         self.settings.child('seq_table').setValue(self.table_model)
@@ -164,7 +171,7 @@ class SequentialScanner(ScannerBase):
         self.table_view.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.table_view.setSelectionMode(QtWidgets.QTableView.SingleSelection)
         for ind_actuator, actuator in enumerate(self.actuators):
-            styledItemDelegate = gutils.SpinBoxDelegate(units=actuator.units)
+            styledItemDelegate = gutils.SpinBoxDelegate(units=actuator.units if self.display_units else None)
             self.table_view.setItemDelegateForRow(ind_actuator, styledItemDelegate)
 
         self.table_view.setDragEnabled(True)
@@ -193,8 +200,8 @@ class SequentialScanner(ScannerBase):
                 state = self.pos_above_stops(positions, steps, stops)
                 if not np.any(np.array(state)):
                     all_positions.append(positions.copy())
-
-        self.get_info_from_positions(np.array(all_positions))
+        all_positions = np.array([[elt.magnitude for elt in positions] for positions in all_positions])
+        self.get_info_from_positions(all_positions)
 
     def get_nav_axes(self) -> List[Axis]:
         return [Axis(label=f'{act.title}', units=act.units, data=self.axes_unique[ind], index=ind)

--- a/src/pymodaq/utils/scanner/scanners/tabular.py
+++ b/src/pymodaq/utils/scanner/scanners/tabular.py
@@ -272,8 +272,7 @@ class TabularScannerSubSegmented(TabularScanner):
         self.update_table_view_points()
 
     def update_table_view(self):
-        self.table_view.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
-        self.table_view.horizontalHeader().setStretchLastSection(True)
+        self.table_view.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Stretch)
         self.table_view.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.table_view.setSelectionMode(QtWidgets.QTableView.SingleSelection)
         self.delegates = []
@@ -284,16 +283,15 @@ class TabularScannerSubSegmented(TabularScanner):
                 ind_actuator, self.delegates[-1])
 
     def update_table_view_points(self):
-        self.table_view_points.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
-        self.table_view_points.horizontalHeader().setStretchLastSection(True)
+        self.table_view_points.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Stretch)
         self.table_view_points.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.table_view_points.setSelectionMode(QtWidgets.QTableView.SingleSelection)
-        self.delegates = []
+        self.delegates_points = []
         for ind_actuator, actuator in enumerate(self.actuators):
-            self.delegates.append(gutils.SpinBoxDelegate(self.table_view,
+            self.delegates_points.append(gutils.SpinBoxDelegate(self.table_view,
                                                          units=actuator.units if self.display_units else None))
             self.table_view.setItemDelegateForColumn(
-                ind_actuator, self.delegates[-1])
+                ind_actuator, self.delegates_points[-1])
 
         self.table_view_points.setDragEnabled(True)
         self.table_view_points.setDropIndicatorShown(True)
@@ -311,9 +309,8 @@ class TabularScannerSubSegmented(TabularScanner):
     def set_scan(self):
         points = [Point(coordinates) for coordinates in self.table_model_points.get_data_all()]
         positions = get_sub_segmented_positions(self.settings['tabular_step'], points)
-
         self.table_model.set_data_all(positions)
-        positions = np.array(self.table_model.get_data_all())
+        positions = np.array([[Q_(elt).magnitude for elt in line] for line in self.table_model.get_data_all()])
         self.get_info_from_positions(positions)
 
     def update_from_scan_selector(self, scan_selector: Selector):

--- a/src/pymodaq/utils/scanner/scanners/tabular.py
+++ b/src/pymodaq/utils/scanner/scanners/tabular.py
@@ -137,9 +137,7 @@ class TabularScanner(ScannerBase):
         self.table_view.horizontalHeader().setStretchLastSection(True)
         self.table_view.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.table_view.setSelectionMode(QtWidgets.QTableView.SingleSelection)
-        styledItemDelegate = QtWidgets.QStyledItemDelegate()
-        styledItemDelegate.setItemEditorFactory(gutils.SpinBoxDelegate())
-        self.table_view.setItemDelegate(styledItemDelegate)
+        self.table_view.setItemDelegate(gutils.SpinBoxDelegate())
 
         self.table_view.setDragEnabled(True)
         self.table_view.setDropIndicatorShown(True)
@@ -271,9 +269,7 @@ class TabularScannerSubSegmented(TabularScanner):
         self.table_view_points.horizontalHeader().setStretchLastSection(True)
         self.table_view_points.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.table_view_points.setSelectionMode(QtWidgets.QTableView.SingleSelection)
-        styledItemDelegate = QtWidgets.QStyledItemDelegate()
-        styledItemDelegate.setItemEditorFactory(gutils.SpinBoxDelegate())
-        self.table_view.setItemDelegate(styledItemDelegate)
+        self.table_view.setItemDelegate(gutils.SpinBoxDelegate())
 
         self.table_view_points.setDragEnabled(True)
         self.table_view_points.setDropIndicatorShown(True)

--- a/src/pymodaq/utils/scanner/scanners/tabular.py
+++ b/src/pymodaq/utils/scanner/scanners/tabular.py
@@ -4,12 +4,14 @@ Created the 05/12/2022
 
 @author: Sebastien Weber
 """
-from typing import List, Tuple, TYPE_CHECKING
+from typing import List, Tuple, TYPE_CHECKING, Iterable
 
 import numpy as np
 
 from qtpy import QtCore, QtWidgets
 from pymodaq_data.data import Axis, DataDistribution
+from pymodaq_data import Q_
+from pymodaq_gui.utils import SpinBoxDelegate
 from pymodaq_utils.logger import set_logger, get_module_name
 
 from pymodaq_utils import config as configmod
@@ -37,19 +39,18 @@ class TableModelTabular(gutils.TableModel):
                 kwargs.pop('header')
             else:
                 raise Exception('Invalid header')
-
         header = [name for name in axes_name]
         editable = [True for name in axes_name]
-        super().__init__(data, header, editable=editable, **kwargs)
+        super().__init__(data, header, editable=editable, cast=str, **kwargs)
 
     def __len__(self):
         return len(self._data)
 
     def add_data(self, row, data=None):
         if data is not None:
-            self.insert_data(row, [float(d) for d in data])
+            self.insert_data(row, [f'{d}' for d in data])
         else:
-            self.insert_data(row, [0. for name in self.header])
+            self.insert_data(row, ['0.' for name in self.header])
 
     def remove_data(self, row):
         self.remove_row(row)
@@ -106,10 +107,14 @@ class TabularScanner(ScannerBase):
               ]
     distribution = DataDistribution['spread']
 
-    def __init__(self, actuators: List['DAQ_Move']):
+    def __init__(self, actuators: List['DAQ_Move'], display_units=True, **kwargs):
         self.table_model: TableModelTabular = None
         self.table_view: TableViewCustom = None
-        super().__init__(actuators=actuators)
+        super().__init__(actuators=actuators, display_units=display_units)
+        self.delegates: Iterable[SpinBoxDelegate] = []
+
+    def set_units(self):
+        pass
 
     @property
     def actuators(self):
@@ -124,7 +129,10 @@ class TabularScanner(ScannerBase):
 
     def update_model(self, init_data=None):
         if init_data is None:
-            init_data = [[0. for _ in self._actuators]]
+            if self.display_units:
+                init_data = [[f'0. {act.units}' for act in self._actuators]]
+            else:
+                init_data = [['0.' for _ in self._actuators]]
 
         self.table_model = TableModelTabular(init_data, [act.title for act in self._actuators])
         self.table_view = putils.get_widget_from_tree(self.settings_tree, TableViewCustom)[0]
@@ -133,11 +141,17 @@ class TabularScanner(ScannerBase):
         self.update_table_view()
 
     def update_table_view(self):
-        self.table_view.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
-        self.table_view.horizontalHeader().setStretchLastSection(True)
+        self.table_view.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeMode.Stretch)
+        # self.table_view.horizontalHeader().setStretchLastSection(True)
         self.table_view.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.table_view.setSelectionMode(QtWidgets.QTableView.SingleSelection)
-        self.table_view.setItemDelegate(gutils.SpinBoxDelegate())
+        self.delegates = []  # ItemDelegates should have parents and be instance attribute to work with setItemDelegateForColumn
+        for ind_actuator, actuator in enumerate(self.actuators):
+
+            self.delegates.append(gutils.SpinBoxDelegate(self.table_view,
+                                                         units=actuator.units if self.display_units else None))
+            self.table_view.setItemDelegateForColumn(
+                ind_actuator, self.delegates[-1])
 
         self.table_view.setDragEnabled(True)
         self.table_view.setDropIndicatorShown(True)
@@ -156,7 +170,7 @@ class TabularScanner(ScannerBase):
         return len(self.table_model)
 
     def set_scan(self):
-        positions = np.array(self.table_model.get_data_all())
+        positions = np.array([[Q_(elt).magnitude for elt in line] for line in self.table_model.get_data_all()])
         self.get_info_from_positions(positions)
 
     def update_tabular_positions(self, positions: np.ndarray = None):
@@ -221,12 +235,12 @@ class TabularScannerSubSegmented(TabularScanner):
                'menu': True},
               ] + TabularScanner.params
 
-    def __init__(self, actuators: List['DAQ_Move']):
+    def __init__(self, actuators: List['DAQ_Move'], display_units=True):
         self.table_model: TableModelTabularReadOnly = None
         self.table_view: TableViewCustom = None
         self.table_model_points: TableModelTabular = None
         self.table_view_points: TableViewCustom = None
-        super().__init__(actuators=actuators)
+        super().__init__(actuators=actuators, display_units=display_units)
 
     @property
     def actuators(self):
@@ -240,7 +254,7 @@ class TabularScannerSubSegmented(TabularScanner):
 
     def update_model(self, init_data=None):
         if init_data is None:
-            init_data = [[0. for _ in self._actuators]]
+            init_data = [['0.' for _ in self._actuators]]
 
         self.table_model = TableModelTabularReadOnly(init_data, [act.title for act in self._actuators])
         self.table_view = putils.get_widget_from_tree(self.settings_tree, TableViewCustom)[1]
@@ -250,7 +264,7 @@ class TabularScannerSubSegmented(TabularScanner):
 
     def update_model_points(self, init_data=None):
         if init_data is None:
-            init_data = [[0. for _ in self._actuators]]
+            init_data = [['0.' for _ in self._actuators]]
 
         self.table_model_points = TableModelTabular(init_data, [act.title for act in self._actuators])
         self.table_view_points = putils.get_widget_from_tree(self.settings_tree, TableViewCustom)[0]
@@ -262,14 +276,24 @@ class TabularScannerSubSegmented(TabularScanner):
         self.table_view.horizontalHeader().setStretchLastSection(True)
         self.table_view.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.table_view.setSelectionMode(QtWidgets.QTableView.SingleSelection)
-        # self.table_view.setEnabled(False)
+        self.delegates = []
+        for ind_actuator, actuator in enumerate(self.actuators):
+            self.delegates.append(gutils.SpinBoxDelegate(self.table_view,
+                                                         units=actuator.units if self.display_units else None))
+            self.table_view.setItemDelegateForColumn(
+                ind_actuator, self.delegates[-1])
 
     def update_table_view_points(self):
         self.table_view_points.horizontalHeader().setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
         self.table_view_points.horizontalHeader().setStretchLastSection(True)
         self.table_view_points.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.table_view_points.setSelectionMode(QtWidgets.QTableView.SingleSelection)
-        self.table_view.setItemDelegate(gutils.SpinBoxDelegate())
+        self.delegates = []
+        for ind_actuator, actuator in enumerate(self.actuators):
+            self.delegates.append(gutils.SpinBoxDelegate(self.table_view,
+                                                         units=actuator.units if self.display_units else None))
+            self.table_view.setItemDelegateForColumn(
+                ind_actuator, self.delegates[-1])
 
         self.table_view_points.setDragEnabled(True)
         self.table_view_points.setDropIndicatorShown(True)

--- a/tests/utils/scanner_test/scan_factory_test.py
+++ b/tests/utils/scanner_test/scan_factory_test.py
@@ -11,7 +11,17 @@ from pymodaq.utils.scanner.scan_factory import ScannerFactory
 from pymodaq.utils.parameter import utils as putils
 
 scanner_factory = ScannerFactory()
-config_scanner = dict(actuators=['act1', 'act2', 'act3'])
+
+units = ['nm', 'kW', 'ms']
+
+class MoveMock:
+    def __init__(self, ind: int = 0):
+        self.title = f'act_{ind}'
+        self.units = units[ind]
+
+actuators = [MoveMock(ind) for ind in range(3)]
+
+config_scanner = dict(actuators=actuators)
 
 
 class TestSettings:


### PR DESCRIPTION
Units are everywhere in the control modules but where not enforced within the daq_scan extension. This PR add in each scanner setting the correct suffix corresponding to the native actuator unit 