### PR TITLE
Fix failing readthedocs since last pyqtgraph version

### DIFF
--- a/docs/automodule.py
+++ b/docs/automodule.py
@@ -1,14 +1,14 @@
-import site
-from os import system
+import sys, subprocess
+from pathlib import Path
+import importlib.util
 
-pymodaq_module_list = ["pymodaq_utils", "pymodaq_gui", "pymodaq_data"]
 
 if __name__ == "__main__":
 
-    module_path = [path for path in site.getsitepackages() if path.endswith("site-packages")][0]
+    installed_modules = filter(lambda s : s and s.origin, map(lambda m : importlib.util.find_spec(m), ["pymodaq_utils", "pymodaq_gui", "pymodaq_data"]))
+    for module in installed_modules:
+        module_path =  Path(module.origin).parent
+        subprocess.run(["sphinx-apidoc", "-e", "-t",  "./src/_templates/apidoc",  "-o", f"./src/api/{module.name}", f"{module_path}"], check=True)
 
-    for module in pymodaq_module_list:
-        system(f"sphinx-apidoc -e -t ./docs/src/_templates/apidoc -o ./docs/src/api/{module} {module_path}/{module}")
-
-    with open('./docs/src/api/pymodaq_data/pymodaq_data.h5modules.exporter.rst', 'a') as file:
+    with open('./src/api/pymodaq_data/pymodaq_data.h5modules.exporter.rst', 'a') as file:
         file.write('   :exclude-members: H5Exporter\n')

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,9 +4,17 @@ releases
 sphinx-csv-filter
 pillow
 toml
-pyqt5
 numpydoc
 sphinx-datatables
+pyqt6
+sphinx-design==0.5.0
+sphinxcontrib-images==0.9.4
+sphinx-favicon==1.0.1
+sphinx-autodoc-typehints
+sphinx-qt-documentation
+sphinxext-rediraffe
+numpy
+pyopengl
 
 # -e ../packages/pymodaq_utils
 # -e ../packages/pymodaq_data

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -59,14 +59,20 @@ release = get_version()
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "sphinx_qt_documentation",
+    "sphinx_design",
+    "sphinx_favicon",
+    "sphinxext.rediraffe",
+    "sphinxcontrib.images",
+    "sphinx_autodoc_typehints",
     'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
     'sphinx.ext.coverage',
     'sphinx.ext.imgmath',
-    'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
-    'sphinx.ext.napoleon',
     'sphinx.ext.autosummary',
     'releases',
     'crate.sphinx.csv',
@@ -76,6 +82,25 @@ extensions = [
 ]
 
 qt_documentation = "PyQt6"
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'numpy': ('https://numpy.org/doc/stable/', None)
+}
+
+nitpick_ignore_regex = [
+    ("py:class", r"re\.Pattern"),  # doesn't seem to be a good ref in python docs
+]
+
+napoleon_preprocess_types = True
+napoleon_type_aliases = {
+    "callable": ":class:`collections.abc.Callable`",
+    "np.ndarray": ":class:`numpy.ndarray`",
+    'array_like': ':term:`array_like`',
+    'color_like': ':func:`pyqtgraph.mkColor`',
+    # 'ColorMapSpecifier': ':class:`str`, (:class:`str`, :class:`str`), or :class:`~pyqtgraph.ColorMap`',
+}
+
 
 # -- Custom Pygments lexer -----------------------------------------------------
 from sphinx.highlighting import lexers
@@ -89,6 +114,9 @@ numfig = True
 autodoc_member_order = "groupwise"
 autoclass_content = "class"
 autosummary_generate = []
+
+autodoc_inherit_docstrings = False
+
 numpydoc_show_inherited_class_members = False
 numpydoc_class_members_toctree = False
 
@@ -123,6 +151,18 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
+
+autodoc_inherit_docstrings = False
+autodoc_mock_imports = [
+    "scipy",
+    "h5py",
+    "matplotlib",
+    "qtpy",
+    "pyqtgraph",
+    "qtpy.QtCore",
+    "qtpy.QtGui",
+    "qtpy.QtWidgets"
+]
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/icons.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/icons.py
@@ -37,10 +37,13 @@ class Icons():
         self.widget.layout().addLayout(layout_style)
         self.widget.layout().addLayout(layout_theme)
 
+def main():
+    app = QApplication(sys.argv)
 
-app = QApplication(sys.argv)
+    w = Icons(QWidget())
+    w.widget.show()
 
-w = Icons(QWidget())
-w.widget.show()
+    app.exec()
 
-app.exec()
+if __name__ == "__main__":
+    main()

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/utils.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/utils.py
@@ -17,7 +17,7 @@ class ParameterWithPath(SerializableBase):
 
     To be used when communicating between TCPIP to reconstruct properly the Parameter
 
-    Parameters
+    Attributes
     ----------
     parameter: Parameter
         a Parameter object
@@ -50,9 +50,7 @@ class ParameterWithPath(SerializableBase):
 
     @staticmethod
     def serialize(param: 'ParameterWithPath') -> bytes:
-        """
-
-        """
+        """ """
         bytes_string = b''
         path = param.path
         param_as_xml = ioxml.parameter_to_xml_string(param.parameter)
@@ -109,23 +107,27 @@ def get_param_path(param: Parameter) -> List[str]:
 
 def getOpts(param:Parameter,) -> OrderedDict:
     """Return an OrderedDict with tree structures of all opts for all children of this parameter
+
         Parameters
         ----------
         param: Parameter
+
         Returns
         -------
         OrderedDict
     """
