### PR TITLE
Load last preset option

### DIFF
--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -5,6 +5,7 @@ import sys
 import datetime
 import subprocess
 import logging
+from functools import total_ordering
 from pathlib import Path
 from importlib import import_module
 from packaging import version as version_mod
@@ -260,10 +261,19 @@ class DashBoard(CustomApp):
 
         try:
             if config('user', 'loadlast') and config('user', 'lastloadok'):
-                logger.warning("Automatically loading"+str(config('user', 'lastpreset')))
-                self.set_file_preset(self.preset_path / Path(config('user', 'lastpreset')+'.xml'))
+                #todo os.path.isfile(self.preset_path / Path(config('user', 'lastpreset')+'.xml'))
+                lastpresetfullpath = self.preset_path / Path(config('user', 'lastpreset')+'.xml')
+                Path(lastpresetfullpath).resolve(strict=True)
+                logger.warning(f"Automatically loading {config('user', 'lastpreset')}")
+                self.set_file_preset(lastpresetfullpath)
         except configmod.ConfigError as ke_error:
             logger.warning(repr(ke_error))
+        except FileNotFoundError:
+            logger.warning(f"Last preset {config('user', 'lastpreset')} not found. Not loading it !!")
+            config['user', 'loadlast'] = False
+            config.save()
+
+
 
     @property
     def splash_sc(self) -> QtWidgets.QSplashScreen:
@@ -1195,7 +1205,8 @@ class DashBoard(CustomApp):
         try:
             config['user', 'loadlast'] = not config('user', 'loadlast')
         except configmod.ConfigError:
-            config['user', 'loadlast'] = True
+            config['user', 'loadlast'] = False
+            logger.warning(f"Config Error : changed load last user config to {config['user', 'loadlast']}")
         config.save()
 
     def modify_preset(self):
@@ -1588,12 +1599,15 @@ class DashBoard(CustomApp):
         if not isinstance(filename, Path):
             filename = Path(filename)
 
+
         config['user', 'lastloadok'] = False
         config.save()
 
         if filename.suffix == ".xml":
             self.preset_file = filename
             self.preset_manager.set_file_preset(filename, show=False)
+            config['user', 'lastpreset'] = filename.name.rstrip(".xml")
+            config.save()
             move_docks = []
             det_docks_settings = []
             det_docks_viewer = []
@@ -1761,7 +1775,6 @@ class DashBoard(CustomApp):
             if self.pid_module is not None:
                 self.pid_module.set_module_manager(detector_modules, actuators_modules)
 
-            config['user', 'lastpreset'] = filename.name.strip(".xml")
             config['user', 'lastloadok'] = True
             config.save()
 

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -261,7 +261,6 @@ class DashBoard(CustomApp):
 
         try:
             if config('user', 'loadlast') and config('user', 'lastloadok'):
-                #todo os.path.isfile(self.preset_path / Path(config('user', 'lastpreset')+'.xml'))
                 lastpresetfullpath = self.preset_path / Path(config('user', 'lastpreset')+'.xml')
                 Path(lastpresetfullpath).resolve(strict=True)
                 logger.warning(f"Automatically loading {config('user', 'lastpreset')}")

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -5,7 +5,6 @@ import sys
 import datetime
 import subprocess
 import logging
-from functools import total_ordering
 from pathlib import Path
 from importlib import import_module
 from packaging import version as version_mod
@@ -957,6 +956,7 @@ class DashBoard(CustomApp):
         self.load_preset_menu = self.preset_menu.addMenu("Load presets")
         self.preset_menu.addSeparator()
         toggle_loadlast = self.preset_menu.addAction('Load last Preset at startup')
+        #toggle_loadlast.triggered.connect(self.preset_menu.show)
         toggle_loadlast.setCheckable(True)
         try:
             toggle_loadlast.setChecked(config('user', 'loadlast'))

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -269,7 +269,7 @@ class DashBoard(CustomApp):
             logger.warning(repr(ke_error))
         except FileNotFoundError:
             logger.warning(f"Last preset {config('user', 'lastpreset')} not found. Not loading it !!")
