### PR TITLE
  Removed support for python 3.9 and added 3.13 + updates on monorepo (5.1.x)

### DIFF
--- a/.github/workflows/tests-data.yml
+++ b/.github/workflows/tests-data.yml
@@ -62,7 +62,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov pytest-xdist wheel numpy h5py
-          pip install -e .    
+          cd ..
+          cd ..
+          python install-packages.py -u pymodaq_data
       
       # Create folder and set permissions on Linux
       - name: Create global pymodaq folder (Linux)

--- a/.github/workflows/tests-data.yml
+++ b/.github/workflows/tests-data.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/tests-gui.yml
+++ b/.github/workflows/tests-gui.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         qt-backend: ["pyqt5", "pyqt6", "pyside6"]
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/tests-gui.yml
+++ b/.github/workflows/tests-gui.yml
@@ -63,7 +63,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install matplotlib flake8 pytest pytest-cov pytest-qt pytest-xvfb setuptools wheel numpy h5py ${{ matrix.qt-backend }}
-          pip install -e .    
+          cd ..
+          cd ..
+          python install-packages.py -u pymodaq_gui 
 
       # Create folder and set permissions on Linux
       - name: Create global pymodaq folder + Setup additional dependencies (Linux)

--- a/.github/workflows/tests-pymodaq.yml
+++ b/.github/workflows/tests-pymodaq.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         qt-backend: ["pyqt5", "pyqt6", "pyside6"]
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/tests-pymodaq.yml
+++ b/.github/workflows/tests-pymodaq.yml
@@ -63,7 +63,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov pytest-qt pytest-xvfb pytest-xdist setuptools wheel numpy h5py ${{ matrix.qt-backend }}
-          pip install -e .    
+          cd ..
+          cd ..
+          python install-packages.py -u pymodaq
+            
 
       # Create folder and set permissions on Linux
       - name: Create global pymodaq folder + Setup additional dependencies (Linux)

--- a/.github/workflows/tests-utils.yml
+++ b/.github/workflows/tests-utils.yml
@@ -62,7 +62,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov pytest-xdist wheel numpy h5py
-          pip install -e .    
+          cd ..
+          cd ..
+          python install-packages.py -u pymodaq_utils
       
       # Create folder and set permissions on Linux
       - name: Create global pymodaq folder (Linux)

--- a/.github/workflows/tests-utils.yml
+++ b/.github/workflows/tests-utils.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/docs/src/developer_folder/contributing.rst
+++ b/docs/src/developer_folder/contributing.rst
@@ -34,6 +34,13 @@ Finally it is advised to create a dedicated virtual environment for this and ins
     - the `-e` option tells pip to install the package in editable mode, meaning that any change done to the source will be reported to the installed package.
     - the `-d` option activates `[dev]` in the package names transmitted to `pip install` (e.g. `pymodaq_utils[dev]`). It indicate to install the package alongside its optional dependancies, declared as `dev` in the `pyproject.toml` file.
 
+.. note::
+  The ``install-packages.py`` script also provides a ``-u/--up-to {pymodaq_utils,pymodaq_data,pymodaq_gui,pymodaq}`` optional argument. 
+
+  When provided, only the necessary packages "up to" the specified ones are installed; e.g. ``-u pymodaq_data`` will install *pymodaq_utils* and *pymodaq_data* but **skip** *pymodaq_gui* and *PyMoDAQ* packages.
+  
+  When not provided, it will install all the packages (equivalent to ``-u pymodaq``)
+
 
 Then any change on the code will be *seen* by python interpreter so that you can see and test your modifications. Think about
 writing tests that will make sure your code is sound and that modification elsewhere doesn't change the expected behavior.

--- a/install-packages.py
+++ b/install-packages.py
@@ -6,6 +6,14 @@ import sys
 from pathlib import Path
 
 
+# Order is important!
+PYMODAQ_PACKAGES = [
+        "pymodaq_utils",
+        "pymodaq_data",
+        "pymodaq_gui",
+        "pymodaq",
+    ]
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Install all four PyMoDAQ packages in the right order (by default in editable mode)."
@@ -23,19 +31,26 @@ def parse_args():
         help="Install packages in non-editable (normal) mode."
     )
 
