### PR TITLE
An attempt to fix coverage report uploads

### DIFF
--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -63,9 +63,8 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-
-  
       - name: Merge coverage files and convert to xml
+        run: |
           python -m pip install coverage
           coverage combine ./merged_coverage_*
           coverage xml -i

--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -1,0 +1,77 @@
+name: Coverage upload
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - "Test for pymodaq"
+      - "Test for pymodaq_utils"
+      - "Test for pymodaq_gui"
+      - "Test for pymodaq_data"
+    types:
+      - completed
+
+concurrency:
+  # github.workflow: name of the workflow
+  # github.event.pull_request.number || github.ref: pull request number or branch name if not a pull request
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
+  
+jobs:
+  merge:
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+    runs-on: "ubuntu-latest"
+    steps:
+
+      - name: Set up GitHub CLI 
+      run: sudo apt-get install gh -y
+
+      - name: Set up Python
+      uses: actions/setup-python@v5.4.0
+      with:
+        python-version: '3.12'
+
+      - name: Trigger missing test workflows per package
+        run: |
+          set -e
+          workflows=("Test for pymodaq" "Test for pymodaq_utils" "Test for pymodaq_gui" "Test for pymodaq_data")
+          for wf in "${workflows[@]}"; do
+            pkg=$(echo "$wf" | sed 's/Test for //')
+      
+            # Try to download artifact to check if workflow already ran
+            if ! gh run download --workflow "$wf" --name "coverage-$pkg" -D ./coverage 2>/dev/null; then
+              gh workflow run "$wf" -f ref="${GITHUB_SHA}"
+
+              # Wait for workflow to complete
+              while true; do
+                sleep 60
+                status=$(gh run list --workflow "$wf" --branch "${GITHUB_REF##*/}" --limit 1 --json status,conclusion -q '.[0]')
+                if [[ "$status" == *"completed"* ]]; then
+                  break
+                fi
+              done
+            fi
+          done
+
+       - name: Download merged coverage artifacts
+        uses: actions/download-artifact@v5.0.0
+        with:
+          pattern: "merged-coverage-*"
+          path: artifacts
+          merge-multiple: true
+
+
+  
+      - name: Merge coverage files and convert to xml
+          python -m pip install coverage
+          coverage combine ./merged_coverage_*
+          coverage xml -i
+
+      - name: Upload combined coverage report to Codecov
+        uses: codecov/codecov-action@v5.5.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml

--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -27,12 +27,12 @@ jobs:
     steps:
 
       - name: Set up GitHub CLI 
-      run: sudo apt-get install gh -y
+        run: sudo apt-get install gh -y
 
       - name: Set up Python
-      uses: actions/setup-python@v5.4.0
-      with:
-        python-version: '3.12'
+        uses: actions/setup-python@v5.4.0
+        with:
+          python-version: '3.12'
 
       - name: Trigger missing test workflows per package
         run: |
@@ -56,7 +56,7 @@ jobs:
             fi
           done
 
-       - name: Download merged coverage artifacts
+      - name: Download merged coverage artifacts
         uses: actions/download-artifact@v5.0.0
         with:
           pattern: "merged-coverage-*"

--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: "ubuntu-latest"
-    steps:
   collect-coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -25,37 +25,123 @@ jobs:
       fail-fast: false
     runs-on: "ubuntu-latest"
     steps:
-
-      - name: Set up GitHub CLI 
-        run: sudo apt-get install gh -y
-
-      - name: Set up Python
-        uses: actions/setup-python@v5.4.0
+  collect-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait and collect coverage
+        uses: actions/github-script@v8
         with:
