### PR TITLE
Feature/use group parameter nested structure

### DIFF
--- a/src/pymodaq/utils/managers/preset_manager_utils.py
+++ b/src/pymodaq/utils/managers/preset_manager_utils.py
@@ -18,6 +18,9 @@ DAQ_1DViewer_Det_types = get_plugins('daq_1Dviewer')
 DAQ_2DViewer_Det_types = get_plugins('daq_2Dviewer')
 DAQ_NDViewer_Det_types = get_plugins('daq_NDviewer')
 
+# Fixed names that will sort the plugin in remote/mock
+REMOTE_ITEMS  = {'LECODirector', 'TCPServer'}
+MOCK_ITEMS = {}
 
 def iterative_show_pb(params):
     for param in params:
@@ -28,12 +31,60 @@ def iterative_show_pb(params):
 
 
 def find_last_index(list_children:list=[], name_prefix ='',format_string='02.0f'):
+    # Custom function to find last available index
     child_indexes = ([int(par.name()[len(name_prefix) + 1:]) for par in list_children if name_prefix in par.name()])
     if child_indexes == []:
         newindex = 0
     else:
         newindex = max(child_indexes) + 1
     return f'{newindex:{format_string}}'
+
+
+def categorize_items(item_list, remote_items=None, mock_items=None):
+    """
+    Core function: categorize any list of items into Mock/Plugin/Remote.
+    
+    Args:
+        item_list: List of items to categorize
+        remote_items: Custom set of remote items (optional)
+        mock_items: Custom set of mock items (optional)
+    
+    Returns: dict {category: [items]} with only non-empty categories
+    """
+    remote_items = remote_items or REMOTE_ITEMS
+    mock_items = mock_items or MOCK_ITEMS
+    
+    categorized = {'Remote': [], 'Mock': [], 'Plugin': []}
+    
+    for item in item_list:
+        if item in remote_items:
+            categorized['Remote'].append(item)
+        elif item in mock_items or 'mock' in item.lower():
+            categorized['Mock'].append(item)
+        else:
+            categorized['Plugin'].append(item)
+    
+    # Return only non-empty categories
+    return {k: v for k, v in categorized.items() if v}
+
+
+def add_category_layers(dimension_dict, remote_items=None, mock_items=None):
+    """
+    Add category layers to a dimension dictionary.
+    Uses categorize_items for each dimension.
+    
+    Args:
+        dimension_dict: {dimension: [items]}
+    
+    Returns: {dimension: {category: [items]}}
+    """
+    result = {}
+    
+    for dimension, items in dimension_dict.items():
+        # Reuse the core categorization function
+        result[dimension] = categorize_items(items, remote_items, mock_items)
+    
+    return result
 
 
 def make_move_params(typ):
@@ -126,7 +177,7 @@ class PresetScalableGroupMove(GroupParameter):
     def __init__(self, **opts):
         opts['type'] = 'groupmove'
         opts['addText'] = "Add"
-        opts['addMenu'] = [mov['name'] for mov in DAQ_Move_Stage_type]
+        opts['addMenu'] = categorize_items([mov['name'] for mov in DAQ_Move_Stage_type])
         super().__init__(**opts)
 
     def addNew(self, typ:tuple):
@@ -139,7 +190,7 @@ class PresetScalableGroupMove(GroupParameter):
             =============== ===========
         """
         name_prefix = 'move'
-        typ = typ[-1]
+        typ = typ[-1] #Only need last entry here
         new_index = find_last_index(self.children(), name_prefix, format_string='02.0f')
         params = make_move_params(typ)
         child = {'title': f'Actuator {new_index}',
@@ -172,14 +223,13 @@ class PresetScalableGroupDet(GroupParameter):
     def __init__(self, **opts):
         opts['type'] = 'groupdet'
         opts['addText'] = "Add"
-        options = [
-        {'DAQ0D': [name for name in [plugin['name'] for plugin in DAQ_0DViewer_Det_types]],
+        options = {
+        'DAQ0D': [name for name in [plugin['name'] for plugin in DAQ_0DViewer_Det_types]],
         'DAQ1D': [name for name in [plugin['name'] for plugin in DAQ_1DViewer_Det_types]],
         'DAQ2D': [name for name in [plugin['name'] for plugin in DAQ_2DViewer_Det_types]],
         'DAQND': [name for name in [plugin['name'] for plugin in DAQ_NDViewer_Det_types]],
          }
-        ]
-        opts['addMenu'] = options
+        opts['addMenu'] = add_category_layers(options)
 
         super().__init__(**opts)
 
@@ -194,10 +244,10 @@ class PresetScalableGroupDet(GroupParameter):
         """
         try:
             name_prefix = 'det'