+    parser.add_argument(
+        "-u", "--up-to",
+        type=lambda value: value.lower(),
+        choices=PYMODAQ_PACKAGES,
+        default='pymodaq',
+        help="Select up to which package to install. (e.g. '-o pymodaq_data' will install utils and data packages but not gui and PyMoDAQ itself)"
+    )
+
     return parser.parse_args()
+
+def slice_up_to(ordered_list, element):
+    return ordered_list[0:ordered_list.index(element)+1]
 
 def main():
     args = parse_args()
     current_dir = Path(__file__).resolve().parent
-    packages = [
-        current_dir / "packages" / "pymodaq_utils",
-        current_dir / "packages" / "pymodaq_data",
-        current_dir / "packages" / "pymodaq_gui",
-        current_dir / "packages" / "pymodaq",
-    ]
 
-    for package in packages:      
+    packages = slice_up_to(PYMODAQ_PACKAGES, args.up_to)
+
+    for package in map(lambda package : current_dir / "packages" / package, packages):
         cmd = [sys.executable, "-m", "pip", "install"]
         if not args.non_editable:
             cmd.append("-e")

--- a/packages/pymodaq/README.rst.tpl
+++ b/packages/pymodaq/README.rst.tpl
@@ -14,27 +14,19 @@ PyMoDAQ
 
 
 
-+-------------+-------------------+------------------+---------------------+
-|  Linux      | PyQt5             | PyQt6            | PySide6             |
-+=============+===================+==================+=====================+
-| Python 3.9  | |39-linux-pyqt5|  | |39-linux-pyqt6| | |39-linux-pyside6|  |
-+-------------+-------------------+------------------+---------------------+
-| Python 3.10 | |310-linux-pyqt5| ||310-linux-pyqt6| | |310-linux-pyside6| |
-+-------------+-------------------+------------------+---------------------+
-| Python 3.11 | |311-linux-pyqt5| ||311-linux-pyqt6| | |311-linux-pyside6| |
-+-------------+-------------------+------------------+---------------------+
-| Python 3.12 | |312-linux-pyqt5| ||312-linux-pyqt6| | |312-linux-pyside6| |
-+-------------+-------------------+------------------+---------------------+
++-------------+-------------------+-------------------+---------------------+
+|  Linux      | PyQt5             | PyQt6             | PySide6             |
++=============+===================+===================+=====================+
+| Python 3.10 | |310-linux-pyqt5| | |310-linux-pyqt6| | |310-linux-pyside6| |
++-------------+-------------------+-------------------+---------------------+
+| Python 3.11 | |311-linux-pyqt5| | |311-linux-pyqt6| | |311-linux-pyside6| |
++-------------+-------------------+-------------------+---------------------+
+| Python 3.12 | |312-linux-pyqt5| | |312-linux-pyqt6| | |312-linux-pyside6| |
++-------------+-------------------+-------------------+---------------------+
+| Python 3.13 | |313-linux-pyqt5| | |313-linux-pyqt6| | |313-linux-pyside6| |
++-------------+-------------------+-------------------+---------------------+
 
 
-.. |39-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Linux_3.9_pyqt5.svg
-    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
-
-.. |39-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Linux_3.9_pyqt6.svg
-    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
-
-.. |39-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Linux_3.9_pyside6.svg
-    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
 .. |310-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Linux_3.10_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
@@ -63,27 +55,27 @@ PyMoDAQ
 .. |312-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Linux_3.12_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-