-            config['user', 'loadlast'] = False
+            config['user', 'lastloadok'] = False
             config.save()
 
 

--- a/src/pymodaq/dashboard.py
+++ b/src/pymodaq/dashboard.py
@@ -258,6 +258,13 @@ class DashBoard(CustomApp):
             if self.check_update(show=False):
                 sys.exit(0)
 
+        try:
+            if config('user', 'loadlast') and config('user', 'lastloadok'):
+                logger.warning("Automatically loading"+str(config('user', 'lastpreset')))
+                self.set_file_preset(self.preset_path / Path(config('user', 'lastpreset')+'.xml'))
+        except configmod.ConfigError as ke_error:
+            logger.warning(repr(ke_error))
+
     @property
     def splash_sc(self) -> QtWidgets.QSplashScreen:
         if not hasattr(self, "_splash_sc") or self._splash_sc is None:
@@ -939,6 +946,18 @@ class DashBoard(CustomApp):
         self.preset_menu.addAction(self.get_action("modify_preset"))
         self.preset_menu.addSeparator()
         self.load_preset_menu = self.preset_menu.addMenu("Load presets")
+        self.preset_menu.addSeparator()
+        toggle_loadlast = self.preset_menu.addAction('Load last Preset at startup')
+        toggle_loadlast.setCheckable(True)
+        try:
+            toggle_loadlast.setChecked(config('user', 'loadlast'))
+        except configmod.ConfigError as conf_error:
+            logger.warning(repr(conf_error))
+            toggle_loadlast.setChecked(False)
+        toggle_loadlast.setToolTip("Load last Preset at startup")
+        # toggle_loadlast.setIconSize(QSize(15, 15)) can't change icon size
+        # import utils.manager.action_manager.ActionManager ?
+        toggle_loadlast.changed.connect(self.modify_loadlast_config)
 
         for ind_file, file in enumerate(self.preset_path.iterdir()):
             if file.suffix == ".xml":
@@ -1170,6 +1189,14 @@ class DashBoard(CustomApp):
                 pass
         except Exception as e:
             logger.exception(str(e))
+
+    @staticmethod
+    def modify_loadlast_config():
+        try:
+            config['user', 'loadlast'] = not config('user', 'loadlast')
+        except configmod.ConfigError:
+            config['user', 'loadlast'] = True
+        config.save()
 
     def modify_preset(self):
         try:
@@ -1561,6 +1588,9 @@ class DashBoard(CustomApp):
         if not isinstance(filename, Path):
             filename = Path(filename)
 
+        config['user', 'lastloadok'] = False
+        config.save()
+
         if filename.suffix == ".xml":
             self.preset_file = filename
             self.preset_manager.set_file_preset(filename, show=False)
@@ -1730,6 +1760,11 @@ class DashBoard(CustomApp):
             self.mainwindow.setWindowTitle(f"PyMoDAQ Dashboard: {self.title}")
             if self.pid_module is not None:
                 self.pid_module.set_module_manager(detector_modules, actuators_modules)
+
+            config['user', 'lastpreset'] = filename.name.strip(".xml")
+            config['user', 'lastloadok'] = True
+            config.save()
+
             return actuators_modules, detector_modules
         else:
             logger.error("Invalid file selected")

--- a/src/pymodaq/utils/gui_utils/loader_utils.py
+++ b/src/pymodaq/utils/gui_utils/loader_utils.py
@@ -8,7 +8,7 @@ from pymodaq.utils.config import get_set_preset_path
 from pymodaq.extensions.utils import CustomExt
 
 
-def load_dashboard_with_preset(preset_name: str, extension_name: str) -> \
+def load_dashboard_with_preset(preset_name: str, extension_name: str=None) -> \
         (DashBoard, CustomExt, QMainWindow):
 
     """ Load the Dashboard using a given preset then load an extension


### PR DESCRIPTION
Added 3 entries in the [user] section of the pymodaq toml :
loadlast = true
lastloadok = true
lastpreset = "preset_name"

Added a checkbox in the preset menu, to activate default loading last preset

Testing parameters, file existence and proper loading of the preset to change config value accordingly.

Bonus : added a default to None for extension when loading a dashboard from command line with preset as an argument