### PR TITLE
Using class attributes instead of instances attributes

### DIFF
--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -819,10 +819,11 @@ class DashBoard(CustomApp):
             mssg.setText('You have to restart the application to take the'
                          ' modifications into account!')
             mssg.setInformativeText("Do you want to restart?")
-            mssg.setStandardButtons(mssg.Ok | mssg.Cancel)
+            mssg.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok |
+                                    QtWidgets.QMessageBox.StandardButton.Cancel)
             ret = mssg.exec()
 
-        if ret == mssg.Ok or not ask:
+        if ret == QtWidgets.QMessageBox.StandardButton.Ok or not ask:
             self.quit_fun()
             subprocess.call([sys.executable, __file__])
 
@@ -1692,8 +1693,8 @@ class DashBoard(CustomApp):
         vlayout.addWidget(tree)
         dialog.setLayout(vlayout)
         buttonBox = QtWidgets.QDialogButtonBox(parent=dialog)
-        buttonBox.addButton('Cancel', buttonBox.RejectRole)
-        buttonBox.addButton('Apply', buttonBox.AcceptRole)
+        buttonBox.addButton('Cancel', QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
+        buttonBox.addButton('Apply', QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
         buttonBox.rejected.connect(dialog.reject)
         buttonBox.accepted.connect(dialog.accept)
 

--- a/src/pymodaq/utils/managers/preset_manager.py
+++ b/src/pymodaq/utils/managers/preset_manager.py
@@ -139,9 +139,9 @@ class PresetManager:
         dialog.setLayout(vlayout)
         buttonBox = QtWidgets.QDialogButtonBox(parent=dialog)
 
-        buttonBox.addButton('Save', buttonBox.AcceptRole)
+        buttonBox.addButton('Save', QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole)
         buttonBox.accepted.connect(dialog.accept)
-        buttonBox.addButton('Cancel', buttonBox.RejectRole)
+        buttonBox.addButton('Cancel', QtWidgets.QDialogButtonBox.ButtonRole.RejectRole)
         buttonBox.rejected.connect(dialog.reject)
 
         vlayout.addWidget(buttonBox)
@@ -151,7 +151,7 @@ class PresetManager:
         path = self.preset_path
         file= None
 
-        if res == dialog.Accepted:
+        if res == QtWidgets.QDialog.DialogCode.Accepted:
             # save managers parameters in a xml file
             # start = os.path.split(os.path.split(os.path.realpath(__file__))[0])[0]
             # start = os.path.join("..",'daq_scan')
@@ -182,7 +182,7 @@ class PresetManager:
             layout_file = layout_path.joinpath(self.filename + '.dock')
             layout_file.unlink(missing_ok=True)
 
-        return res == dialog.Accepted
+        return res == QtWidgets.QDialog.DialogCode.Accepted
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello PyMoDAQ,

I was experiencing issues with the dashboard using PySide6:
- **File → Restart** not working
- **File → Configuration file** or **Preset Modes → New Preset** windows not opening

I found out issue was being taken care of in pymodaq_gui [here](https://github.com/PyMoDAQ/pymodaq_gui/issues/63). This PR is for PyMoDAQ repository and I only checked [dashboard.py](https://github.com/PyMoDAQ/PyMoDAQ/blob/5.0.x/src/pymodaq/dashboard.py) file here. A similar issue is most likely to appear somewhere else (extensions or  but these changes should fix **Restart** and **New preset** buttons in dashboard.

Cheers,

Bastien