-+-------------+---------------------+--------------------+-----------------------+
-|  Windows    | PyQt5               | PyQt6              | PySide6               |
-+=============+=====================+====================+=======================+
-| Python 3.9  | |39-windows-pyqt5|  | |39-windows-pyqt6| | |39-windows-pyside6|  |
-+-------------+---------------------+--------------------+-----------------------+
-| Python 3.10 | |310-windows-pyqt5| ||310-windows-pyqt6| | |310-windows-pyside6| |
-+-------------+---------------------+--------------------+-----------------------+
-| Python 3.11 | |311-windows-pyqt5| ||311-windows-pyqt6| | |311-windows-pyside6| |
-+-------------+---------------------+--------------------+-----------------------+
-| Python 3.12 | |312-windows-pyqt5| ||312-windows-pyqt6| | |312-windows-pyside6| |
-+-------------+---------------------+--------------------+-----------------------+
-
-.. |39-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Windows_3.9_pyqt5.svg
+.. |313-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Linux_3.13_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |39-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Windows_3.9_pyqt6.svg
+.. |313-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Linux_3.13_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |39-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Windows_3.9_pyside6.svg
+.. |313-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Linux_3.13_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
+
++-------------+---------------------+---------------------+-----------------------+
+|  Windows    | PyQt5               | PyQt6               | PySide6               |
++=============+=====================+=====================+=======================+
+| Python 3.10 | |310-windows-pyqt5| | |310-windows-pyqt6| | |310-windows-pyside6| |
++-------------+---------------------+---------------------+-----------------------+
+| Python 3.11 | |311-windows-pyqt5| | |311-windows-pyqt6| | |311-windows-pyside6| |
++-------------+---------------------+---------------------+-----------------------+
+| Python 3.12 | |312-windows-pyqt5| | |312-windows-pyqt6| | |312-windows-pyside6| |
++-------------+---------------------+---------------------+-----------------------+
+| Python 3.13 | |313-windows-pyqt5| | |313-windows-pyqt6| | |313-windows-pyside6| |
++-------------+---------------------+---------------------+-----------------------+
+
 
 .. |310-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Windows_3.10_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
@@ -112,6 +104,14 @@ PyMoDAQ
 .. |312-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Windows_3.12_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
+.. |313-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Windows_3.13_pyqt5.svg
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
+
+.. |313-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Windows_3.13_pyqt6.svg
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
+
+.. |313-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/{{BRANCH_NAME}}/tests_Windows_3.13_pyside6.svg
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
 
 

--- a/packages/pymodaq_data/README.rst.tpl
+++ b/packages/pymodaq_data/README.rst.tpl
@@ -15,20 +15,18 @@ PyMoDAQ Data
 +-------------+-------------+---------------+
 |             | Linux       | Windows       |
 +=============+=============+===============+
-| Python 3.9  | |39-linux|  | |39-windows|  |
-+-------------+-------------+---------------+
 | Python 3.10 | |310-linux| | |310-windows| |
 +-------------+-------------+---------------+
 | Python 3.11 | |311-linux| | |311-windows| |
 +-------------+-------------+---------------+
 | Python 3.12 | |312-linux| | |312-windows| |
 +-------------+-------------+---------------+
+| Python 3.13 | |313-linux| | |313-windows| |
++-------------+-------------+---------------+
 
 
 
 
-.. |39-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Linux_3.9.svg
-    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
 .. |310-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Linux_3.10.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
@@ -39,7 +37,7 @@ PyMoDAQ Data
 .. |312-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Linux_3.12.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
-.. |39-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Windows_3.9.svg
+.. |313-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Linux_3.13.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
 .. |310-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Windows_3.10.svg
@@ -51,6 +49,8 @@ PyMoDAQ Data
 .. |312-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Windows_3.12.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
+.. |313-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Windows_3.13.svg
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
 
 

--- a/packages/pymodaq_data/README.rst.tpl
+++ b/packages/pymodaq_data/README.rst.tpl
@@ -28,28 +28,28 @@ PyMoDAQ Data
 
 
 .. |39-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Linux_3.9.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_data/actions/workflows/tests-data.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
 .. |310-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Linux_3.10.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_data/actions/workflows/tests-data.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
 .. |311-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Linux_3.11.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_data/actions/workflows/tests-data.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
 .. |312-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Linux_3.12.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_data/actions/workflows/tests-data.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
 .. |39-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Windows_3.9.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_data/actions/workflows/tests-data.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
 .. |310-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Windows_3.10.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_data/actions/workflows/tests-data.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
 .. |311-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Windows_3.11.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_data/actions/workflows/tests-data.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
 .. |312-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/{{BRANCH_NAME}}/tests_Windows_3.12.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_data/actions/workflows/tests-data.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
 
 

