### PR TITLE
Specify up to which packages to install in install-packages.py script

### DIFF
--- a/docs/src/developer_folder/contributing.rst
+++ b/docs/src/developer_folder/contributing.rst
@@ -34,6 +34,13 @@ Finally it is advised to create a dedicated virtual environment for this and ins
     - the `-e` option tells pip to install the package in editable mode, meaning that any change done to the source will be reported to the installed package.
     - the `-d` option activates `[dev]` in the package names transmitted to `pip install` (e.g. `pymodaq_utils[dev]`). It indicate to install the package alongside its optional dependancies, declared as `dev` in the `pyproject.toml` file.
 
+.. note::
+  The ``install-packages.py`` script also provides a ``-u/--up-to {pymodaq_utils,pymodaq_data,pymodaq_gui,pymodaq}`` optional argument. 
+
+  When provided, only the necessary packages "up to" the specified ones are installed; e.g. ``-u pymodaq_data`` will install *pymodaq_utils* and *pymodaq_data* but **skip** *pymodaq_gui* and *PyMoDAQ* packages.
+  
+  When not provided, it will install all the packages (equivalent to ``-u pymodaq``)
+
 
 Then any change on the code will be *seen* by python interpreter so that you can see and test your modifications. Think about
 writing tests that will make sure your code is sound and that modification elsewhere doesn't change the expected behavior.

--- a/install-packages.py
+++ b/install-packages.py
@@ -6,6 +6,14 @@ import sys
 from pathlib import Path
 
 
+# Order is important!
+PYMODAQ_PACKAGES = [
+        "pymodaq_utils",
+        "pymodaq_data",
+        "pymodaq_gui",
+        "pymodaq",
+    ]
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Install all four PyMoDAQ packages in the right order (by default in editable mode)."
@@ -23,19 +31,26 @@ def parse_args():
         help="Install packages in non-editable (normal) mode."
     )
 
+    parser.add_argument(
+        "-u", "--up-to",
+        type=lambda value: value.lower(),
+        choices=PYMODAQ_PACKAGES,
+        default='pymodaq',
+        help="Select up to which package to install. (e.g. '-o pymodaq_data' will install utils and data packages but not gui and PyMoDAQ itself)"
+    )
+
     return parser.parse_args()
+
+def slice_up_to(ordered_list, element):
+    return ordered_list[0:ordered_list.index(element)+1]
 
 def main():
     args = parse_args()
     current_dir = Path(__file__).resolve().parent
-    packages = [
-        current_dir / "packages" / "pymodaq_utils",
-        current_dir / "packages" / "pymodaq_data",
-        current_dir / "packages" / "pymodaq_gui",
-        current_dir / "packages" / "pymodaq",
-    ]
 
-    for package in packages:      
+    packages = slice_up_to(PYMODAQ_PACKAGES, args.up_to)
+
+    for package in map(lambda package : current_dir / "packages" / package, packages):
         cmd = [sys.executable, "-m", "pip", "install"]
         if not args.non_editable:
             cmd.append("-e")


### PR DESCRIPTION
New ``-u/--up-to`` argument to specify up to which package to install. e.g. ``python install-packages.py -u pymodaq_data`` will install pymodaq_utils and pymodaq_data only (from the local source)