### PR TITLE
remove other type of suffix... encountered during install

### DIFF
--- a/git_describe.py
+++ b/git_describe.py
@@ -28,6 +28,7 @@ try:
 
     # Remove "~1" or similar suffix
     version = version.split("~")[0]
+    version = version.split("^")[0]
 except Exception:
     version = FALLBACK_VERSION
 


### PR DESCRIPTION
While trying to create locally a "dev tag" :

git tag -a 5.2.0.dev (without triggering a release)

the installation of the packages was failing because the version extracted by the git_describe returned something with the "^" character different from the "~" one already taken into account...
This PR strip this character BUT we should try and see where it comes from and what are the other bits that could be added... 