-          python-version: '3.12'
-
-      - name: Trigger missing test workflows per package
-        run: |
-          set -e
-          workflows=("Test for pymodaq" "Test for pymodaq_utils" "Test for pymodaq_gui" "Test for pymodaq_data")
-          for wf in "${workflows[@]}"; do
-            pkg=$(echo "$wf" | sed 's/Test for //')
-      
-            # Try to download artifact to check if workflow already ran
-            if ! gh run download --workflow "$wf" --name "coverage-$pkg" -D ./coverage 2>/dev/null; then
-              gh workflow run "$wf" -f ref="${GITHUB_SHA}"
-
-              # Wait for workflow to complete
-              while true; do
-                sleep 60
-                status=$(gh run list --workflow "$wf" --branch "${GITHUB_REF##*/}" --limit 1 --json status,conclusion -q '.[0]')
-                if [[ "$status" == *"completed"* ]]; then
-                  break
-                fi
-              done
-            fi
-          done
-
+          script: |
+            const packages = ['pymodaq_utils', 'pymodaq_data', 'pymodaq_gui', 'pymodaq'];
+            const headSha = context.payload.workflow_run.head_sha;
+            const headBranch = context.payload.workflow_run.head_branch;
+            const event = context.payload.workflow_run.event;
+            
+            console.log(`SHA: ${headSha}, Branch: ${headBranch}, Event: ${event}\n`);
+            
+            // Wait 10 minutes so that test mostly finishes
+            await new Promise(r => setTimeout(r, 10*60000));
+            // Get all test runs for this commit
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: headSha,
+              event: event
+            });
+            
+            const testRuns = {};
+            for (const pkg of packages) {
+              const run = runs.workflow_runs.find(r => r.name === `Test for ${pkg}`);
+              if (run) testRuns[pkg] = run;
+            }
+            
+            // Wait for in-progress runs
+            for (const pkg of packages) {
+              if (testRuns[pkg]?.status !== 'completed') {
+                console.log(`Waiting for ${pkg}...`);
+                let attempts = 0;
+                while (attempts < 60) {
+                  await new Promise(r => setTimeout(r, 1*60000));
+                  const { data: run } = await github.rest.actions.getWorkflowRun({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    run_id: testRuns[pkg].id
+                  });
+                  if (run.status === 'completed') {
+                    testRuns[pkg] = run;
+                    console.log(`${pkg} completed`);
+                    break;
+                  }
+                  attempts++;
+                }
+              }
+            }
+            
+            // Check for missing artifacts and trigger tests
+            for (const pkg of packages) {
+              const run = testRuns[pkg];
+              let hasArtifact = false;
+              
+              if (run) {
+                const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id
+                });
+                hasArtifact = artifacts.artifacts.some(a => a.name === `coverage-${pkg}`);
+              }
+              
+              if (!hasArtifact) {
+                console.log(`Triggering test for ${pkg}...`);
+                
+                const { data: workflows } = await github.rest.actions.listRepoWorkflows({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo
+                });
+                
+                const workflow = workflows.workflows.find(w => w.name === `Test for ${pkg}`);
+                if (workflow) {
+                  await github.rest.actions.createWorkflowDispatch({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: workflow.id,
+                    ref: headBranch
+                  });
+                  
+                  // Wait for new run to appear and complete (10 minutes should be enough)
+                  await new Promise(r => setTimeout(r, 10*60000));
+                  
+                  const { data: newRuns } = await github.rest.actions.listWorkflowRuns({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    workflow_id: workflow.id,
+                    branch: headBranch,
+                    per_page: 1
+                  });
+                  
+                  if (newRuns.workflow_runs[0]) {
+                    const runId = newRuns.workflow_runs[0].id;
+                    console.log(`Waiting for triggered ${pkg}...`);
+                    
+                    let attempts = 0;
+                    while (attempts < 60) {
+                      await new Promise(r => setTimeout(r, 1*60000));
+                      const { data: run } = await github.rest.actions.getWorkflowRun({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        run_id: runId
+                      });
+                      if (run.status === 'completed') {
+                        testRuns[pkg] = run;
+                        console.log(`${pkg} completed`);
+                        break;
+                      }
+                      attempts++;
+                    }
+                  }
+                }
+              }
+            }
       - name: Download merged coverage artifacts
         uses: actions/download-artifact@v5.0.0
         with:

--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -22,129 +22,256 @@ jobs:
   collect-coverage:
     runs-on: ubuntu-latest
     steps:
-      - name: Wait and collect coverage
+      - name: Checkout the repo
+        uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 0
+
+
+      - name: Ensure coverage is generated and download artifacts
         uses: actions/github-script@v8
         with:
           script: |