--- a/packages/pymodaq_gui/README.rst.tpl
+++ b/packages/pymodaq_gui/README.rst.tpl
@@ -28,40 +28,40 @@ PyMoDAQ GUI
 
 
 .. |39-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.9_pyqt5.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |39-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.9_pyqt6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |39-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.9_pyside6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |310-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.10_pyqt5.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |310-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.10_pyqt6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |310-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.10_pyside6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |311-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.11_pyqt5.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |311-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.11_pyqt6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |311-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.11_pyside6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |312-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.12_pyqt5.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |312-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.12_pyqt6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |312-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.12_pyside6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 
 +-------------+---------------------+--------------------+-----------------------+
@@ -77,40 +77,40 @@ PyMoDAQ GUI
 +-------------+---------------------+--------------------+-----------------------+
 
 .. |39-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.9_pyqt5.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |39-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.9_pyqt6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |39-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.9_pyside6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |310-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.10_pyqt5.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |310-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.10_pyqt6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |310-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.10_pyside6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |311-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.11_pyqt5.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |311-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.11_pyqt6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |311-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.11_pyside6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |312-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.12_pyqt5.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |312-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.12_pyqt6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |312-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.12_pyside6.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_gui/actions/workflows/tests-gui.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 
 .. figure:: http://pymodaq.cnrs.fr/en/latest/_static/splash.png

--- a/packages/pymodaq_gui/README.rst.tpl
+++ b/packages/pymodaq_gui/README.rst.tpl
@@ -14,27 +14,19 @@ PyMoDAQ GUI
 
 
 
-+-------------+-------------------+------------------+---------------------+
-|  Linux      | PyQt5             | PyQt6            | PySide6             |
-+=============+===================+==================+=====================+
-| Python 3.9  | |39-linux-pyqt5|  | |39-linux-pyqt6| | |39-linux-pyside6|  |
-+-------------+-------------------+------------------+---------------------+
-| Python 3.10 | |310-linux-pyqt5| ||310-linux-pyqt6| | |310-linux-pyside6| |
-+-------------+-------------------+------------------+---------------------+
-| Python 3.11 | |311-linux-pyqt5| ||311-linux-pyqt6| | |311-linux-pyside6| |
-+-------------+-------------------+------------------+---------------------+
-| Python 3.12 | |312-linux-pyqt5| ||312-linux-pyqt6| | |312-linux-pyside6| |
-+-------------+-------------------+------------------+---------------------+
++-------------+-------------------+-------------------+---------------------+
+|  Linux      | PyQt5             | PyQt6             | PySide6             |
++=============+===================+===================+=====================+
+| Python 3.10 | |310-linux-pyqt5| | |310-linux-pyqt6| | |310-linux-pyside6| |
++-------------+-------------------+-------------------+---------------------+
+| Python 3.11 | |311-linux-pyqt5| | |311-linux-pyqt6| | |311-linux-pyside6| |
++-------------+-------------------+-------------------+---------------------+
+| Python 3.12 | |312-linux-pyqt5| | |312-linux-pyqt6| | |312-linux-pyside6| |
++-------------+-------------------+-------------------+---------------------+
+| Python 3.13 | |313-linux-pyqt5| | |313-linux-pyqt6| | |313-linux-pyside6| |
++-------------+-------------------+-------------------+---------------------+
 
 
-.. |39-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.9_pyqt5.svg
-    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
-
-.. |39-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.9_pyqt6.svg
-    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
-
-.. |39-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.9_pyside6.svg
-    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. |310-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.10_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
@@ -63,27 +55,27 @@ PyMoDAQ GUI
 .. |312-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.12_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-
