### PR TITLE
Documentation about monorepo and install script update

### DIFF
--- a/docs/src/developer_folder/contributing.rst
+++ b/docs/src/developer_folder/contributing.rst
@@ -19,7 +19,7 @@ If you're willing to help, there are several ways to do it:
 For the last point, here are some pointers:
 
 You should `fork and clone <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo#forking-a-repository/>`_
-the up-to-date GitHub repo: https://github.com/PyMoDAQ using git command line or GitHub Desktop
+the up-to-date GitHub repo: https://github.com/PyMoDAQ/PyMoDAQ using git command line or GitHub Desktop
 (the latter is recommended for newcomers, just make sure to uncheck "Copy the ... branch only").
 Then create a dedicated branch name from the change you want to work on
 (using git).
@@ -29,10 +29,10 @@ Finally it is advised to create a dedicated virtual environment for this and ins
 - ``mamba create -n dev_env``
 - ``mamba activate dev_env``
 - ``cd`` to the location of the folder where you downloaded or cloned the repository.
-- install the package as a developer with test tools using the command ``pip install -e ".[dev]"``.
+- install the package as a developer with test tools using the command either by using the provided script ``python install-packages.py -d``.
+    - it calls `pip install -e` on each pymodaq package (pymodaq_utils, pymodaq_data, pymodaq_gui and pymodaq) in the package folder.
     - the `-e` option tells pip to install the package in editable mode, meaning that any change done to the source will be reported to the installed package.
-    - the `".[dev]"` argument indicate to install the current folder as a package alongside its optional dependancies, declared as `dev` in the `pyproject.toml` file.
-    - the quotes around `[dev]` just allow to escape the sequence in order to not be interpreted by the shell.
+    - the `-d` option activates `[dev]` in the package names transmitted to `pip install` (e.g. `pymodaq_utils[dev]`). It indicate to install the package alongside its optional dependancies, declared as `dev` in the `pyproject.toml` file.
 
 
 Then any change on the code will be *seen* by python interpreter so that you can see and test your modifications. Think about