-            const packages = ['pymodaq_utils', 'pymodaq_data', 'pymodaq_gui', 'pymodaq'];
-            const headSha = context.payload.workflow_run.head_sha;
-            const headBranch = context.payload.workflow_run.head_branch;
-            const event = context.payload.workflow_run.event;
-            
-            console.log(`SHA: ${headSha}, Branch: ${headBranch}, Event: ${event}\n`);
-            
-            // Wait 10 minutes so that test mostly finishes
-            await new Promise(r => setTimeout(r, 10*60000));
-            // Get all test runs for this commit
-            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              head_sha: headSha,
-              event: event
-            });
-            
-            const testRuns = {};
-            for (const pkg of packages) {
-              const run = runs.workflow_runs.find(r => r.name === `Test for ${pkg}`);
-              if (run) testRuns[pkg] = run;
-            }
-            
-            // Wait for in-progress runs
-            for (const pkg of packages) {
-              if (testRuns[pkg]?.status !== 'completed') {
-                console.log(`Waiting for ${pkg}...`);
-                let attempts = 0;
-                while (attempts < 60) {
-                  await new Promise(r => setTimeout(r, 1*60000));
-                  const { data: run } = await github.rest.actions.getWorkflowRun({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    run_id: testRuns[pkg].id
+            /* ================================================================================= */
+            /* ================================================================================= */
+            /* =================================== Context ===================================== */
+            /* ================================================================================= */
+            /* ================================================================================= */
+
+            const sha    = process.env.GITHUB_SHA;
+            const branch = process.env.GITHUB_REF_NAME;
+            const event  = process.env.GITHUB_EVENT_NAME;
+            const owner  = context.repo.owner
+            const repo   = context.repo.repo
+
+            const artifact_save_base_path = "."
+
+            const fs = require("fs");
+            const path = require("path");
+
+            /* ================================================================================= */
+            /* ================================================================================= */
+            /* ============================== Helper functions ================================= */
+            /* ================================================================================= */
+            /* ================================================================================= */
+
+            //Sleep `seconds` seconds (works with floats)
+            const sleep = (seconds) => new Promise(r => setTimeout(r, seconds * 1000));
+
+            //Check if a json object contains something
+            const is_empty = (json) => Object.keys(json).length === 0;
+
+            //List all "Test for <package>" runs for the current event
+            const get_corresponding_test_runs = async (packages, _event=event, strict=false) => {
+              const test_runs = {};
+
+
+              // Define the filter strategies in order as it's only triggered by changes
+              const base_strategies = [
+                {branch : branch, head_sha: sha, event : _event }, // Runs that are triggered by any modification on this branch from this event
+                {branch : branch, head_sha: sha },        // Then we try with the same commit but different event
+                {branch : branch},                        // Then anything else, as if no run was triggered, the code wasn't changed
+                {}                                        // Otherwise anything else, as if there was no triggered run on the commit 
+              ];
+
+              const strategies = strict ? [base_strategies[0]] : base_strategies;
+
+              for (const package of packages) {
+                let run = null;
+
+                // Try each strategy untila run is found
+                for (const strategy of strategies) {
+                  const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                    owner : owner,
+                    repo : repo,
+                    ...strategy,
                   });
-                  if (run.status === 'completed') {
-                    testRuns[pkg] = run;
-                    console.log(`${pkg} completed`);
+
+                  run = data.workflow_runs.find(r => r.name === `Test for ${package}`);
+                  if (run) break; // stop as soon as a match is found
+                }
+
+                test_runs[package] = run;
+              }
+
+              return test_runs;
+            };
+
+            // Wait `attempts` times for `seconds` seconds that `run_id` run is over
+            // return null if timed out.  
+            const wait_for_run_completion = async (run_id, seconds = 60, attempts=10) => {
+              let i = 0;
+              while (i < attempts) {
+                await sleep(seconds);
+                const { data: run } = await github.rest.actions.getWorkflowRun({
+                  owner: owner,
+                  repo: repo,
+                  run_id: run_id
+                });
+                if (run.status === 'completed') {
+                  return run;
+                }
+                i++;
+              }
+              return null;
+            };
+
+            // Return a workflow by its name
+            const get_workflow_by_name = async (name) => {
+              const { data: workflows } = await github.rest.actions.listRepoWorkflows({
+                owner: owner,
+                repo: repo
+              });
+              
+              return workflows.workflows.find(w => w.name === name);
+            };
+
+
+            const save_artifact = async (artifact) => {
+              const {data : artifact_data } = await github.rest.actions.downloadArtifact({
+                owner : owner,
+                repo : repo,
+                artifact_id : artifact.id,
+                archive_format : "zip"
+              });
+
+              const filename = path.join(artifact_save_base_path, `${artifact.name}.zip`)
+              fs.writeFileSync(filename, Buffer.from(artifact_data, "base64"))
+            }
+            /* ================================================================================= */
+            /* ================================================================================= */
+            /* ================================== Entrypoint =================================== */
+            /* ================================================================================= */
+            /* ================================================================================= */
+
+            const packages = ['pymodaq_utils', 'pymodaq_data', 'pymodaq_gui', 'pymodaq'];
+            console.log(`SHA: ${sha}, Branch: ${branch}, Event: ${event}\n`);
+
+
+            //Create artifact download folder
+            if (!fs.existsSync(artifact_save_base_path)) fs.mkdirSync(artifact_save_base_path, { recursive: true });
+
+            //Wait 10 seconds so that we're "sure" that everything else is started
+            await sleep(10);
+
+            // Get last test runs for each package in this commit (if they exist)
+            const test_runs = await get_corresponding_test_runs(packages);
+
+            // Wait for in-progress runs
+            // For each package, is there's a run not completed, we wait for it
+            for (const package of packages) {
+              if (!test_runs[package]){
+                continue;
+              }
+
+              if (test_runs[package].status !== 'completed') {
+                console.log(`Waiting for initial run of ${package}...`);
+                const run = await wait_for_run_completion(test_runs[package].id);
+
+                if (run){
+                  console.log(`Initial run of ${package} is over.`);
+                  test_runs[package] = run;
+                }
+                else {
+                  console.log(`Waiting for initial run of ${package} timed out.`);
+                }
+              }
+            }
+
+            // For each package_name, get the corresponding run, 
+            // and check if one of its artifact is "merged-coverage-<package-name>"
+            // If a package doesn't have an artifact, keep track of it
+            // Otherwise, download it
+            const packages_without_coverage_artifact = [];
+            for (const package of packages) {
+              console.log(`Looking for artifacts in ${package}`)
+              const { data: artifacts } = await github.rest.actions.listArtifactsForRepo({
+                owner: owner,
+                repo: repo,
+                name : `merged-coverage-${package.split("_")[1] ?? package}`
+              });
+
+              let artifact = artifacts.artifacts?.[0]
+
+              if (artifact) {
+                await save_artifact(artifact)
+                console.log(`Saved artifact ${artifact.name} for ${package}`)
+              }
+              else {
+                console.log(`${package} is missing coverage artifact`);
+                packages_without_coverage_artifact.push(package);
+              }
+            }
+
+
+            // For each package with a missing coverage artifact, trigger a run for its test
+            const triggered_runs = {};
+            for (const package of packages_without_coverage_artifact) {
+              console.log(`Triggering test for ${package}...`);
+
+              
+              const workflow = await get_workflow_by_name(`Test for ${package}`);
+              if (workflow) {
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: owner,
+                  repo: repo,
+                  workflow_id: workflow.id,
+                  ref : branch
+                });
+
+                for (let i = 0; i < 30; i++) {
+                  await sleep(10);
+                  const runs = await get_corresponding_test_runs([package], _event='workflow_dispatch', strict=true);
+                  if (runs[package]) {
+                    console.log(`Triggered ${package}, run id = ${runs[package].id}`);
+                    triggered_runs[package] = runs[package];
                     break;
                   }
-                  attempts++;
-                }
-              }
-            }
-            
-            // Check for missing artifacts and trigger tests
-            for (const pkg of packages) {
-              const run = testRuns[pkg];
-              let hasArtifact = false;
-              
-              if (run) {
-                const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  run_id: run.id
-                });
-                hasArtifact = artifacts.artifacts.some(a => a.name === `coverage-${pkg}`);
-              }
-              
-              if (!hasArtifact) {
-                console.log(`Triggering test for ${pkg}...`);
-                
-                const { data: workflows } = await github.rest.actions.listRepoWorkflows({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo
-                });
-                
-                const workflow = workflows.workflows.find(w => w.name === `Test for ${pkg}`);
-                if (workflow) {
-                  await github.rest.actions.createWorkflowDispatch({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    workflow_id: workflow.id,
-                    ref: headBranch
-                  });
-                  
-                  // Wait for new run to appear and complete (10 minutes should be enough)
-                  await new Promise(r => setTimeout(r, 10*60000));
-                  
-                  const { data: newRuns } = await github.rest.actions.listWorkflowRuns({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    workflow_id: workflow.id,
-                    branch: headBranch,
-                    per_page: 1
-                  });
-                  
-                  if (newRuns.workflow_runs[0]) {
-                    const runId = newRuns.workflow_runs[0].id;
-                    console.log(`Waiting for triggered ${pkg}...`);
-                    
-                    let attempts = 0;
-                    while (attempts < 60) {
-                      await new Promise(r => setTimeout(r, 1*60000));
-                      const { data: run } = await github.rest.actions.getWorkflowRun({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        run_id: runId
-                      });
-                      if (run.status === 'completed') {
-                        testRuns[pkg] = run;
-                        console.log(`${pkg} completed`);
-                        break;
-                      }
-                      attempts++;
-                    }
+                  else{
+                    console.log(`Failed to detect triggered run for ${package}`)
                   }
                 }
               }
             }
-      - name: Download merged coverage artifacts
-        uses: actions/download-artifact@v5.0.0
-        with:
-          pattern: "merged-coverage-*"
-          path: artifacts
-          merge-multiple: true
+
+            if (!is_empty(triggered_runs)){
+              // Sleep for 10 minutes should be enough for all test runs to be over
+              await sleep(10*60);
+
+              //Wait for each triggered run to complete
+              for(const package of Object.keys(triggered_runs)) {
+                console.log(`Waiting for triggered run of ${package}...`);
+                const run = await wait_for_run_completion(triggered_runs[package].id);
+                if (run){
+                    console.log(`Triggered run of ${package} is over.`);
+                
+                    const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
+                      owner: owner,
+                      repo: repo,
+                      run_id: test_runs[package].id
+                    });
+                
+                    const artifact = artifacts.artifacts.find(a => a.name ===  `merged-coverage-${package.split("_")[1] ?? package}`);
+                
+                    if (artifact) {
+                      await save_artifact(artifact)
+                      console.log(`Saved artifact ${artifact.name} for ${package}`)
+                    }
+                    else {
+                      console.log(`${package} is missing coverage artifact`);
+                      packages_without_coverage_artifact.push(package);
+                    }
+                }
+                else {
+                  console.log(`Waiting for triggered run of ${package} timed out.`);
+                }
+              }
+            }
 
       - name: Merge coverage files and convert to xml
         run: |