-+-------------+---------------------+--------------------+-----------------------+
-|  Windows    | PyQt5               | PyQt6              | PySide6               |
-+=============+=====================+====================+=======================+
-| Python 3.9  | |39-windows-pyqt5|  | |39-windows-pyqt6| | |39-windows-pyside6|  |
-+-------------+---------------------+--------------------+-----------------------+
-| Python 3.10 | |310-windows-pyqt5| ||310-windows-pyqt6| | |310-windows-pyside6| |
-+-------------+---------------------+--------------------+-----------------------+
-| Python 3.11 | |311-windows-pyqt5| ||311-windows-pyqt6| | |311-windows-pyside6| |
-+-------------+---------------------+--------------------+-----------------------+
-| Python 3.12 | |312-windows-pyqt5| ||312-windows-pyqt6| | |312-windows-pyside6| |
-+-------------+---------------------+--------------------+-----------------------+
-
-.. |39-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.9_pyqt5.svg
+.. |313-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.13_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |39-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.9_pyqt6.svg
+.. |313-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.13_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |39-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.9_pyside6.svg
+.. |313-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Linux_3.13_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
+
++-------------+---------------------+---------------------+-----------------------+
+|  Windows    | PyQt5               | PyQt6               | PySide6               |
++=============+=====================+=====================+=======================+
+| Python 3.10 | |310-windows-pyqt5| | |310-windows-pyqt6| | |310-windows-pyside6| |
++-------------+---------------------+---------------------+-----------------------+
+| Python 3.11 | |311-windows-pyqt5| | |311-windows-pyqt6| | |311-windows-pyside6| |
++-------------+---------------------+---------------------+-----------------------+
+| Python 3.12 | |312-windows-pyqt5| | |312-windows-pyqt6| | |312-windows-pyside6| |
++-------------+---------------------+---------------------+-----------------------+
+| Python 3.13 | |313-windows-pyqt5| | |313-windows-pyqt6| | |313-windows-pyside6| |
++-------------+---------------------+---------------------+-----------------------+
+
 
 .. |310-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.10_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
@@ -112,6 +104,14 @@ PyMoDAQ GUI
 .. |312-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.12_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
+.. |313-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.13_pyqt5.svg
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
+
+.. |313-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.13_pyqt6.svg
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
+
+.. |313-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/{{BRANCH_NAME}}/tests_Windows_3.13_pyside6.svg
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. figure:: http://pymodaq.cnrs.fr/en/latest/_static/splash.png
    :alt: shortcut

--- a/packages/pymodaq_utils/README.rst.tpl
+++ b/packages/pymodaq_utils/README.rst.tpl
@@ -15,21 +15,18 @@ PyMoDAQ Utils
 +-------------+-------------+---------------+
 |             | Linux       | Windows       |
 +=============+=============+===============+
-| Python 3.9  | |39-linux|  | |39-windows|  |
-+-------------+-------------+---------------+
 | Python 3.10 | |310-linux| | |310-windows| |
 +-------------+-------------+---------------+
 | Python 3.11 | |311-linux| | |311-windows| |
 +-------------+-------------+---------------+
 | Python 3.12 | |312-linux| | |312-windows| |
 +-------------+-------------+---------------+
+| Python 3.13 | |313-linux| | |313-windows| |
++-------------+-------------+---------------+
 
 
 
 
-
-.. |39-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Linux_3.9.svg
-    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 .. |310-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Linux_3.10.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
@@ -40,7 +37,7 @@ PyMoDAQ Utils
 .. |312-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Linux_3.12.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
-.. |39-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Windows_3.9.svg
+.. |313-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Linux_3.13.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 .. |310-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Windows_3.10.svg
@@ -50,6 +47,9 @@ PyMoDAQ Utils
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 .. |312-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Windows_3.12.svg
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
+
+.. |313-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Windows_3.13.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 

--- a/packages/pymodaq_utils/README.rst.tpl
+++ b/packages/pymodaq_utils/README.rst.tpl
@@ -29,28 +29,28 @@ PyMoDAQ Utils
 
 
 .. |39-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Linux_3.9.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_utils/actions/workflows/tests-utils.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 .. |310-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Linux_3.10.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_utils/actions/workflows/tests-utils.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 .. |311-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Linux_3.11.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_utils/actions/workflows/tests-utils.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 .. |312-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Linux_3.12.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_utils/actions/workflows/tests-utils.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 .. |39-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Windows_3.9.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_utils/actions/workflows/tests-utils.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 .. |310-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Windows_3.10.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_utils/actions/workflows/tests-utils.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 .. |311-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Windows_3.11.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_utils/actions/workflows/tests-utils.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 .. |312-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/{{BRANCH_NAME}}/tests_Windows_3.12.svg
-    :target: https://github.com/PyMoDAQ/pymodaq_utils/actions/workflows/tests-utils.yml
+    :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 
 


### PR DESCRIPTION
Same as #794 but for 5.1.x branch plus some cherry picked commits:
 - update `install-package.py` to accept `-u/--up-to` argument
 - update the doc about `install-package.py`
 - use `install-packages.py` in github actions for tests.