-            typ = "/".join(typ)
+            typ = "/".join((typ[0],typ[-1])) #Only need first and last element to retrieve associated plugin
             new_index = find_last_index(list_children=self.children(), name_prefix=name_prefix, format_string='02.0f')
             params = make_viewer_params(typ)
-            child = {'title': f'Det {new_index}', 'name': new_index,
+            child = {'title': f'Det {new_index}', 'name': f'{name_prefix}{new_index}',
                         'type': 'group', 'children': [
                 {'title': 'Name:', 'name': 'name', 'type': 'str', 'value': f'Det {new_index}'},
                 {'title': 'Init?:', 'name': 'init', 'type': 'bool', 'value': True},

--- a/src/pymodaq/utils/managers/preset_manager_utils.py
+++ b/src/pymodaq/utils/managers/preset_manager_utils.py
@@ -27,6 +27,88 @@ def iterative_show_pb(params):
             iterative_show_pb(param['children'])
 
 
+def find_last_index(list_children:list=[], name_prefix ='',format_string='02.0f'):
+    child_indexes = ([int(par.name()[len(name_prefix) + 1:]) for par in list_children if name_prefix in par.name()])
+    if child_indexes == []:
+        newindex = 0
+    else:
+        newindex = max(child_indexes) + 1
+    return f'{newindex:{format_string}}'
+
+
+def make_move_params(typ):
+    params = daq_move_params
+    iterative_show_pb(params)
+
+    parent_module = utils.find_dict_in_list_from_key_val(DAQ_Move_Stage_type, 'name', typ)
+    class_ = getattr(getattr(parent_module['module'], 'daq_move_' + typ),
+                        'DAQ_Move_' + typ)
+    params_hardware = getattr(class_, 'params')
+    iterative_show_pb(params_hardware)
+
+    for main_child in params:
+        if main_child['name'] == 'move_settings':
+            main_child['children'] = params_hardware
+            controller_dict = get_param_dict_from_name(params_hardware, 'controller_ID')
+            controller_dict['value'] = random.randint(0, 9999)
+
+        elif main_child['name'] == 'main_settings':
+            typ_dict = get_param_dict_from_name(main_child['children'], 'move_type')
+            typ_dict['value'] = typ
+
+    return params
+
+
+def make_viewer_params(typ):
+        params = daq_viewer_params
+        iterative_show_pb(params)
+
+        for main_child in params:
+            if main_child['name'] == 'main_settings':
+                for child in main_child['children']:
+                    if child['name'] == 'DAQ_type':
+                        child['value'] = typ[0:5]
+                    if child['name'] == 'detector_type':
+                        child['value'] = typ[6:]
+                    if child['name'] == 'controller_status':
+                        child['visible'] = True
+
+        if '0D' in typ:
+            parent_module = utils.find_dict_in_list_from_key_val(DAQ_0DViewer_Det_types, 'name', typ[6:])
+            class_ = getattr(getattr(parent_module['module'], 'daq_0Dviewer_' + typ[6:]), 'DAQ_0DViewer_' + typ[6:])
+        elif '1D' in typ:
+            parent_module = utils.find_dict_in_list_from_key_val(DAQ_1DViewer_Det_types, 'name', typ[6:])
+            class_ = getattr(getattr(parent_module['module'], 'daq_1Dviewer_' + typ[6:]), 'DAQ_1DViewer_' + typ[6:])
+        elif '2D' in typ:
+            parent_module = utils.find_dict_in_list_from_key_val(DAQ_2DViewer_Det_types, 'name', typ[6:])
+            class_ = getattr(getattr(parent_module['module'], 'daq_2Dviewer_' + typ[6:]), 'DAQ_2DViewer_' + typ[6:])
+        elif 'ND' in typ:
+            parent_module = utils.find_dict_in_list_from_key_val(DAQ_NDViewer_Det_types, 'name', typ[6:])
+            class_ = getattr(getattr(parent_module['module'], 'daq_NDviewer_' + typ[6:]), 'DAQ_NDViewer_' + typ[6:])
+        for main_child in params:
+            if main_child['name'] == 'main_settings':
+                for child in main_child['children']:
+                    if child['name'] == 'axes':
+                        child['visible'] = True
+
+        params_hardware = getattr(class_, 'params')
+        iterative_show_pb(params_hardware)
+
+        for main_child in params:
+            # Was this condition useful? 
+            # if main_child['name'] == 'detector_settings':
+            #     while len(main_child['children']) > 0:
+            #         for child in main_child['children']:
+            #             main_child['children'].remove(child)
+
+            #     main_child['children'].extend(params_hardware)
+            if main_child['name'] == 'detector_settings':
+                main_child['children'] = params_hardware
+        controller_dict = get_param_dict_from_name(main_child['children'], 'controller_ID')
+        controller_dict['value'] = random.randint(0, 9999)
+        
+        return params
+    
 class PresetScalableGroupMove(GroupParameter):
     """
         |
@@ -57,46 +139,19 @@ class PresetScalableGroupMove(GroupParameter):
             =============== ===========
         """
         name_prefix = 'move'
-
-        child_indexes = [int(par.name()[len(name_prefix) + 1:]) for par in self.children()]
-
-        if child_indexes == []:
-            newindex = 0
-        else:
-            newindex = max(child_indexes) + 1
-
-        params = daq_move_params
-        iterative_show_pb(params)
-
-        parent_module = utils.find_dict_in_list_from_key_val(DAQ_Move_Stage_type, 'name', typ)
-        class_ = getattr(getattr(parent_module['module'], 'daq_move_' + typ),
-                         'DAQ_Move_' + typ)
-        params_hardware = getattr(class_, 'params')
-        iterative_show_pb(params_hardware)
-
-        for main_child in params:
-            if main_child['name'] == 'move_settings':
-                main_child['children'] = params_hardware
-                controller_dict = get_param_dict_from_name(params_hardware, 'controller_ID')
-                controller_dict['value'] = random.randint(0, 9999)
-
-            elif main_child['name'] == 'main_settings':
-                typ_dict = get_param_dict_from_name(main_child['children'], 'move_type')
-                typ_dict['value'] = typ
-
-        child = {'title': 'Actuator {:02.0f}'.format(newindex),
-                 'name': f'{name_prefix}{newindex:02.0f}',
-                 'type': 'group',
-                 'removable': True, 'renamable': False,
-                 'children': [
-                     {'title': 'Name:', 'name': 'name', 'type': 'str',
-                      'value': 'Move {:02.0f}'.format(newindex)},
-                     {'title': 'Init?:', 'name': 'init', 'type': 'bool', 'value': True},
-                     {'title': 'Settings:', 'name': 'params', 'type': 'group', 'children': params},
-                 ]}
-
+        new_index = find_last_index(self.children(), name_prefix, format_string='02.0f')
+        params = make_move_params(typ)
+        child = {'title': f'Actuator {new_index}',
+            'name': f'{name_prefix}{new_index}',
+            'type': 'group',
+            'removable': True, 'renamable': False,
+            'children': [
+                {'title': 'Name:', 'name': 'name', 'type': 'str',
+                'value': f'Move {new_index}'},
+                {'title': 'Init?:', 'name': 'init', 'type': 'bool', 'value': True},
+                {'title': 'Settings:', 'name': 'params', 'type': 'group', 'children': params},
+            ]}
         self.addChild(child)
-
 
 registerParameterType('groupmove', PresetScalableGroupMove, override=True)
 
@@ -140,63 +195,14 @@ class PresetScalableGroupDet(GroupParameter):
         """
         try:
             name_prefix = 'det'
-            child_indexes = [int(par.name()[len(name_prefix) + 1:]) for par in self.children()]
-
-            if child_indexes == []:
-                newindex = 0
-            else:
-                newindex = max(child_indexes) + 1
-
-            params = daq_viewer_params
-            iterative_show_pb(params)
-
-            for main_child in params:
-                if main_child['name'] == 'main_settings':
-                    for child in main_child['children']:
-                        if child['name'] == 'DAQ_type':
-                            child['value'] = typ[0:5]
-                        if child['name'] == 'detector_type':
-                            child['value'] = typ[6:]
-                        if child['name'] == 'controller_status':
-                            child['visible'] = True
-
-            if '0D' in typ:
-                parent_module = utils.find_dict_in_list_from_key_val(DAQ_0DViewer_Det_types, 'name', typ[6:])
-                class_ = getattr(getattr(parent_module['module'], 'daq_0Dviewer_' + typ[6:]), 'DAQ_0DViewer_' + typ[6:])
-            elif '1D' in typ:
-                parent_module = utils.find_dict_in_list_from_key_val(DAQ_1DViewer_Det_types, 'name', typ[6:])
-                class_ = getattr(getattr(parent_module['module'], 'daq_1Dviewer_' + typ[6:]), 'DAQ_1DViewer_' + typ[6:])
-            elif '2D' in typ:
-                parent_module = utils.find_dict_in_list_from_key_val(DAQ_2DViewer_Det_types, 'name', typ[6:])
-                class_ = getattr(getattr(parent_module['module'], 'daq_2Dviewer_' + typ[6:]), 'DAQ_2DViewer_' + typ[6:])
-            elif 'ND' in typ:
-                parent_module = utils.find_dict_in_list_from_key_val(DAQ_NDViewer_Det_types, 'name', typ[6:])
-                class_ = getattr(getattr(parent_module['module'], 'daq_NDviewer_' + typ[6:]), 'DAQ_NDViewer_' + typ[6:])
-            for main_child in params:
-                if main_child['name'] == 'main_settings':
-                    for child in main_child['children']:
-                        if child['name'] == 'axes':
-                            child['visible'] = True
-
-            params_hardware = getattr(class_, 'params')
-            iterative_show_pb(params_hardware)
-
-            for main_child in params:
-                if main_child['name'] == 'detector_settings':
-                    while len(main_child['children']) > 0:
-                        for child in main_child['children']:
-                            main_child['children'].remove(child)
-
-                    main_child['children'].extend(params_hardware)
-            controller_dict = get_param_dict_from_name(main_child['children'], 'controller_ID')
-            controller_dict['value'] = random.randint(0, 9999)
-
-            child = {'title': 'Det {:02.0f}'.format(newindex), 'name': f'{name_prefix}{newindex:02.0f}',
-                     'type': 'group', 'children': [
-                {'title': 'Name:', 'name': 'name', 'type': 'str', 'value': 'Det {:02.0f}'.format(newindex)},
+            new_index = find_last_index(list_children=self.children(), name_prefix=name_prefix, format_string='02.0f')
+            params = make_viewer_params(typ)
+            child = {'title': f'Det {new_index}', 'name': new_index,
+                        'type': 'group', 'children': [
+                {'title': 'Name:', 'name': 'name', 'type': 'str', 'value': f'Det {new_index}'},
                 {'title': 'Init?:', 'name': 'init', 'type': 'bool', 'value': True},
                 {'title': 'Settings:', 'name': 'params', 'type': 'group', 'children': params},
-            ], 'removable': True, 'renamable': False}
+            ], 'removable': True, 'renamable': False}            
 
             self.addChild(child)
         except Exception as e:

--- a/src/pymodaq/utils/managers/preset_manager_utils.py
+++ b/src/pymodaq/utils/managers/preset_manager_utils.py
@@ -106,7 +106,7 @@ def make_viewer_params(typ):
                 main_child['children'] = params_hardware
         controller_dict = get_param_dict_from_name(main_child['children'], 'controller_ID')
         controller_dict['value'] = random.randint(0, 9999)
-        
+
         return params
     
 class PresetScalableGroupMove(GroupParameter):
@@ -126,10 +126,10 @@ class PresetScalableGroupMove(GroupParameter):
     def __init__(self, **opts):
         opts['type'] = 'groupmove'
         opts['addText'] = "Add"
-        opts['addList'] = [mov['name'] for mov in DAQ_Move_Stage_type]
+        opts['addMenu'] = [mov['name'] for mov in DAQ_Move_Stage_type]
         super().__init__(**opts)
 
-    def addNew(self, typ):
+    def addNew(self, typ:tuple):
         """
             Add a child.
 
@@ -139,6 +139,7 @@ class PresetScalableGroupMove(GroupParameter):
             =============== ===========
         """
         name_prefix = 'move'
+        typ = typ[-1]
         new_index = find_last_index(self.children(), name_prefix, format_string='02.0f')
         params = make_move_params(typ)
         child = {'title': f'Actuator {new_index}',
@@ -171,20 +172,18 @@ class PresetScalableGroupDet(GroupParameter):
     def __init__(self, **opts):
         opts['type'] = 'groupdet'
         opts['addText'] = "Add"
-        options = []
-        for name in [plugin['name'] for plugin in DAQ_0DViewer_Det_types]:
-            options.append('DAQ0D/' + name)
-        for name in [plugin['name'] for plugin in DAQ_1DViewer_Det_types]:
-            options.append('DAQ1D/' + name)
-        for name in [plugin['name'] for plugin in DAQ_2DViewer_Det_types]:
-            options.append('DAQ2D/' + name)
-        for name in [plugin['name'] for plugin in DAQ_NDViewer_Det_types]:
-            options.append('DAQND/' + name)
-        opts['addList'] = options
+        options = [
+        {'DAQ0D': [name for name in [plugin['name'] for plugin in DAQ_0DViewer_Det_types]],
+        'DAQ1D': [name for name in [plugin['name'] for plugin in DAQ_1DViewer_Det_types]],
+        'DAQ2D': [name for name in [plugin['name'] for plugin in DAQ_2DViewer_Det_types]],
+        'DAQND': [name for name in [plugin['name'] for plugin in DAQ_NDViewer_Det_types]],
+         }
+        ]
+        opts['addMenu'] = options
 
         super().__init__(**opts)
 
-    def addNew(self, typ):
+    def addNew(self, typ:tuple):
         """
             Add a child.
 
@@ -195,6 +194,7 @@ class PresetScalableGroupDet(GroupParameter):
         """
         try:
             name_prefix = 'det'
+            typ = "/".join(typ)
             new_index = find_last_index(list_children=self.children(), name_prefix=name_prefix, format_string='02.0f')
             params = make_viewer_params(typ)
             child = {'title': f'Det {new_index}', 'name': new_index,


### PR DESCRIPTION
In this PR, I updated the preset_manager_utils.py to benefit from the nested structure available from GroupParameter
https://github.com/PyMoDAQ/pymodaq_gui/pull/88

This allows to easily sort the plugin according to their type:
I decided to use three subtypes:
- Remote (lecodirector/TPCserver)
- Mock (every plugin with Mock in its name)
- Plugin (all the "true" plugins)

This allows the user to easily find the relevant plugins. This could later be enhanced to allow the user to make his own listing

For now the sorting is done by the name of the plugin, but this could instead be through an additional keyword in the plugin itself which would sort it accordingly.

https://github.com/user-attachments/assets/bc9b9894-b636-4f5d-928e-258e14ed18cb