@@ -53,9 +53,9 @@ define here. PyMoDAQ versioning follows usual practice, as described `in this li
     :width: 150
     :align: center
 
-Starting from January 2024, the following structure was agreed upon by the contributors. At any given time,
-there is a **stable** version of PyMoDAQ - at the time of writing it is 4.1.0 - which is not to be modified except for
-bugfixes, and a **development** version (currently, 4.2.0), onto which new features may be added.
+Starting from November 2025, the following structure was agreed upon by the contributors. At any given time,
+there is a **stable** version of PyMoDAQ - at the time of writing it is 5.1.0 - which is not to be modified except for
+bugfixes, and a **development** version (he next **minor** version), onto which new features may be added.
 
 The release cycle is illustrated in this figure:
 
@@ -65,18 +65,19 @@ This cycle makes use of several types of branches:
 
 **Code flow branches:**
 
-* **the stable branch, eg: '4.1.x'** This is the branch representing the stable version of PyMoDAQ. No change should be
+* **the stable branch, eg: '5.1.x'** This is the branch representing the stable version of PyMoDAQ. No change should be
   made on this branch except bugfixes and hotfixes (see below). This is the branch from which the official releases are
-  created, for instance version 4.1.0, 4.1.1, 4.1.2, etc.
+  created, for instance version *5.1.0*, *5.1.1*, *5.1.2*, etc. Only packages with modifications will be part of a bugfix release.
+  For example, if the current version is *5.1.0*, all packaged are at version *5.1.0*. Then, pymodaq_data and pymodaq_utils are
+  modified and a new bugfix version is released, then pymodaq_utils and pymodaq_data *5.1.1* will be released and pymodaq_gui
+  and pymodaq will stay at *5.1.0*.
 
-* **the development branch, eg: '4.2.x_dev** Note that the branch name differs from the stable branch by one increment
-  on the minor revision number (2 instead of 1), and the '_dev' suffix is added for clarity.
+* **the development branch: 'dev** Note that the branch name will **always** be dev.
   This is the development branch. It is *ahead* of the main branch, in the sense that it contains more
   recent commits than the main branch. It is thus the future state of the code. This is where the last developments
   of the code of PyMoDAQ are pushed. When the developers are happy with the state of this branch, typically when they
-  finished to develop a new functionality and they tested it, this will lead to a new *release* of PyMoDAQ (4.1.x -> 4.2.0 in our example).
-  In practice, the branch will simply be renamed from *4.2.x_dev* to *4.2.x*, and a new branch *4.3.x_dev* will be created
-  to continue the cycle.
+  finished to develop a new functionality and they tested it, this will lead to a new *release* of all four packages (5.1.x -> 5.2.0 in our example).
+  In practice, the branch will stay *dev* but a *5.2.x* branch  will be created based on the last state of *dev*
 
 **Temporary branches:**
 
@@ -89,7 +90,7 @@ This cycle makes use of several types of branches:
   all branches, if applicable (see note below).
 
 * **Hotfix, eg: 'hotfix/fix_huge_bug'**: This is similar to a bugfix, but for more important bugs. More precisely, hotfixes
-  are important enough that when applied, they will trigger an immediate new release (e.g. *4.1.1* -> *4.1.2*) that incorporate the fix.
+  are important enough that when applied, they will trigger an immediate new release (e.g. *5.1.1* -> *5.1.2*) that incorporate the fix.
   At the contrary bugfixes can wait for a future release.
 
 .. note::

--- a/docs/src/tutorials/write_documentation.rst
+++ b/docs/src/tutorials/write_documentation.rst
@@ -118,7 +118,7 @@ We will now create a new branch from *pymodaq-dev* so that we can isolate our ch
 
 Finally, install our local repository in edition mode in our Python environment
 
-``(pmd_dev) >pip install -e .``
+``(pmd_dev) >python install-packages.py``
 
 We can now safely modify our local repository.
 

--- a/docs/src/user_folder/installation_tips.rst
+++ b/docs/src/user_folder/installation_tips.rst
@@ -27,20 +27,20 @@ suggested to delete/remake the folder (or empty its content) when setting up a n
 version.
 
 
-.. _qt5backend:
+.. _qtbackend:
 
-Qt5 backend
+Qt backend
 -----------
 
 PyMoDAQ source code uses a python package called `qtpy`__ that add an abstraction layer between PyMoDAQ's code
-and the actual Qt5 python implementation (either PyQt5 or PySide2, and soon PyQt6 and PySide6). Qtpy will look on what
+and the actual Qt python implementation (either PyQt6 or PySide6, but also PyQt5). Qtpy will look on what
 is installed on your environment and load PyQt5 by default (see the :ref:`configfile` to change this default behaviour).
 This means you have to install one of these backends on your environment using either:
 
+
+* ``pip install pyqt6`` 
+* ``pip install pyside6``
 * ``pip install pyqt5``
-* ``pip install pyside2`` (still some issues with some parts of pymodaq's code. If you want to help fix them, please, don't be shy!)
-* ``pip install pyqt6`` (not tested yet)
-* ``pip install pyside6`` (not tested yet)
 
 
 __ https://pypi.org/project/QtPy/

--- a/install-packages.py
+++ b/install-packages.py
@@ -8,19 +8,25 @@ from pathlib import Path
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Install PyMoDAQ packages (optionally in editable mode)."
+        description="Install all four PyMoDAQ packages in the right order (by default in editable mode)."
     )
+
     parser.add_argument(
-        "-e", "--editable",
+        "-d", "--dev",
         action="store_true",
-        help="Install packages in editable mode."
+        help="Also install dev requirements"
+    )
+
+    parser.add_argument(
+        "-n", "--non-editable",
+        action="store_true",
+        help="Install packages in non-editable (normal) mode."
     )
 
     return parser.parse_args()
 
 def main():
     args = parse_args()
-
     current_dir = Path(__file__).resolve().parent
     packages = [
         current_dir / "packages" / "pymodaq_utils",
@@ -31,11 +37,12 @@ def main():
 
     for package in packages:      
         cmd = [sys.executable, "-m", "pip", "install"]
-        if args.editable:
+        if not args.non_editable:
             cmd.append("-e")
         cmd.append(str(package))
+        if args.dev:
+            cmd[-1] += '[dev]'
         subprocess.run(cmd, check=True)
-
-
+        
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Updated documentation about monorepo and the new install script
Install script installs in editable mode by default and can install optional dev dependencies

It's still missing a figure about the new branches organization (but it will be ready soon)