### PR TITLE
Bugfix/pyqtgraph issues

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer_ui.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer_ui.py
@@ -370,7 +370,8 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
 
 def main(init_qt=True):
     from pymodaq.utils.gui_utils.dock import DockArea
-    from pymodaq.utils.parameter import ParameterTree, Parameter
+    from pymodaq.utils.parameter import ParameterTree
+    from pymodaq_gui.parameter import Parameter
     from pymodaq.control_modules.viewer_utility_classes import params as daq_viewer_params
 
     if init_qt:  # used for the test suite

--- a/packages/pymodaq/src/pymodaq/control_modules/instruments.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/instruments.py
@@ -1,4 +1,4 @@
-from pyqtgraph.parametertree import Parameter
+from pymodaq_gui.parameter import Parameter
 
 from pymodaq_gui.plotting.data_viewers import ViewersEnum
 from pymodaq_utils.enums import BaseEnum

--- a/packages/pymodaq/src/pymodaq/control_modules/mocks.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/mocks.py
@@ -4,7 +4,7 @@ Created the 16/03/2023
 
 @author: Sebastien Weber
 """
-from pymodaq.utils.parameter import Parameter
+from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.h5modules import saving
 from pymodaq.utils.h5modules.module_saving import DetectorSaver, ActuatorTimeSaver, ScanSaver
 

--- a/packages/pymodaq/src/pymodaq/control_modules/move_utility_classes.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/move_utility_classes.py
@@ -34,6 +34,7 @@ from pymodaq.control_modules.daq_move_ui.factory import ActuatorUIFactory
 from pymodaq.control_modules.utils import create_controller_param, ControllerStatus
 from pymodaq_gui.parameter.ioxml import VALID_FOR_CONFIGURATION
 
+
 if TYPE_CHECKING:
     from pymodaq.control_modules.daq_move import DAQ_Move_Hardware
 

--- a/packages/pymodaq/src/pymodaq/control_modules/viewer_utility_classes.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/viewer_utility_classes.py
@@ -5,7 +5,6 @@ from qtpy.QtCore import QObject, Slot, Signal
 
 from pymodaq.utils.parameter import ioxml
 from pymodaq.utils.parameter.utils import get_param_path, get_param_from_name, iter_children
-from pymodaq.utils.parameter import Parameter
 from easydict import EasyDict as edict
 
 import numpy as np
@@ -22,7 +21,9 @@ from pymodaq_gui.plotting.utils.plot_utils import RoiInfo
 from pymodaq.control_modules.thread_commands import ThreadStatus, ThreadStatusViewer
 from pymodaq.control_modules.utils import create_controller_param, ControllerStatus
 from pymodaq_gui.utils.utils import mkQApp
+from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.parameter.ioxml import VALID_FOR_CONFIGURATION
+
 
 local_path = get_set_local_dir()
 # look for eventual calibration files

--- a/packages/pymodaq/src/pymodaq/extensions/daq_scan.py
+++ b/packages/pymodaq/src/pymodaq/extensions/daq_scan.py
@@ -26,9 +26,9 @@ from pymodaq_utils import utils
 from pymodaq_data import data as data_mod
 from pymodaq_data.h5modules import data_saving
 
-from pymodaq_gui.parameter import ioxml
+from pymodaq_gui.parameter import ioxml, Parameter
 from pymodaq_gui.plotting.data_viewers import ViewersEnum
-from pymodaq_gui.managers.parameter_manager import ParameterManager, Parameter, ParameterTree
+from pymodaq_gui.managers.parameter_manager import ParameterManager, ParameterTree
 from pymodaq_gui.plotting.navigator import Navigator
 from pymodaq_gui.messenger import messagebox
 from pymodaq_gui import utils as gutils

--- a/packages/pymodaq/src/pymodaq/extensions/daq_scan_ui.py
+++ b/packages/pymodaq/src/pymodaq/extensions/daq_scan_ui.py
@@ -23,7 +23,7 @@ from pymodaq_gui.plotting.data_viewers import ViewersEnum
 
 
 if TYPE_CHECKING:
-    from pymodaq.utils.parameter import ParameterTree
+    from pymodaq_gui.parameter import ParameterTree
 
 config = Config()
 logger = set_logger(get_module_name(__file__))

--- a/packages/pymodaq/src/pymodaq/extensions/data_mixer/model.py
+++ b/packages/pymodaq/src/pymodaq/extensions/data_mixer/model.py
@@ -14,7 +14,8 @@ from pymodaq_utils.logger import set_logger, get_module_name
 
 from pymodaq_data.data import DataToExport
 
-from pymodaq_gui.managers.parameter_manager import ParameterManager, Parameter
+from pymodaq_gui.managers.parameter_manager import ParameterManager
+from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.config_saver_loader import ConfigSaverLoader
 
 

--- a/packages/pymodaq/src/pymodaq/extensions/optimizers_base/utils.py
+++ b/packages/pymodaq/src/pymodaq/extensions/optimizers_base/utils.py
@@ -22,7 +22,7 @@ from pymodaq_utils.enums import StrEnum
 from pymodaq_utils.config import BaseConfig
 
 from pymodaq_gui.plotting.data_viewers.viewer import ViewersEnum
-from pymodaq_gui.managers.parameter_manager import Parameter
+from pymodaq_gui.parameter import Parameter
 
 
 from pymodaq_data.data import (DataToExport, DataCalculated,

--- a/packages/pymodaq/src/pymodaq/utils/managers/modules_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/modules_manager.py
@@ -12,7 +12,8 @@ from pymodaq_utils.enums import StrEnum
 
 from pymodaq_data.data import DataToExport
 
-from pymodaq_gui.managers.parameter_manager import ParameterManager, Parameter
+from pymodaq_gui.managers.parameter_manager import ParameterManager
+from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.utils import Dock
 
 from pymodaq.utils.data import DataActuator

--- a/packages/pymodaq/src/pymodaq/utils/scanner/scan_factory.py
+++ b/packages/pymodaq/src/pymodaq/utils/scanner/scan_factory.py
@@ -19,7 +19,8 @@ from pymodaq_utils.abstract import abstract_attribute
 from pymodaq_utils import math_utils as mutils
 from pymodaq_utils import config as configmod
 
-from pymodaq_gui.managers.parameter_manager import ParameterManager, Parameter
+from pymodaq_gui.managers.parameter_manager import ParameterManager
+from pymodaq_gui.parameter import Parameter
 from pymodaq_data.data import Axis, DataDistribution
 
 from pymodaq.utils.scanner.scan_config import ScanConfig

--- a/packages/pymodaq/src/pymodaq/utils/scanner/scanner.py
+++ b/packages/pymodaq/src/pymodaq/utils/scanner/scanner.py
@@ -10,7 +10,8 @@ from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.config import Config
 import pymodaq_utils.utils as utils
 
-from pymodaq_gui.managers.parameter_manager import ParameterManager, Parameter
+from pymodaq_gui.managers.parameter_manager import ParameterManager
+from pymodaq_gui.parameter import Parameter
 
 from pymodaq.utils.scanner.scan_factory import ScannerFactory, ScannerBase
 from pymodaq.utils.scanner.utils import ScanInfo

--- a/packages/pymodaq/tests/utils/h5module_test/module_saving_test.py
+++ b/packages/pymodaq/tests/utils/h5module_test/module_saving_test.py
@@ -11,7 +11,7 @@ import pytest
 from pymodaq_data.h5modules.saving import H5SaverLowLevel
 from pymodaq.utils.h5modules.module_saving import DetectorSaver, ScanSaver, GroupModuleType
 
-from pymodaq.utils.parameter import Parameter
+from pymodaq_gui.parameter import Parameter
 from pymodaq.control_modules.mocks import MockScan, MockDAQMove, MockDAQViewer
 
 @pytest.fixture()

--- a/packages/pymodaq/tests/utils/scanner_test/scan_factory_test.py
+++ b/packages/pymodaq/tests/utils/scanner_test/scan_factory_test.py
@@ -6,7 +6,8 @@ Created the 05/12/2022
 """
 import pytest
 from qtpy import QtWidgets, QtCore
