### PR TITLE
replace attributes actuator_modules and detector_modules by properties relating them to the modules manager

### DIFF
--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -205,7 +205,7 @@ class DashBoard(CustomApp):
         self.joysticks = dict([])
         self.ispygame_init = False
 
-        self.modules_manager: ModulesManager = None
+        self.modules_manager = ModulesManager()
 
         self.overshoot = False
         self.actuators_modules: list[DAQ_Move] = []
@@ -222,6 +222,22 @@ class DashBoard(CustomApp):
         if config_utils("general", "check_version"):
             if self.check_update(show=False):
                 sys.exit(0)
+
+    @property
+    def actuators_modules(self) -> list[DAQ_Move]:
+        return self.modules_manager.actuators_all
+
+    @actuators_modules.setter
+    def actuators_modules(self, modules: list[DAQ_Move]):
+        self.modules_manager.actuators_all = modules
+
+    @property
+    def detector_modules(self) -> list[DAQ_Viewer]:
+        return self.modules_manager.detectors_all
+
+    @detector_modules.setter
+    def detector_modules(self, modules: list[DAQ_Viewer]):
+        self.modules_manager.detectors_all = modules
 
     def do_things_after_ui_setup(self):
         self.preset_manager = PresetManager(dashboard=self,
@@ -294,7 +310,6 @@ class DashBoard(CustomApp):
                 dock = self.dockarea.docks.get(f"{detector_module.title} viewer", None)
                 if dock:
                     dock.close()
-            self.update_module_manager()
         except Exception as e:
             logger.exception(str(e))
 
@@ -317,7 +332,6 @@ class DashBoard(CustomApp):
                 if dock:
                     dock.close()
             self.compact_actuator_dock.close()
-            self.update_module_manager()
         except Exception as e:
             logger.exception(str(e))
 
@@ -360,32 +374,16 @@ class DashBoard(CustomApp):
             actuators_modules = []
             detector_modules = []
             for module in modules:
-                if isinstance(
-                    module, DAQ_Move
-                ):  # Test if module is an instance of DAQ_Move
+                if isinstance(module, DAQ_Move):  # Test if module is an instance of DAQ_Move
                     actuators_modules.append(module)
-                elif isinstance(
-                    module, DAQ_Viewer
-                ):  # Test if module is an instance of DAQ_Viewer
+                elif isinstance(module, DAQ_Viewer):  # Test if module is an instance of DAQ_Viewer
                     detector_modules.append(module)
-                if isinstance(
-                    module, str
-                ):  # Test if module is a string (name of the module)
+                if isinstance(module, str):  # Test if module is a string (name of the module)
                     actuators_modules.extend(
-                        self.modules_manager.get_mods_from_names(
-                            [
-                                module,
-                            ],
-                            "act",
-                        )  # For actuators
-                    )
+                        self.modules_manager.get_mods_from_names([module,], "act",))  # For actuators
+
                     detector_modules.extend(
-                        self.modules_manager.get_mods_from_names(
-                            [
-                                module,
-                            ],
-                            "det",
-                        )  # For detectors
+                        self.modules_manager.get_mods_from_names([module,], "det",)  # For detectors
                     )
             if (hasattr(self, "actuators_modules")) & (
                 self.actuators_modules is not None
@@ -1165,7 +1163,6 @@ class DashBoard(CustomApp):
 
         # Update actuators modules and module manager
         self.actuators_modules.append(actuator)
-        self.update_module_manager()
 
     def add_det(self, plug_name, plug_settings, detector_docks_settings, detector_docks_viewer,
                 detector_modules, plug_type: str = None,  plug_subtype: str = None) -> DAQ_Viewer:
@@ -1261,16 +1258,6 @@ class DashBoard(CustomApp):
 
         # Update actuators modules and module manager
         self.detector_modules.append(detector)
-        self.update_module_manager()
-
-    def update_module_manager(self):
-        if self.modules_manager is None:
-            self.modules_manager = ModulesManager(
-                self.detector_modules, self.actuators_modules, parent_name="Dashboard"
-            )
-        else:
-            self.modules_manager.actuators_all = self.actuators_modules
-            self.modules_manager.detectors_all = self.detector_modules
 
     def poll_init(self, module):
         is_init = False

--- a/packages/pymodaq/src/pymodaq/utils/managers/preset/preset_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/preset/preset_manager.py
@@ -89,9 +89,9 @@ class PresetManager(ManagerBase):
         """
         try:
             if len(self.dashboard.actuators_modules) != 0 or len(self.dashboard.detector_modules) != 0:
-                ret = dialog(f'Warning!',
-                             f'Are you sure you want '
-                             f'to load a new {self.entry_type.capitalize()}: {entry.stem}? \n')
+                ret = dialog(title=f'Warning!',
+                             message=f'Are you sure you want '
+                                     f'to load a new {self.entry_type.capitalize()}: {entry.stem}? \n')
                 if ret:
                     self.dashboard.remove_actuators(self.dashboard.actuators_modules)
                     self.dashboard.remove_detectors(self.dashboard.detector_modules)
@@ -142,8 +142,6 @@ class PresetManager(ManagerBase):
                 self.dashboard.actuators_modules = actuators_modules
                 self.dashboard.detector_modules = detector_modules
 
-                self.dashboard.update_module_manager()
-
                 for mov in actuators_modules:
                     mov.init_signal.connect(self.dashboard.update_init_tree)
                 for det in detector_modules:
@@ -155,8 +153,6 @@ class PresetManager(ManagerBase):
                     area.window().setVisible(True)
 
                 self.dashboard.update_init_tree()
-
-                self.applied_entry.emit(entry.stem)
 
             logger.info(f"{self.entry_type.capitalize()} file: {entry} has been loaded")
 


### PR DESCRIPTION
because synchronisation between the two is not ok (when reloading a preset, removing actuators...)