-    vals = OrderedDict()    
-    for ch in param:      
+    vals = OrderedDict()
+    for ch in param:
         vals[ch.name()] = (ch.opts, getOpts(ch))
     return vals
 
 def getStruct(param:Parameter,) -> OrderedDict:
     """Return an OrderedDict with tree structures of all children of this parameter
+
         Parameters
         ----------
         param: Parameter
+
         Returns
         -------
         OrderedDict    
@@ -137,9 +139,11 @@ def getStruct(param:Parameter,) -> OrderedDict:
 
 def getValues(param:Parameter,) -> OrderedDict:
     """Return an OrderedDict with tree structures of all values for all children of this parameter
+
         Parameters
         ----------
         param: Parameter
+
         Returns
         -------
         OrderedDict    
@@ -149,25 +153,27 @@ def getValues(param:Parameter,) -> OrderedDict:
 
 def compareParameters(param1:Parameter, param2:Parameter, with_self: bool = True)-> bool:
     """Compare the structure and the opts of two parameters with their children,
-     return True if structure and all opts are identical.
-     If with_self is False, only the children opts are compared.
+        return True if structure and all opts are identical.
+        If with_self is False, only the children opts are compared.
+
         Parameters
         ----------
         param1: Parameter
-        param2: Parameter   
+        param2: Parameter
         with_self: bool
-        
+
         Returns
         -------
-        Bool    
+        Bool
     """
     is_same = getOpts(param1) == getOpts(param2)
-    if with_self:        
-        is_same = is_same and (param1.opts == param2.opts)        
+    if with_self:
+        is_same = is_same and (param1.opts == param2.opts)
     return is_same
     
 def compareStructureParameter(param1:Parameter, param2: Parameter,)-> bool:
     """Compare the structure of two parameters with their children, return True if structure is identical
+
         Parameters
         ----------
         param1: Parameter
@@ -181,18 +187,20 @@ def compareStructureParameter(param1:Parameter, param2: Parameter,)-> bool:
 
 
 def compareValuesParameter(param1:Parameter, param2: Parameter, with_self: bool = True)-> bool:
-    """Compare the structure and the values of two parameters with their children, return True if structures and values are identical
-        Parameters
+    """Compare the structure and the values of two parameters with their children, return True if structures and values
+        are identical.
         If with_self is False, only the children opts are compared.
+
+        Parameters
         ----------
         param1: Parameter
-        param2: Parameter   
+        param2: Parameter
         with_self: bool
-        
+
         Returns
         -------
-        Bool    
-    """    
+        Bool
+    """
     is_same = getValues(param1) == getValues(param2)
     if with_self:        
         is_same = is_same and (param1.value == param2.value)        
@@ -200,8 +208,6 @@ def compareValuesParameter(param1:Parameter, param2: Parameter, with_self: bool 
 
 
 def iter_children(param, childlist: list = [], filter_type=(), filter_name=(), select_filter=False)-> list:
-
-
     """
     Get a list of parameters' name under a given Parameter (see iter_children_params)
 
@@ -422,14 +428,16 @@ def change_visibility_all_descendants(param: Parameter, visible: bool = True):
 def scroll_log(scroll_val, min_val, max_val):
     """
     Convert a scroll value [0-100] to a log scale between min_val and max_val
+
     Parameters
     ----------
     scroll
     min_val
     max_val
+
     Returns
     -------
-
+    the scaled value
     """
     assert scroll_val >= 0
     assert scroll_val <= 100
@@ -440,14 +448,16 @@ def scroll_log(scroll_val, min_val, max_val):
 def scroll_linear(scroll_val, min_val, max_val):
     """
     Convert a scroll value [0-100] to a linear scale between min_val and max_val
+
     Parameters
     ----------
     scroll
     min_val
     max_val
+
     Returns
     -------
-
+    the scaled value
     """
     assert scroll_val >= 0
     assert scroll_val <= 100

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,33 +9,14 @@ build:
   os: "ubuntu-24.04"
   tools:
     python: "3.12"
-  apt_packages:
-    - libxkbcommon-x11-0
-    - libxcb-icccm4
-    - libxcb-image0
-    - libxcb-keysyms1
-    - libxcb-cursor0
-    - libxcb-cursor-dev
-    - libxcb-randr0
-    - libxcb-render-util0
-    - libxcb-xinerama0
-    - libxcb-xfixes0
-    - x11-utils
-    - libgl1
-    - libegl1
 
   jobs:
     post_checkout:
-      - git branch
       - git fetch --prune --unshallow
-      - git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - git fetch --tags
     pre_build:
-      - export QT_DEBUG_PLUGINS=1
-      - export QT_QPA_PLATFORM=offscreen
-      #      - sudo mkdir -p /etc/.pymodaq # cannot use sudo command in readthedoc...
-#      - sudo chmod uo+rw /etc/.pymodaq
-      - python docs/automodule.py || true
-      - python install-packages.py 
+      - python docs/automodule.py
+      - python install-packages.py
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -43,7 +24,7 @@ sphinx:
 
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+# formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:


### PR DESCRIPTION
Some small things were needed:
- automodule.py script was fixed (wrong output path)
- readthedocs.yml was simplified
- conf.py and requirements.txt from the docs were updated using the pyqtgraph one
- Faulty docstrings in pymodaq_gui were fixed
- An example script without a `if __name__ == "__main__"` check for code execution was also fixed