-from pymodaq_gui.managers.parameter_manager import ParameterManager, Parameter, ParameterTree
+from pymodaq_gui.managers.parameter_manager import ParameterManager, ParameterTree
+from pymodaq_gui.parameter import Parameter
 from pymodaq.utils.scanner.scan_factory import ScannerFactory
 from pymodaq.utils.parameter import utils as putils
 

--- a/packages/pymodaq/tests/utils/tcp_ip/tcp_server_client_test.py
+++ b/packages/pymodaq/tests/utils/tcp_ip/tcp_server_client_test.py
@@ -6,7 +6,7 @@ from pymodaq.utils.daq_utils import ThreadCommand
 from pymodaq.utils.tcp_ip.tcp_server_client import MockServer, TCPClient, TCPServer
 from pymodaq_utils.serialize.mysocket import Socket
 from pymodaq_utils.serialize.serializer_legacy import DeSerializer
-from pyqtgraph.parametertree import Parameter
+from pymodaq_gui.parameter import Parameter
 from pymodaq.utils.exceptions import Expected_1, Expected_2
 from pymodaq.utils.data import DataActuator, DataToExport
 

--- a/packages/pymodaq_gui/pyproject.toml
+++ b/packages/pymodaq_gui/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 dependencies = [
     "pymodaq_utils>=0.0.8",
     "pymodaq_data>=5.0.13",
-    "pyqtgraph>=0.12 , <0.14.0",
+    "pyqtgraph>=0.12",
     "qtpy",
     "easydict",
 ]

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/parameter_ex.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/parameter_ex.py
@@ -89,9 +89,9 @@ class ParameterEx(ParameterManager):
              },
         ]},
         {'title': 'Browsing files:', 'name': 'browser', 'type': 'group', 'children': [
-            {'title': 'Look for a file:', 'name': 'afile', 'type': 'browsepath', 'value': '', 'filetype': True,
+            {'title': 'Look for a file:', 'name': 'afile', 'type': 'browsepath', 'value': 'D:\Data', 'filetype': True,
              'tip': 'If filetype is True select a file otherwise a directory'},
-            {'title': 'Look for a dir:', 'name': 'adir', 'type': 'browsepath', 'value': '', 'filetype': False,
+            {'title': 'Look for a dir:', 'name': 'adir', 'type': 'browsepath', 'value': 'D:\Databis', 'filetype': False,
              'tip': 'If filetype is True select a file otherwise a directory'},
 
         ]},

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/__init__.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/__init__.py
@@ -3,6 +3,14 @@ from qtpy import QtWidgets
 from pyqtgraph.parametertree import parameterTypes, Parameter, ParameterTree
 from . import pymodaq_ptypes
 
+__parameter_value_old_fun = Parameter.value
+def __parameter_value_monkey_path(self):
+    try:
+        return __parameter_value_old_fun(self)
+    except ValueError:
+        return None
+
+Parameter.value = __parameter_value_monkey_path
 
 class ParameterTree(ParameterTree):
     def __init__(self, *args, **kwargs):

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/__init__.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/__init__.py
@@ -13,7 +13,8 @@ from .filedir import FileDirParameter
 from .text import PlainTextPbParameter
 from .numeric import NumericParameter
 from .group import GroupParameter
-from pyqtgraph.parametertree.Parameter import registerParameterType, registerParameterItemType, Parameter
+from pyqtgraph.parametertree.Parameter import registerParameterType, registerParameterItemType
+
 
 registerParameterType('float', NumericParameter, override=True)
 registerParameterType('int',   NumericParameter, override=True)

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/date.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/date.py
@@ -1,7 +1,8 @@
 from qtpy import QtWidgets, QtCore
 from pyqtgraph import functions as fn
 from pyqtgraph.parametertree.parameterTypes.basetypes import WidgetParameterItem, SimpleParameter
-from pyqtgraph.parametertree import Parameter, ParameterItem
+from pyqtgraph.parametertree import ParameterItem
+from pymodaq_gui.parameter import Parameter
 import numpy as np
 
 

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/filedir.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/filedir.py
@@ -118,11 +118,15 @@ class FileDirParameterItem(WidgetParameterItem):
             self.filetype = self.param.opts['filetype']
         else:
             self.filetype = True
-
-        self.w = FileDirWidget(self.param.value(), file_type=self.filetype)
-
+        if 'value' in self.param.opts:
+            self.w = FileDirWidget(init_path=self.param.opts['value'],
+                               file_type=self.filetype)
+        else:
+            self.w = FileDirWidget(file_type=self.filetype)
+            self.param.opts['value'] = self.w.path
         # if 'tip' in self.param.opts:
         #     self.w.setToolTip(self.param.opts['tip'])
+
 
         self.w.base_path_edit.setReadOnly(self.param.opts['readonly'])
         self.w.value = self.w.get_value

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/filedir.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/filedir.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from qtpy import QtWidgets, QtCore, QtGui
 from pyqtgraph.parametertree.Parameter import ParameterItem
 from pyqtgraph.parametertree.parameterTypes.basetypes import WidgetParameterItem
-from pyqtgraph.parametertree import Parameter
+from pymodaq_gui.parameter import Parameter
 
 
 class FileDirWidget(QtWidgets.QWidget):

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/itemselect.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/itemselect.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from qtpy import QtWidgets, QtCore, QtGui
 from pyqtgraph.parametertree.Parameter import ParameterItem
 from pyqtgraph.parametertree.parameterTypes.basetypes import WidgetParameterItem
-from pyqtgraph.parametertree import Parameter
+from pymodaq_gui.parameter import Parameter
 
 
 class ItemSelect_pb(QtWidgets.QWidget):

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/table.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/table.py
@@ -1,7 +1,7 @@
 from qtpy import QtWidgets, QtCore
 from collections import OrderedDict
 from pyqtgraph.parametertree.parameterTypes.basetypes import WidgetParameterItem
-from pyqtgraph.parametertree import Parameter
+from pymodaq_gui.parameter import Parameter
 
 
 class TableWidget(QtWidgets.QTableWidget):

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/tableview.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/tableview.py
@@ -2,8 +2,8 @@ from qtpy import QtWidgets, QtCore
 from collections import OrderedDict
 from pyqtgraph.parametertree.Parameter import ParameterItem
 from pyqtgraph.parametertree.parameterTypes.basetypes import WidgetParameterItem
-from pyqtgraph.parametertree import Parameter
 from pyqtgraph.widgets import ColorButton
+from pymodaq_gui.parameter import Parameter
 
 
 class TableViewCustom(QtWidgets.QTableView):

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/text.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/text.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from qtpy import QtWidgets, QtCore, QtGui
 from pyqtgraph.parametertree.Parameter import ParameterItem
 from pyqtgraph.parametertree.parameterTypes.basetypes import WidgetParameterItem
-from pyqtgraph.parametertree import Parameter
+from pymodaq_gui.parameter import Parameter
 
 
 class PlainTextWidget(QtWidgets.QWidget):

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/utils.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/utils.py
@@ -135,7 +135,8 @@ def getStruct(param:Parameter,) -> OrderedDict:
         vals[ch.name()] = (None, getStruct(ch))
     return vals 
 
-def getValues(param:Parameter,) -> OrderedDict:
+
+def getValues(param:Parameter) -> OrderedDict:
     """Return an OrderedDict with tree structures of all values for all children of this parameter
         Parameters
         ----------
@@ -143,8 +144,14 @@ def getValues(param:Parameter,) -> OrderedDict:
         Returns
         -------
         OrderedDict    
-    """    
-    return param.getValues()
+    """
+    values = OrderedDict()
+    for ch in param:
+        if 'value' in ch.opts:
+            values[ch.name()] = (ch.value(), getValues(ch))
+        else:
+            values[ch.name()] = (None, getValues(ch))
+    return values
 
 
 def compareParameters(param1:Parameter, param2:Parameter, with_self: bool = True)-> bool:
@@ -329,10 +336,11 @@ def set_param_from_param(param_old, param_new):
                 # (limits are usually set at initialization) but carefull as such paramater limits can be a list or a
                 # dict object
                 if isinstance(child_old.opts['limits'], list):
-                    if child_new.value() not in child_old.opts['limits']:
-                        new_limits = child_old.opts['limits'].copy()
-                        new_limits.append(child_new.value())
-                        child_old.setLimits(new_limits)
+                    if 'value' in child_new.opts:
+                        if child_new.value() not in child_old.opts['limits']:
+                            new_limits = child_old.opts['limits'].copy()
+                            new_limits.append(child_new.value())
+                            child_old.setLimits(new_limits)
                         
                 elif isinstance(child_old.opts['limits'], dict):
                     if child_new.value() not in child_old.opts['limits'].values():
@@ -340,8 +348,8 @@ def set_param_from_param(param_old, param_new):
                         new_limits = child_old.opts['limits'].copy()
                         new_limits.update({child_new_key: child_new.value()})
                         child_old.setLimits(new_limits)
-
-                child_old.setValue(child_new.value())
+                if 'value' in child_new.opts:
+                    child_old.setValue(child_new.value())
             elif 'str' in param_type or 'browsepath' in param_type or 'text' in param_type:
                 if child_new.value() != "":  # to make sure one doesnt overwrite something
                     child_old.setValue(child_new.value())

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/utils/filter.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/utils/filter.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pyqtgraph.parametertree import Parameter
+from pymodaq_gui.parameter import Parameter
 from qtpy import QtCore, QtWidgets, QtGui
 from qtpy.QtCore import QPointF, Slot, Signal, QObject
 from typing import List, Tuple

--- a/packages/pymodaq_gui/tests/managers/parameter_manager_test.py
+++ b/packages/pymodaq_gui/tests/managers/parameter_manager_test.py
@@ -10,7 +10,7 @@ import pytest
 from qtpy import QtWidgets
 
 
-from pyqtgraph.parametertree import Parameter
+from pymodaq_gui.parameter import Parameter
 
 from pymodaq_gui.examples.parameter_ex import ParameterEx
 from pymodaq_gui.parameter.utils import (getValues,getStruct,

--- a/packages/pymodaq_gui/tests/managers/parameter_manager_test.py
+++ b/packages/pymodaq_gui/tests/managers/parameter_manager_test.py
@@ -15,7 +15,7 @@ from pyqtgraph.parametertree import Parameter
 from pymodaq_gui.examples.parameter_ex import ParameterEx
 from pymodaq_gui.parameter.utils import (getValues,getStruct,
     iter_children_params, compareParameters,
-    compareStructureParameter, compareValuesParameter)
+    compareStructureParameter, compareValuesParameter, getValues)
 from pymodaq_gui.utils.widgets.table import TableModel
 from pymodaq_gui.managers.parameter_manager import ParameterManager
 
@@ -89,7 +89,9 @@ def test_load(qtbot, tmp_path):
 
     for parameter in parameters:
         if not parameter.hasChildren() and 'group' not in parameter.opts['type']:
-            default_parameter = Parameter.create(name='settings', type=parameter.opts['type'])
+            #default_parameter = Parameter.create(name='settings', type=parameter.opts['type'])
+            default_parameter = Parameter.create(**parameter.opts)
+
             if not 'table' in parameter.opts['type']:
                 item = default_parameter.makeTreeItem(0)
                 if hasattr(item, 'widget'):
@@ -99,15 +101,22 @@ def test_load(qtbot, tmp_path):
             elif 'tabular_table' == parameter.opts['type']:
                 parameter.setValue(TableModel([[0.5, 0.2, 0.6]], ['value20', 'val2', '555']))
 
-    assert not compareValuesParameter(ptree.settings, parameter_copy, with_self=False)
+    parameters = iter_children_params(ptree.settings, childlist=[])
+    parameters_copy = iter_children_params(parameter_copy, childlist=[])
+    for parameter, pcopy in zip(parameters, parameters_copy):
+        if 'value' in parameter.opts:
+            if parameter.value() != pcopy.value():
+                print(parameter)
+    assert compareValuesParameter(ptree.settings, parameter_copy, with_self=False)
     assert compareStructureParameter(ptree.settings, parameter_copy)
 
     ptree.update_settings_slot(file_path)
     parameters = iter_children_params(ptree.settings, childlist=[])
 
     for parameter, pcopy in zip(parameters, parameters_copy):
-        if parameter.value() != pcopy.value():
-            print(parameter)
+        if 'value' in parameter.opts:
+            if parameter.value() != pcopy.value():
+                print(parameter)
 
     assert compareValuesParameter(ptree.settings, parameter_copy, with_self=False)
     assert compareStructureParameter(ptree.settings, parameter_copy)

--- a/packages/pymodaq_gui/tests/parameter_test/param_ioxml_test.py
+++ b/packages/pymodaq_gui/tests/parameter_test/param_ioxml_test.py
@@ -104,7 +104,8 @@ class TestXMLbackForth():
         for child, child_back in zip(children_list_in,children_list_back):
             assert child_back.name() == child.name()
             assert child_back.title() == child.title()
-            assert child_back.value() == child.value()
+            if 'value' in child_back.opts:
+                assert child_back.value() == child.value()
             assert child_back.readonly() == child.readonly()
             if 'limits' in child_back.opts:
                 assert child_back.opts['limits'] == child.opts['limits']

--- a/packages/pymodaq_gui/tests/plotting_test/data_viewers_test/viewer1D_test.py
+++ b/packages/pymodaq_gui/tests/plotting_test/data_viewers_test/viewer1D_test.py
@@ -1,4 +1,4 @@
-from pyqtgraph.parametertree import Parameter
+from pymodaq_gui.parameter import Parameter
 import pyqtgraph as pg
 import numpy as np
 import pytest

--- a/packages/pymodaq_gui/tests/utils/config_test.py
+++ b/packages/pymodaq_gui/tests/utils/config_test.py
@@ -5,7 +5,7 @@ import datetime
 import toml
 
 from pymodaq_utils import config as config_mod
-from pyqtgraph.parametertree import Parameter
+from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.config_saver_loader import ConfigSaverLoader, get_set_roi_path
 
 

--- a/packages/pymodaq_utils/src/pymodaq_utils/config.py
+++ b/packages/pymodaq_utils/src/pymodaq_utils/config.py
@@ -11,7 +11,7 @@ from typing import Iterable as IterableType
 import toml
 import logging
 if TYPE_CHECKING:
-    from pyqtgraph import Parameter
+    from pymodaq_gui.parameter import Parameter
 
 
 try:


### PR DESCRIPTION
new version of pyqtgraph make Parameter object raise an error if calling p.value() while no value has been set beforehand.

Our tests where failing because we used a comparaValues method that triggered value call for all parameters. Some other tests where calling value method without making sure the value is set.

These modification, while still doing parameters comparison lead to no more issues