### PR TITLE
Patch/datamixer overrideen detectors

### DIFF
--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -1477,8 +1477,8 @@ class DashBoard(CustomApp):
         return det_mod_tmp
 
     def override_det_from_extension(self, overriden_grabbers: Sequence[str] = None):
-        """(Experimental) If an extension adding detectors within the Dashboard need to, it could call this
-        method.
+        """(Experimental) If an extension adding detectors within the Dashboard need to,
+         it could call this method.
 
         Then if some other extension trigger a grab from it, the request of a grab won't be done twice
 

--- a/src/pymodaq/extensions/data_mixer/daq_0Dviewer_DataMixer.py
+++ b/src/pymodaq/extensions/data_mixer/daq_0Dviewer_DataMixer.py
@@ -25,7 +25,11 @@ class DAQ_0DViewer_DataMixer(DAQ_Viewer_base):
          hardware library.
 
     """
-    params = comon_parameters+[]
+    params = (comon_parameters+
+              [
+                  {'title': 'Related Detectors', 'name': 'overridden_detectors', 'type': 'list',
+                   'readonly': True}  # mandatory to know what detectors are related to the DataMixer
+              ])
 
     def ini_attributes(self):
         self.controller: DataMixer = None

--- a/src/pymodaq/extensions/data_mixer/data_mixer.py
+++ b/src/pymodaq/extensions/data_mixer/data_mixer.py
@@ -127,7 +127,7 @@ class DataMixer(CustomExt):
 
     def connect_things(self):
         """Connect actions and/or other widgets signal to methods"""
-        self.connect_action('quit', self.quit)
+        self.connect_action('quit', self.quit_fun)
         self.connect_action('models', self.update_model_settings_from_action, signal_name='currentTextChanged')
         self.connect_action('ini_model', self.ini_model)
         self.modules_manager.det_done_signal.connect(self.process_data)
@@ -151,7 +151,7 @@ class DataMixer(CustomExt):
         try:
             self.dashboard.add_det_from_extension('DataMixer', 'DAQ0D', 'DataMixer', self)
             self.dashboard.modules_manager.get_mod_from_name(
-                'DataMixer', 'det').settings.child('main_settings', 'overridden_detectors').setOpts(
+                'DataMixer', 'det').settings.child('detector_settings', 'overridden_detectors').setOpts(
                 limits=self.modules_manager.selected_detectors_name)
             self.set_action_enabled('create_computed_detectors', False)
             #self.dashboard.override_det_from_extension(self.modules_manager.selected_detectors_name)
@@ -240,7 +240,7 @@ class DataMixer(CustomExt):
             if self.model_class is not None:
                 self.model_class.update_settings(param)
 
-    def quit(self):
+    def quit_fun(self):
         self.mainwindow.close()
         self.dashboard.remove_modules(['DataMixer'])
 

--- a/src/pymodaq/extensions/data_mixer/data_mixer.py
+++ b/src/pymodaq/extensions/data_mixer/data_mixer.py
@@ -150,8 +150,11 @@ class DataMixer(CustomExt):
     def create_computed_detectors(self):
         try:
             self.dashboard.add_det_from_extension('DataMixer', 'DAQ0D', 'DataMixer', self)
+            self.dashboard.modules_manager.get_mod_from_name(
+                'DataMixer', 'det').settings.child('main_settings', 'overridden_detectors').setOpts(
+                limits=self.modules_manager.selected_detectors_name)
             self.set_action_enabled('create_computed_detectors', False)
-            self.dashboard.override_det_from_extension(self.modules_manager.selected_detectors_name)
+            #self.dashboard.override_det_from_extension(self.modules_manager.selected_detectors_name)
         except Exception as e:
             logger.exception(str(e))
             pass
@@ -185,6 +188,7 @@ class DataMixer(CustomExt):
         self.settings.child('models', 'ini_model').setValue(True)
         self.set_action_enabled('models', False)
         self.settings.child('models', 'model_class').setOpts(enabled=False)
+        self.modules_manager.settings_tree.setEnabled(False)
 
         self.update_connect_detectors()
 

--- a/src/pymodaq/utils/managers/modules_manager.py
+++ b/src/pymodaq/utils/managers/modules_manager.py
@@ -329,7 +329,8 @@ class ModulesManager(QObject, ParameterManager):
         
         if 'DataMixer' in self.selected_detectors_name:
             overridden_detectors = self.get_mod_from_name(
-                'DataMixer', 'det').settings.child('main_settings', 'overridden_detectors').opts['limits']
+                'DataMixer', 'det').settings.child(
+                'detector_settings', 'overridden_detectors').opts['limits']
         else:
             overridden_detectors = []
 

--- a/src/pymodaq/utils/managers/modules_manager.py
+++ b/src/pymodaq/utils/managers/modules_manager.py
@@ -326,16 +326,23 @@ class ModulesManager(QObject, ParameterManager):
         self.det_done_flag = False
         self.settings.child('det_done').setValue(self.det_done_flag)
         tzero = time.perf_counter()
+        
+        if 'DataMixer' in self.selected_detectors_name:
+            overridden_detectors = self.get_mod_from_name(
+                'DataMixer', 'det').settings.child('main_settings', 'overridden_detectors').opts['limits']
+        else:
+            overridden_detectors = []
 
         for mod in self.detectors:
-            if not (check_do_override and mod.override_grab_from_extension):
+            #if not (check_do_override and mod.override_grab_from_extension):
+            if mod.title not in overridden_detectors:    
                 kwargs.update(dict(Naverage=mod.Naverage))
                 mod.command_hardware.emit(utils.ThreadCommand("single", kwargs))
 
         while not self.det_done_flag:
             # wait for grab done signals to end
             QtWidgets.QApplication.processEvents()  # mandatory for the det_done_flag boolean to be modified in the corresponding method
-            if time.perf_counter() - tzero > self.detector_timeout:
+            if time.perf_counter() - tzero > self.detector_timeout / 1000:
                 self.timeout_signal.emit(True)
                 logger.error('Timeout Fired during waiting for data to be acquired')
                 break


### PR DESCRIPTION
when using another extension calling  an underlying detector nothing grabs because it was overridden.
Now it is overriden only in both DataMixer is selected AND this detector belongs to the datamixer