+          unzip \*.zip
+          ls 
           python -m pip install coverage
           coverage combine ./merged_coverage_*
           coverage xml -i

--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -19,11 +19,6 @@ concurrency:
   cancel-in-progress: true
   
 jobs:
-  merge:
-    continue-on-error: true
-    strategy:
-      fail-fast: false
-    runs-on: "ubuntu-latest"
   collect-coverage:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -58,28 +58,29 @@ jobs:
             //Sleep `seconds` seconds (works with floats)
             const sleep = (seconds) => new Promise(r => setTimeout(r, seconds * 1000));
 
-            //Check if a json object contains something
+            //Check if a json object contains something or is just {}
             const is_empty = (json) => Object.keys(json).length === 0;
 
-            //List all "Test for <package>" runs for the current event
+            // List all "Test for <package>" runs for each package in packages.
+            // If strict is true, only _event is considered
+            // Otherwise a priority based search strategy is made
             const get_corresponding_test_runs = async (packages, _event=event, strict=false) => {
               const test_runs = {};
-
-
-              // Define the filter strategies in order as it's only triggered by changes
+            
+              
               const base_strategies = [
-                {branch : branch, head_sha: sha, event : _event }, // Runs that are triggered by any modification on this branch from this event
-                {branch : branch, head_sha: sha },        // Then we try with the same commit but different event
-                {branch : branch},                        // Then anything else, as if no run was triggered, the code wasn't changed
-                {}                                        // Otherwise anything else, as if there was no triggered run on the commit 
+                {branch : branch, head_sha: sha, event : _event }, // Runs directly triggered by this event
+                {branch : branch, head_sha: sha },                 // Runs from the same commit 
+                {branch : branch},                                 // Runs from the same branch
+                {}                                                 // Any run
               ];
 
+              // strict => we only want runs triggered by this event so, only the first strategy
               const strategies = strict ? [base_strategies[0]] : base_strategies;
 
               for (const package of packages) {
                 let run = null;
-
-                // Try each strategy untila run is found
+                // Try each strategy until a run is found
                 for (const strategy of strategies) {
                   const { data } = await github.rest.actions.listWorkflowRunsForRepo({
                     owner : owner,
@@ -97,7 +98,7 @@ jobs:
               return test_runs;
             };
 
-            // Wait `attempts` times for `seconds` seconds that `run_id` run is over
+            // Wait `attempts` times for `seconds` seconds for `run_id` run to complete
             // return null if timed out.  
             const wait_for_run_completion = async (run_id, seconds = 60, attempts=10) => {
               let i = 0;
@@ -116,7 +117,7 @@ jobs:
               return null;
             };
 
-            // Return a workflow by its name
+            // Return a workflow from its name
             const get_workflow_by_name = async (name) => {
               const { data: workflows } = await github.rest.actions.listRepoWorkflows({
                 owner: owner,
@@ -126,9 +127,33 @@ jobs:
               return workflows.workflows.find(w => w.name === name);
             };
 
+            // Return the reference of an artifact by its name, and an optional associated 
+            // run id. If run id is provided the artifact is fetched from this run,
+            // otherwise from any workflow, The first one found (most recent) is returned
+            const get_artifact_from_name = async (name, run_id=undefined) => {
+              let artifacts;
+              if (run_id) {
+                ({ data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
+                  owner: owner,
+                  repo: repo,
+                  run_id: run_id,
+                  name :  name
+                }));
+              } 
+              else {
+                ({ data: artifacts } = await github.rest.actions.listArtifactsForRepo({
+                  owner: owner,
+                  repo: repo,
+                  name : name
+                }));
+              }
+              return artifacts.artifacts?.[0]
+            };
 
+            // Download and save an artifact as zip file from its name.
+            // It is saved in the globally defined location `artifact_save_base_path`
             const save_artifact = async (artifact) => {
-              const {data : artifact_data } = await github.rest.actions.downloadArtifact({
+              const {data : data } = await github.rest.actions.downloadArtifact({
                 owner : owner,
                 repo : repo,
                 artifact_id : artifact.id,
@@ -136,8 +161,8 @@ jobs:
               });
 
               const filename = path.join(artifact_save_base_path, `${artifact.name}.zip`)
-              fs.writeFileSync(filename, Buffer.from(artifact_data, "base64"))
-            }
+              fs.writeFileSync(filename, Buffer.from(data, "base64"))
+            };
             /* ================================================================================= */
             /* ================================================================================= */
             /* ================================== Entrypoint =================================== */
@@ -149,7 +174,9 @@ jobs:
 
 
             //Create artifact download folder
-            if (!fs.existsSync(artifact_save_base_path)) fs.mkdirSync(artifact_save_base_path, { recursive: true });
+            if (!fs.existsSync(artifact_save_base_path)){
+              fs.mkdirSync(artifact_save_base_path, {recursive: true});
+            }
 
             //Wait 10 seconds so that we're "sure" that everything else is started
             await sleep(10);
@@ -181,18 +208,12 @@ jobs:
             // For each package_name, get the corresponding run, 
             // and check if one of its artifact is "merged-coverage-<package-name>"
             // If a package doesn't have an artifact, keep track of it
-            // Otherwise, download it
+            // Otherwise, download and save it
             const packages_without_coverage_artifact = [];
             for (const package of packages) {
               console.log(`Looking for artifacts in ${package}`)
-              const { data: artifacts } = await github.rest.actions.listArtifactsForRepo({
-                owner: owner,
-                repo: repo,
-                name : `merged-coverage-${package.split("_")[1] ?? package}`
-              });
-
-              let artifact = artifacts.artifacts?.[0]
-
+              const artifact = await get_artifact_from_name(`merged-coverage-${package.split("_")[1] ?? package}`);
+      
               if (artifact) {
                 await save_artifact(artifact)
                 console.log(`Saved artifact ${artifact.name} for ${package}`)
@@ -209,7 +230,7 @@ jobs:
             for (const package of packages_without_coverage_artifact) {
               console.log(`Triggering test for ${package}...`);
 
-              
+              //Start the workflow
               const workflow = await get_workflow_by_name(`Test for ${package}`);
               if (workflow) {
                 await github.rest.actions.createWorkflowDispatch({
@@ -219,21 +240,20 @@ jobs:
                   ref : branch
                 });
 
-                for (let i = 0; i < 30; i++) {
-                  await sleep(10);
-                  const runs = await get_corresponding_test_runs([package], _event='workflow_dispatch', strict=true);
-                  if (runs[package]) {
-                    console.log(`Triggered ${package}, run id = ${runs[package].id}`);
-                    triggered_runs[package] = runs[package];
-                    break;
-                  }
-                  else{
-                    console.log(`Failed to detect triggered run for ${package}`)
-                  }
+                //Try to get the run corresponding to the started workflow
+                // by polling the API after 30 seconds. 
+                await sleep(10);
+                ({ [package] : triggered_runs[package]} = await get_corresponding_test_runs([package], _event='workflow_dispatch', strict=true));
+                if (triggered_runs[package]) {
+                  console.log(`Triggered ${package}, run id = ${triggered_runs[package].id}`);
+                }
+                else{
+                  console.log(`Failed to detect triggered run for ${package}`)  
                 }
               }
             }
 
+            //Wait for any triggered run
             if (!is_empty(triggered_runs)){
               // Sleep for 10 minutes should be enough for all test runs to be over
               await sleep(10*60);
@@ -244,14 +264,7 @@ jobs:
                 const run = await wait_for_run_completion(triggered_runs[package].id);
                 if (run){
                     console.log(`Triggered run of ${package} is over.`);
-                
-                    const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
-                      owner: owner,
-                      repo: repo,
-                      run_id: test_runs[package].id
-                    });
-                
-                    const artifact = artifacts.artifacts.find(a => a.name ===  `merged-coverage-${package.split("_")[1] ?? package}`);
+                    const artifact = await get_artifact_from_name(`merged-coverage-${package.split("_")[1] ?? package}`, run.id);
                 
                     if (artifact) {
                       await save_artifact(artifact)
@@ -259,7 +272,6 @@ jobs:
                     }
                     else {
                       console.log(`${package} is missing coverage artifact`);
-                      packages_without_coverage_artifact.push(package);
                     }
                 }
                 else {
@@ -267,11 +279,9 @@ jobs:
                 }
               }
             }
-
       - name: Merge coverage files and convert to xml
         run: |
           unzip \*.zip
-          ls 
           python -m pip install coverage
           coverage combine ./merged_coverage_*
           coverage xml -i

--- a/.github/workflows/tests-data.yml
+++ b/.github/workflows/tests-data.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     paths:
       - 'packages/pymodaq_data/**'
+    branches:
+    - '*'
+    - '!badges' # to exclude execution if someone PR on this branch (shouldn't happen)
   push:
     paths:
       - 'packages/pymodaq_data/**'
@@ -183,10 +186,10 @@ jobs:
         run: |
           python -m pip install coverage
           coverage combine ./coverage-reports/coverage_*
-          coverage xml -i
+          mv .coverage merged_coverage_data
 
-      - name: Upload combined coverage report to Codecov
-        uses: codecov/codecov-action@v5.5.1
+      - name: Upload merged coverage artifact
+        uses: actions/upload-artifact@v4.6.2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
+          name: merged-coverage-data
+          path: merged_coverage_data

--- a/.github/workflows/tests-gui.yml
+++ b/.github/workflows/tests-gui.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     paths:
       - 'packages/pymodaq_gui/**'
+    branches:
+    - '*'
+    - '!badges' # to exclude execution if someone PR on this branch (shouldn't happen)
   push:
     paths:
       - 'packages/pymodaq_gui/**'
@@ -213,10 +216,10 @@ jobs:
         run: |
           python -m pip install coverage
           coverage combine ./coverage-reports/coverage_*
-          coverage xml -i
+          mv .coverage merged_coverage_gui
 
-      - name: Upload combined coverage report to Codecov
-        uses: codecov/codecov-action@v5.5.1
+      - name: Upload merged coverage artifact
+        uses: actions/upload-artifact@v4.6.2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
+          name: merged-coverage-gui
+          path: merged_coverage_gui

--- a/.github/workflows/tests-pymodaq.yml
+++ b/.github/workflows/tests-pymodaq.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     paths:
       - 'packages/pymodaq/**'
+    branches:
+    - '*'
+    - '!badges' # to exclude execution if someone PR on this branch (shouldn't happen)
   push:
     paths:
       - 'packages/pymodaq/**'
@@ -211,10 +214,10 @@ jobs:
         run: |
           python -m pip install coverage
           coverage combine ./coverage-reports/coverage_*
-          coverage xml -i
+          mv .coverage merged_coverage_pymodaq
 
-      - name: Upload combined coverage report to Codecov
-        uses: codecov/codecov-action@v5.5.1
+      - name: Upload merged coverage artifact
+        uses: actions/upload-artifact@v4.6.2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
+          name: merged-coverage-pymodaq
+          path: merged_coverage_pymodaq

--- a/.github/workflows/tests-utils.yml
+++ b/.github/workflows/tests-utils.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     paths:
       - 'packages/pymodaq_utils/**'
+    branches:
+    - '*'
+    - '!badges' # to exclude execution if someone PR on this branch (shouldn't happen)
   push:
     paths:
       - 'packages/pymodaq_utils/**'
@@ -183,10 +186,10 @@ jobs:
         run: |
           python -m pip install coverage
           coverage combine ./coverage-reports/coverage_*
-          coverage xml -i
+          mv .coverage merged_coverage_utils
 
-      - name: Upload combined coverage report to Codecov
-        uses: codecov/codecov-action@v5.5.1
+      - name: Upload merged coverage artifact
+        uses: actions/upload-artifact@v4.6.2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
+          name: merged-coverage-utils
+          path: merged_coverage_utils

--- a/packages/pymodaq/README.rst.tpl
+++ b/packages/pymodaq/README.rst.tpl
@@ -5,11 +5,11 @@ PyMoDAQ
    :target: https://pypi.org/project/pymodaq/
    :alt: Latest Version
 
-.. image:: https://readthedocs.org/projects/pymodaq/badge/?version=latest
-   :target: https://pymodaq.readthedocs.io/en/stable/?badge=latest
+.. image:: https://readthedocs.org/projects/pymodaq/badge/?version={{BRANCH_NAME}}
+   :target: https://pymodaq.readthedocs.io/en/stable/?badge={{BRANCH_NAME}}
    :alt: Documentation Status
 
-.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/graph/badge.svg?token=IQNJRCQDM2
+.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/branch/{{BRANCH_NAME}}/graph/badge.svg?token=IQNJRCQDM2 
  :target: https://codecov.io/gh/PyMoDAQ/PyMoDAQ
 
 

--- a/packages/pymodaq_data/README.rst.tpl
+++ b/packages/pymodaq_data/README.rst.tpl
@@ -5,12 +5,12 @@ PyMoDAQ Data
    :target: https://pypi.org/project/pymodaq_data/
    :alt: Latest Version
 
-.. image:: https://readthedocs.org/projects/pymodaq/badge/?version=latest
-   :target: https://pymodaq.readthedocs.io/en/stable/?badge=latest
+.. image:: https://readthedocs.org/projects/pymodaq/badge/?version={{BRANCH_NAME}}
+   :target: https://pymodaq.readthedocs.io/en/stable/?badge={{BRANCH_NAME}}
    :alt: Documentation Status
 
-.. image:: https://codecov.io/gh/PyMoDAQ/pymodaq_data/branch/5.0.x_dev/graph/badge.svg?token=H32JflMEYR 
- :target: https://codecov.io/gh/PyMoDAQ/pymodaq_data
+.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/branch/{{BRANCH_NAME}}/graph/badge.svg?token=IQNJRCQDM2 
+ :target: https://codecov.io/gh/PyMoDAQ/PyMoDAQ
 
 +-------------+-------------+---------------+
 |             | Linux       | Windows       |

--- a/packages/pymodaq_gui/README.rst.tpl
+++ b/packages/pymodaq_gui/README.rst.tpl
@@ -5,12 +5,12 @@ PyMoDAQ GUI
    :target: https://pypi.org/project/pymodaq_gui/
    :alt: Latest Version
 
-.. image:: https://readthedocs.org/projects/pymodaq/badge/?version=latest
-   :target: https://pymodaq.readthedocs.io/en/stable/?badge=latest
+.. image:: https://readthedocs.org/projects/pymodaq/badge/?version={{BRANCH_NAME}}
+   :target: https://pymodaq.readthedocs.io/en/stable/?badge={{BRANCH_NAME}}
    :alt: Documentation Status
 
-.. image:: https://codecov.io/gh/PyMoDAQ/pymodaq_gui/branch/5.0.x_dev/graph/badge.svg?token=dCg4zaWeBa 
- :target: https://codecov.io/gh/PyMoDAQ/pymodaq_gui
+.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/branch/{{BRANCH_NAME}}/graph/badge.svg?token=IQNJRCQDM2 
+ :target: https://codecov.io/gh/PyMoDAQ/PyMoDAQ
 
 
 

--- a/packages/pymodaq_utils/README.rst.tpl
+++ b/packages/pymodaq_utils/README.rst.tpl
@@ -5,12 +5,12 @@ PyMoDAQ Utils
    :target: https://pypi.org/project/pymodaq_utils/
    :alt: Latest Version
 
-.. image:: https://readthedocs.org/projects/pymodaq/badge/?version=latest
-   :target: https://pymodaq.readthedocs.io/en/stable/?badge=latest
+.. image:: https://readthedocs.org/projects/pymodaq/badge/?version={{BRANCH_NAME}}
+   :target: https://pymodaq.readthedocs.io/en/stable/?badge={{BRANCH_NAME}}
    :alt: Documentation Status
 
-.. image:: https://codecov.io/gh/PyMoDAQ/pymodaq_utils/branch/0.0.x_dev/graph/badge.svg?token=IyhqsXIhjt 
- :target: https://codecov.io/gh/PyMoDAQ/pymodaq_utils
+.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/branch/{{BRANCH_NAME}}/graph/badge.svg?token=IQNJRCQDM2 
+ :target: https://codecov.io/gh/PyMoDAQ/PyMoDAQ
 
 +-------------+-------------+---------------+
 |             | Linux       | Windows       |


### PR DESCRIPTION
The goal is to have only one coverage report uploaded on codecov (not that we have a choice with a monorepo!)

To do that, each test action for a package generate a coverage report and uploads it as an artifact. Then another action, wait for any running test, then try to download each coverage artifact, if no artifact is found (they are only kept one week) tests are restarted. Then all coverage artifacts are combined and sent to codecov!

I don't know if it works, so I'm testing it now!