### PR TITLE
Feature/widget synchronizer

### DIFF
--- a/docs/src/developer.rst
+++ b/docs/src/developer.rst
@@ -9,6 +9,7 @@ Developer's Guide
    /developer_folder/plugins
    /developer_folder/custom_app
    /developer_folder/managers
+   /developer_folder/widget_sync
    /developer_folder/whats_new34
    /developer_folder/whats_new45
 

--- a/docs/src/developer_folder/widget_sync.rst
+++ b/docs/src/developer_folder/widget_sync.rst
@@ -1,0 +1,464 @@
+.. _widget_sync:
+
+Widget Synchronization
+======================
+
+.. contents::
+   :local:
+   :depth: 2
+
+Overview
+--------
+
+The ``widget_sync`` module provides a simple, powerful way to synchronize widget properties across multiple Qt widgets.
+It's perfect for keeping toolbar buttons, menu items, and settings panels in sync without manual signal management.
+
+**Key features:**
+
+* Automatic bidirectional synchronization
+* Multiple sync modes (bidirectional, to_sync, from_sync)
+* Value transformations between widgets
+* Automatic cleanup when widgets are deleted
+* No memory leaks (uses weak references)
+* Easy extension with custom factory methods
+
+Basic Usage
+-----------
+
+Simple Synchronization
+~~~~~~~~~~~~~~~~~~~~~
+
+Keep multiple checkboxes in sync:
+
+.. code-block:: python
+
+    from pymodaq_gui.utils.widget_sync import WidgetSync
+
+    # Create sync from first checkbox
+    sync = WidgetSync.for_checkbox(toolbar_checkbox, initial=True)
+
+    # Add more checkboxes - they stay in sync automatically
+    sync.add(menu_checkbox)
+    sync.add(settings_checkbox)
+
+    # Change value programmatically - all update
+    sync.value = False  # All three checkboxes uncheck
+
+Different Widget Types
+~~~~~~~~~~~~~~~~~~~~~
+
+Sync different widget types representing the same value:
+
+.. code-block:: python
+
+    # Slider and spinbox for same value
+    sync = WidgetSync.for_slider(slider, initial=50)
+    sync.add(spinbox)  # Stays in sync
+
+    # Add read-only display
+    sync.connect(
+        progress_bar,
+        setter=lambda v: progress_bar.setValue(v),
+        mode=SyncMode.FROM_SYNC  # Read-only
+    )
+
+Factory Methods
+---------------
+
+Built-in Factories
+~~~~~~~~~~~~~~~~~
+
+Convenient factories for common widget types:
+
+.. code-block:: python
+
+    # Checkboxes
+    sync = WidgetSync.for_checkbox(checkbox, initial=True)
+
+    # SpinBoxes / DoubleSpinBoxes
+    sync = WidgetSync.for_spinbox(spinbox, initial=50)
+
+    # Sliders
+    sync = WidgetSync.for_slider(slider, initial=75)
+
+    # ComboBoxes
+    sync = WidgetSync.for_combobox(combo, initial=0)  # By index
+    sync = WidgetSync.for_combobox(combo, initial="Option A", use_text=True)  # By text
+
+    # LineEdits
+    sync = WidgetSync.for_lineedit(edit, initial="Hello")
+
+Generic Factory
+~~~~~~~~~~~~~~
+
+For any Qt property:
+
+.. code-block:: python
+
+    sync = WidgetSync.for_property(
+        widget,
+        property_name='value',  # Qt property name
+        signal_name='valueChanged',  # Change signal (optional, auto-detected)
+        initial=50
+    )
+
+Sync Modes
+----------
+
+Three synchronization modes:
+
+.. code-block:: python
+
+    from pymodaq_gui.utils.widget_sync import SyncMode
+
+    # BIDIRECTIONAL (default): Widget ↔ Sync
+    sync.add(widget, mode=SyncMode.BIDIRECTIONAL)
+
+    # TO_SYNC: Widget → Sync only
+    sync.add(widget, mode=SyncMode.TO_SYNC)
+
+    # FROM_SYNC: Sync → Widget only (read-only display)
+    sync.connect(label, setter=lambda v: label.setText(str(v)),
+                 mode=SyncMode.FROM_SYNC)
+
+Value Transformations
+---------------------
+
+Transform values between widgets:
+
+.. code-block:: python
+
+    # Temperature: Celsius ↔ Fahrenheit
+    celsius_sync = WidgetSync.for_spinbox(celsius_spin, initial=0)
+
+    celsius_sync.add(
+        fahrenheit_spin,
+        to_sync_transform=lambda f: round((f - 32) * 5/9),  # F → C
+        from_sync_transform=lambda c: round(c * 9/5 + 32)   # C → F
+    )
+
+    # Boolean ↔ ComboBox index
+    bool_sync = WidgetSync.for_checkbox(checkbox, initial=True)
+
+    bool_sync.connect(
+        combobox,
+        signal=combobox.currentIndexChanged,
+        getter=lambda: combobox.currentIndex(),
+        setter=lambda i: combobox.setCurrentIndex(i),
+        to_sync_transform=lambda i: i == 1,  # Index → Bool
+        from_sync_transform=lambda b: 1 if b else 0  # Bool → Index
+    )
+
+Advanced Usage
+--------------
+
+Manual Connection
+~~~~~~~~~~~~~~~~
+
+For complete control:
+
+.. code-block:: python
+
+    sync = WidgetSync(initial_value=50)
+
+    sync.connect(
+        widget,
+        signal=widget.valueChanged,
+        getter=lambda: widget.value(),
+        setter=lambda v: widget.setValue(v),
+        mode=SyncMode.BIDIRECTIONAL
+    )
+
+Temporarily Disable Connections
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Temporarily pause syncing without disconnecting:
+
+.. code-block:: python
+
+    sync = WidgetSync.for_slider(slider1, initial=50)
+    sync.add(slider2)
+    sync.add(slider3)
+
+    # Disable one slider temporarily
+    sync.disable(slider2)
+    slider1.setValue(75)  # slider2 doesn't update, slider3 does
+
+    # Re-enable it
+    sync.enable(slider2)
+    slider2.setValue(60)  # Now it syncs again
+
+    # Check if enabled
+    if sync.is_enabled(slider2):
+        print("Slider 2 is syncing")
+
+**Use cases:**
+
+* Temporarily pause sync during batch operations
+* Conditional syncing based on application state
+* Prevent feedback loops during complex updates
+* Testing and debugging
+
+**Key differences:**
+
+* ``disable()`` - Temporarily stops syncing, connection remains
+* ``disconnect()`` - Removes connection entirely, needs reconnection
+
+Conditional Widget Enable/Disable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enable/disable widgets based on another widget's state:
+
+.. code-block:: python
+
+    # Create sync for master checkbox
+    enable_sync = WidgetSync.for_checkbox(master_checkbox, initial=False)
+
+    # Connect to enable/disable other widgets
+    enable_sync.value_changed.connect(
+        lambda enabled: advanced_spinbox.setEnabled(enabled)
+    )
+    enable_sync.value_changed.connect(
+        lambda enabled: advanced_slider.setEnabled(enabled)
+    )
+
+Introspection
+~~~~~~~~~~~~~
+
+Check sync state:
+
+.. code-block:: python
+
+    # Get connected widgets
+    widgets = sync.connected_widgets  # List of active widgets
+
+    # Get connection count
+    count = sync.connection_count  # Number of connections
+
+    # Get current value
+    value = sync.value
+
+Connection Management
+~~~~~~~~~~~~~~~~~~~~~
+
+Cleanup is automatic via weak reference callbacks - when a widget is deleted,
+its connection is automatically removed. Manual management is available when needed:
+
+.. code-block:: python
+
+    # Temporarily pause syncing (connection remains)
+    sync.disable(widget)
+    sync.enable(widget)  # Resume syncing
+
+    # Check connection state
+    is_syncing = sync.is_enabled(widget)
+
+    # Permanently disconnect widget
+    sync.disconnect(widget)
+    # or
+    sync.remove(widget)  # Alias for disconnect
+
+    # Disconnect all (useful when deleting the sync itself)
+    sync.disconnect_all()
+
+**When to use what:**
+
+* ``disable()`` - Temporary pause, keeps connection setup, fast to re-enable
+* ``disconnect()`` - Permanent removal, requires full reconnection
+* Automatic cleanup - Widget deletion triggers cleanup automatically
+
+
+Common Patterns
+---------------
+
+Toolbar and Menu Sync
+~~~~~~~~~~~~~~~~~~~~~
+
+Keep toolbar and menu items synchronized:
+
+.. code-block:: python
+
+    class MyWindow(QMainWindow):
+        def __init__(self):
+            super().__init__()
+
+            # Create toolbar and menu actions
+            self.toolbar_auto = QCheckBox("Auto")
+            self.menu_auto = QAction("Auto Mode", self)
+            self.menu_auto.setCheckable(True)
+
+            # Sync them
+            self.auto_sync = WidgetSync.for_checkbox(self.toolbar_auto)
+
+            # Connect menu action
+            self.auto_sync.connect(
+                self.menu_auto,
+                signal=self.menu_auto.toggled,
+                getter=lambda: self.menu_auto.isChecked(),
+                setter=lambda v: self.menu_auto.setChecked(v)
+            )
+
+Settings Panel
+~~~~~~~~~~~~~~
+
+Manage complex settings with multiple syncs:
+
+.. code-block:: python
+
+    class SettingsPanel(QWidget):
+        def __init__(self):
+            super().__init__()
+
+            # Create syncs for different settings
+            self.syncs = {
+                'auto_mode': WidgetSync.for_checkbox(self.auto_cb, initial=False),
+                'sample_rate': WidgetSync.for_spinbox(self.rate_spin, initial=1000),
+                'averaging': WidgetSync.for_spinbox(self.avg_spin, initial=10),
+            }
+
+        def get_settings(self):
+            """Get all settings as dict"""
+            return {key: sync.value for key, sync in self.syncs.items()}
+
+        def set_settings(self, settings):
+            """Set all settings from dict"""
+            for key, value in settings.items():
+                if key in self.syncs:
+                    self.syncs[key].value = value
+
+Multi-View Synchronization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Keep multiple views of the same data synchronized:
+
+.. code-block:: python
+
+    # Main view slider
+    main_sync = WidgetSync.for_slider(main_slider, initial=50)
+
+    # Add compact view
+    main_sync.add(compact_slider)
+
+    # Add detailed view with transforms
+    main_sync.connect(
+        detailed_label,
+        setter=lambda v: detailed_label.setText(
+            f"Value: {v} ({v/100:.0%})"
+        ),
+        mode=SyncMode.FROM_SYNC
+    )
+
+Dynamic Widget Management
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Manage widgets that are created and destroyed dynamically:
+
+.. code-block:: python
+
+    class DynamicPanel(QWidget):
+        def __init__(self):
+            super().__init__()
+            self.sync = WidgetSync(initial_value=50)
+            self.widgets = []
+
+        def add_widget(self):
+            """Add a new widget to the panel"""
+            slider = QSlider(Qt.Horizontal)
+            slider.setRange(0, 100)
+
+            # Connect to sync
+            self.sync.connect(
+                slider,
+                signal=slider.valueChanged,
+                getter=lambda: slider.value(),
+                setter=lambda v: slider.setValue(v)
+            )
+
+            self.widgets.append(slider)
+            self.layout().addWidget(slider)
+
+        def remove_widget(self, slider):
+            """Remove a widget from the panel"""
+            self.sync.disconnect(slider)
+            self.widgets.remove(slider)
+            slider.deleteLater()
+
+        def pause_widget(self, slider):
+            """Temporarily pause syncing for a widget"""
+            self.sync.disable(slider)
+
+        def resume_widget(self, slider):
+            """Resume syncing for a widget"""
+            self.sync.enable(slider)
+
+        def get_connection_info(self):
+            """Get info about active connections"""
+            return {
+                'count': self.sync.connection_count,
+                'widgets': self.sync.connected_widgets
+            }
+
+API Reference
+-------------
+
+WidgetSync Class
+~~~~~~~~~~~~~~~~
+
+.. autoclass:: pymodaq_gui.utils.widget_sync.WidgetSync
+   :members:
+   :undoc-members:
+
+SyncMode Enum
+~~~~~~~~~~~~~
+
+.. autoclass:: pymodaq_gui.utils.widget_sync.SyncMode
+   :members:
+
+WidgetSyncFactories Mixin
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pymodaq_gui.utils.widget_sync.WidgetSyncFactories
+   :members:
+   :undoc-members:
+
+Examples
+--------
+
+See the complete example in:
+
+.. code-block:: bash
+
+    python -m pymodaq_gui.examples.widget_sync_example
+
+
+Best Practices
+--------------
+
+DO:
+~~~
+
+* ✅ Use ``add()`` for widgets of the same type
+* ✅ Use ``connect()`` for different widget types
+* ✅ Use ``SyncMode.FROM_SYNC`` for read-only displays
+* ✅ Use factory methods for common cases
+* ✅ Create custom factories for your widget types
+* ✅ Use ``disable()``/``enable()`` for temporary pauses
+* ✅ Use ``disconnect()`` for permanent removal
+* ✅ Check ``connection_count`` and ``connected_widgets`` for debugging
+
+DON'T:
+~~~~~~
+
+* ❌ Don't use ``add()`` with different widget types (use ``connect()`` instead)
+* ❌ Don't create circular sync chains (A→B→C→A)
+* ❌ Don't disconnect/reconnect frequently (use ``disable()``/``enable()`` instead)
+* ❌ Don't manually disconnect unless necessary (automatic cleanup works)
+* ❌ Don't forget to handle value transformations when syncing different types
+
+
+See Also
+--------
+
+* :ref:`contributing` - Contributing guidelines
+* :ref:`api` - Full API reference
+* Example code: ``pymodaq_gui/examples/widget_sync_example.py``

--- a/docs/src/developer_folder/widget_sync.rst
+++ b/docs/src/developer_folder/widget_sync.rst
@@ -57,7 +57,7 @@ Sync different widget types representing the same value:
     sync.add(spinbox, match='property')  # Works because both use 'value'/'valueChanged'
 
     # Add read-only display
-    sync.connect(
+    sync.bind(
         progress_bar,
         setter=lambda v: progress_bar.setValue(v),
         mode=SyncMode.FROM_SYNC  # Read-only
@@ -165,8 +165,8 @@ Three synchronization modes:
     sync.add(widget, mode=SyncMode.TO_SYNC)
 
     # FROM_SYNC: Sync → Widget only (read-only display)
-    sync.connect(label, setter=lambda v: label.setText(str(v)),
-                 mode=SyncMode.FROM_SYNC)
+    sync.bind(label, setter=lambda v: label.setText(str(v)),
+              mode=SyncMode.FROM_SYNC)
 
 Value Transformations
 ---------------------
@@ -199,7 +199,7 @@ Transform values between widgets:
     # Boolean ↔ ComboBox index
     bool_sync = WidgetSync.for_checkbox(checkbox, initial=True)
 
-    bool_sync.connect(
+    bool_sync.bind(
         combobox,
         signal=combobox.currentIndexChanged,
         getter=lambda: combobox.currentIndex(),
@@ -220,7 +220,7 @@ For complete control:
 
     sync = WidgetSync(initial_value=50)
 
-    sync.connect(
+    sync.bind(
         widget,
         signal=widget.valueChanged,
         getter=lambda: widget.value(),
@@ -261,7 +261,7 @@ Temporarily pause syncing without disconnecting:
 **Key differences:**
 
 * ``disable()`` - Temporarily stops syncing, connection remains
-* ``disconnect()`` - Removes connection entirely, needs reconnection
+* ``unbind()`` - Removes connection entirely, needs reconnection
 
 Conditional Widget Enable/Disable
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -312,18 +312,18 @@ its connection is automatically removed. Manual management is available when nee
     # Check connection state
     is_syncing = sync.is_enabled(widget)
 
-    # Permanently disconnect widget
-    sync.disconnect(widget)
+    # Permanently unbind widget
+    sync.unbind(widget)
     # or
-    sync.remove(widget)  # Alias for disconnect
+    sync.remove(widget)  # Alias for unbind
 
-    # Disconnect all (useful when deleting the sync itself)
-    sync.disconnect_all()
+    # Unbind all (useful when deleting the sync itself)
+    sync.unbind_all()
 
 **When to use what:**
 
 * ``disable()`` - Temporary pause, keeps connection setup, fast to re-enable
-* ``disconnect()`` - Permanent removal, requires full reconnection
+* ``unbind()`` - Permanent removal, requires full reconnection
 * Automatic cleanup - Widget deletion triggers cleanup automatically
 
 
@@ -349,8 +349,8 @@ Keep toolbar and menu items synchronized:
             # Sync them
             self.auto_sync = WidgetSync.for_checkbox(self.toolbar_auto)
 
-            # Connect menu action
-            self.auto_sync.connect(
+            # Bind menu action
+            self.auto_sync.bind(
                 self.menu_auto,
                 signal=self.menu_auto.toggled,
                 getter=lambda: self.menu_auto.isChecked(),
@@ -372,7 +372,7 @@ Keep multiple views of the same data synchronized:
     main_sync.add(compact_slider)
 
     # Add detailed view with transforms
-    main_sync.connect(
+    main_sync.bind(
         detailed_label,
         setter=lambda v: detailed_label.setText(
             f"Value: {v} ({v/100:.0%})"
@@ -398,8 +398,8 @@ Manage widgets that are created and destroyed dynamically:
             slider = QSlider(Qt.Horizontal)
             slider.setRange(0, 100)
 
-            # Connect to sync
-            self.sync.connect(
+            # Bind to sync
+            self.sync.bind(
                 slider,
                 signal=slider.valueChanged,
                 getter=lambda: slider.value(),
@@ -411,7 +411,7 @@ Manage widgets that are created and destroyed dynamically:
 
         def remove_widget(self, slider):
             """Remove a widget from the panel"""
-            self.sync.disconnect(slider)
+            self.sync.unbind(slider)
             self.widgets.remove(slider)
             slider.deleteLater()
 
@@ -471,12 +471,12 @@ DO:
 
 * ✅ Use ``add()`` for widgets of the same type (default ``match='type'``)
 * ✅ Use ``add(widget, match='property')`` for different types with compatible properties
-* ✅ Use ``connect()`` for complete control over getter/setter/transforms
+* ✅ Use ``bind()`` for complete control over getter/setter/transforms
 * ✅ Use ``SyncMode.FROM_SYNC`` for read-only displays
 * ✅ Use factory methods for common widget types
 * ✅ Use ``data_type`` parameter for explicit type checking
 * ✅ Use ``disable()``/``enable()`` for temporary pauses
-* ✅ Use ``disconnect()`` for permanent removal
+* ✅ Use ``unbind()`` for permanent removal
 * ✅ Check ``connection_count`` and ``connected_widgets`` for debugging
 
 DON'T:

--- a/docs/src/developer_folder/widget_sync.rst
+++ b/docs/src/developer_folder/widget_sync.rst
@@ -53,7 +53,8 @@ Sync different widget types representing the same value:
 
     # Slider and spinbox for same value
     sync = WidgetSync.for_slider(slider, initial=50)
-    sync.add(spinbox)  # Stays in sync
+    # Use match='property' to allow different widget types with same property/signal
+    sync.add(spinbox, match='property')  # Works because both use 'value'/'valueChanged'
 
     # Add read-only display
     sync.connect(
@@ -99,8 +100,54 @@ For any Qt property:
         widget,
         property_name='value',  # Qt property name
         signal_name='valueChanged',  # Change signal (optional, auto-detected)
-        initial=50
+        initial=50,
+        data_type=int  # Optional: explicit type checking
     )
+
+Adding Widgets: Type vs Property Matching
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When adding widgets with ``add()``, you can control the matching strategy:
+
+.. code-block:: python
+
+    # Type matching (default) - only same widget types
+    sync = WidgetSync.for_slider(slider1)
+    sync.add(slider2)  # OK - both QSlider
+    # sync.add(spinbox)  # Would raise TypeError
+
+    # Property matching - different widget types with compatible property/signal
+    sync = WidgetSync.for_slider(slider1)
+    sync.add(spinbox, match='property')  # OK - both use 'value'/'valueChanged'
+    sync.add(dial, match='property')     # OK - also uses 'value'/'valueChanged'
+
+**When to use:**
+
+- ``match='type'`` (default): Safest, ensures identical widget behavior
+- ``match='property'``: Flexible, allows mixing compatible widget types (e.g., QSlider + QSpinBox)
+
+Data Type Safety
+~~~~~~~~~~~~~~~~
+
+WidgetSync supports explicit data type checking:
+
+.. code-block:: python
+
+    # Type inferred from initial value
+    sync = WidgetSync(initial_value=True)  # data_type = bool
+    sync = WidgetSync(initial_value=50)    # data_type = int
+
+    # Explicit type checking
+    sync = WidgetSync(initial_value=0, data_type=int)
+
+    # Using factories with data_type
+    sync = WidgetSync.for_property(
+        widget, 'value', initial=50, data_type=int
+    )
+
+    # Type checking validates values and transforms
+    sync.value = 100  # OK
+    # sync.value = "text"  # Raises TypeError
 
 Sync Modes
 ----------
@@ -136,6 +183,18 @@ Transform values between widgets:
         to_sync_transform=lambda f: round((f - 32) * 5/9),  # F → C
         from_sync_transform=lambda c: round(c * 9/5 + 32)   # C → F
     )
+
+    # Opposite/Inverted Checkboxes
+    # Perfect for "Enable/Disable" vs "Lock/Unlock" scenarios
+    enable_sync = WidgetSync.for_checkbox(enable_checkbox, initial=True)
+
+    enable_sync.add(
+        disable_checkbox,
+        match='property',  # Both are checkboxes with 'checked' property
+        to_sync_transform=lambda checked: not checked,  # Invert: checked → not checked
+        from_sync_transform=lambda checked: not checked  # Invert: checked → not checked
+    )
+    # Now: enable_checkbox=True ↔ disable_checkbox=False
 
     # Boolean ↔ ComboBox index
     bool_sync = WidgetSync.for_checkbox(checkbox, initial=True)
@@ -298,33 +357,6 @@ Keep toolbar and menu items synchronized:
                 setter=lambda v: self.menu_auto.setChecked(v)
             )
 
-Settings Panel
-~~~~~~~~~~~~~~
-
-Manage complex settings with multiple syncs:
-
-.. code-block:: python
-
-    class SettingsPanel(QWidget):
-        def __init__(self):
-            super().__init__()
-
-            # Create syncs for different settings
-            self.syncs = {
-                'auto_mode': WidgetSync.for_checkbox(self.auto_cb, initial=False),
-                'sample_rate': WidgetSync.for_spinbox(self.rate_spin, initial=1000),
-                'averaging': WidgetSync.for_spinbox(self.avg_spin, initial=10),
-            }
-
-        def get_settings(self):
-            """Get all settings as dict"""
-            return {key: sync.value for key, sync in self.syncs.items()}
-
-        def set_settings(self, settings):
-            """Set all settings from dict"""
-            for key, value in settings.items():
-                if key in self.syncs:
-                    self.syncs[key].value = value
 
 Multi-View Synchronization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -401,25 +433,25 @@ Manage widgets that are created and destroyed dynamically:
 API Reference
 -------------
 
-WidgetSync Class
-~~~~~~~~~~~~~~~~
+.. WidgetSync Class
+.. ~~~~~~~~~~~~~~~~
 
-.. autoclass:: pymodaq_gui.utils.widget_sync.WidgetSync
-   :members:
-   :undoc-members:
+.. .. autoclass:: pymodaq_gui.utils.widget_sync.WidgetSync
+..    :members:
+..    :undoc-members:
 
-SyncMode Enum
-~~~~~~~~~~~~~
+.. SyncMode Enum
+.. ~~~~~~~~~~~~~
 
-.. autoclass:: pymodaq_gui.utils.widget_sync.SyncMode
-   :members:
+.. .. autoclass:: pymodaq_gui.utils.widget_sync.SyncMode
+..    :members:
 
-WidgetSyncFactories Mixin
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. WidgetSyncFactories Mixin
+.. ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: pymodaq_gui.utils.widget_sync.WidgetSyncFactories
-   :members:
-   :undoc-members:
+.. .. autoclass:: pymodaq_gui.utils.widget_sync.WidgetSyncFactories
+..    :members:
+..    :undoc-members:
 
 Examples
 --------
@@ -437,11 +469,12 @@ Best Practices
 DO:
 ~~~
 
-* ✅ Use ``add()`` for widgets of the same type
-* ✅ Use ``connect()`` for different widget types
+* ✅ Use ``add()`` for widgets of the same type (default ``match='type'``)
+* ✅ Use ``add(widget, match='property')`` for different types with compatible properties
+* ✅ Use ``connect()`` for complete control over getter/setter/transforms
 * ✅ Use ``SyncMode.FROM_SYNC`` for read-only displays
-* ✅ Use factory methods for common cases
-* ✅ Create custom factories for your widget types
+* ✅ Use factory methods for common widget types
+* ✅ Use ``data_type`` parameter for explicit type checking
 * ✅ Use ``disable()``/``enable()`` for temporary pauses
 * ✅ Use ``disconnect()`` for permanent removal
 * ✅ Check ``connection_count`` and ``connected_widgets`` for debugging
@@ -449,11 +482,12 @@ DO:
 DON'T:
 ~~~~~~
 
-* ❌ Don't use ``add()`` with different widget types (use ``connect()`` instead)
+* ❌ Don't use ``add()`` without considering the ``match`` parameter
 * ❌ Don't create circular sync chains (A→B→C→A)
 * ❌ Don't disconnect/reconnect frequently (use ``disable()``/``enable()`` instead)
 * ❌ Don't manually disconnect unless necessary (automatic cleanup works)
 * ❌ Don't forget to handle value transformations when syncing different types
+* ❌ Don't mix incompatible data types without proper transforms
 
 
 See Also

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync_example.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync_example.py
@@ -207,7 +207,7 @@ class WidgetSyncDemo(QWidget):
         self.value_sync.add(self.value_spin, match='property')
 
         # Add progress bar as read-only display
-        self.value_sync.connect(
+        self.value_sync.bind(
             self.value_progress,
             setter=lambda v: self.value_progress.setValue(v),
             mode=SyncMode.FROM_SYNC
@@ -464,7 +464,7 @@ class WidgetSyncDemo(QWidget):
         reconnect_btn.setEnabled(False)
 
         # Add to sync
-        self.dynamic_sync.connect(
+        self.dynamic_sync.bind(
             slider,
             signal=slider.valueChanged,
             getter=lambda s=slider: s.value(),
@@ -482,14 +482,14 @@ class WidgetSyncDemo(QWidget):
             self.update_connection_info()
 
         def disconnect_slider():
-            self.dynamic_sync.disconnect(slider)
+            self.dynamic_sync.unbind(slider)
             enable_btn.setEnabled(False)
             disconnect_btn.setEnabled(False)
             reconnect_btn.setEnabled(True)
             self.update_connection_info()
 
         def reconnect_slider():
-            self.dynamic_sync.connect(
+            self.dynamic_sync.bind(
                 slider,
                 signal=slider.valueChanged,
                 getter=lambda s=slider: s.value(),
@@ -531,11 +531,11 @@ class WidgetSyncDemo(QWidget):
         slider_widget = slider_data[0]
         slider = slider_data[1]
 
-        # Disconnect from sync if still connected
+        # Unbind from sync if still connected
         try:
-            self.dynamic_sync.disconnect(slider)
+            self.dynamic_sync.unbind(slider)
         except ValueError:
-            pass  # Already disconnected
+            pass  # Already unbound
 
         # Remove from UI
         self.sliders_layout.removeWidget(slider_widget)
@@ -612,11 +612,11 @@ class WidgetSyncDemo(QWidget):
 
         layout.addLayout(row4)
 
-        # Create sync and connect all widgets
+        # Create sync and bind all widgets
         self.multi_sync = WidgetSync(initial_value=50)
 
         # Slider
-        self.multi_sync.connect(
+        self.multi_sync.bind(
             self.multi_slider,
             signal=self.multi_slider.valueChanged,
             getter=lambda: self.multi_slider.value(),
@@ -624,7 +624,7 @@ class WidgetSyncDemo(QWidget):
         )
 
         # SpinBox
-        self.multi_sync.connect(
+        self.multi_sync.bind(
             self.multi_spin,
             signal=self.multi_spin.valueChanged,
             getter=lambda: self.multi_spin.value(),
@@ -632,7 +632,7 @@ class WidgetSyncDemo(QWidget):
         )
 
         # Dial
-        self.multi_sync.connect(
+        self.multi_sync.bind(
             self.multi_dial,
             signal=self.multi_dial.valueChanged,
             getter=lambda: self.multi_dial.value(),
@@ -640,14 +640,14 @@ class WidgetSyncDemo(QWidget):
         )
 
         # Progress (read-only)
-        self.multi_sync.connect(
+        self.multi_sync.bind(
             self.multi_progress,
             setter=lambda v: self.multi_progress.setValue(v),
             mode=SyncMode.FROM_SYNC
         )
 
         # LineEdit with validation
-        self.multi_sync.connect(
+        self.multi_sync.bind(
             self.multi_lineedit,
             signal=self.multi_lineedit.textChanged,
             getter=lambda: self.multi_lineedit.text(),
@@ -656,7 +656,7 @@ class WidgetSyncDemo(QWidget):
         )
 
         # Label (read-only)
-        self.multi_sync.connect(
+        self.multi_sync.bind(
             self.multi_label,
             setter=lambda v: self.multi_label.setText(f"Value: {v}"),
             mode=SyncMode.FROM_SYNC
@@ -702,23 +702,23 @@ class WidgetSyncDemo(QWidget):
         # Create sync
         self.color_sync = WidgetSync(initial_value="red")
 
-        # Connect custom widget
-        self.color_sync.connect(
+        # Bind custom widget
+        self.color_sync.bind(
             self.color_display,
             signal=self.color_display.colorChanged,
             getter=lambda: self.color_display.get_color(),
             setter=lambda c: self.color_display.set_color(c)
         )
 
-        # Connect ComboBox
-        self.color_sync.connect(
+        # Bind ComboBox
+        self.color_sync.bind(
             self.color_combo,
             signal=self.color_combo.currentTextChanged,
             getter=lambda: self.color_combo.currentText(),
             setter=lambda c: self.color_combo.setCurrentText(c)
         )
 
-        # Connect radio buttons
+        # Bind radio buttons
         def get_selected_radio():
             checked = self.color_radio_group.checkedButton()
             return checked.property("color") if checked else "red"
@@ -737,7 +737,7 @@ class WidgetSyncDemo(QWidget):
             return button
 
         first_radio = self.color_radio_group.buttons()[0]
-        self.color_sync.connect(
+        self.color_sync.bind(
             first_radio,
             signal=self.color_radio_group.buttonClicked,
             getter=get_selected_radio,

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync_example.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync_example.py
@@ -1,9 +1,6 @@
 """
 Widget Synchronization Example
 
-Demonstrates how to use WidgetSync to keep multiple widgets synchronized.
-Perfect for settings panels, toolbar/menu consistency, and multi-view UIs.
-
 Run this example:
     python -m pymodaq_gui.examples.widget_sync_example
 """
@@ -78,6 +75,7 @@ class WidgetSyncDemo(QWidget):
         tabs.addTab(self.create_settings_example(), "Module State")
         tabs.addTab(self.create_value_control_example(), "Value Control")
         tabs.addTab(self.create_enable_disable_example(), "Enable/Disable")
+        tabs.addTab(self.create_opposite_checkbox_example(), "Opposite Checkboxes")
         tabs.addTab(self.create_dynamic_add_remove_example(), "Add/Remove Widgets")
         tabs.addTab(self.create_many_widget_types_example(), "Many Widgets")
         tabs.addTab(self.create_custom_widget_example(), "Custom Widget")
@@ -95,8 +93,7 @@ class WidgetSyncDemo(QWidget):
         layout = QVBoxLayout()
 
         layout.addWidget(QLabel(
-            "Use case: Sync DAQ module state between compact and full views\n"
-            "Perfect for PyMoDAQ's module initialization and control states"
+            "Use case: Sync DAQ module state between compact and full views"
         ))
 
         # Compact view controls
@@ -174,8 +171,7 @@ class WidgetSyncDemo(QWidget):
         layout = QVBoxLayout()
 
         layout.addWidget(QLabel(
-            "Use case: Control same value with different widgets\n"
-            "Perfect for PyMoDAQ's parameter controls with multiple views"
+            "Use case: Control same value with different widgets"
         ))
 
         # Slider
@@ -207,7 +203,8 @@ class WidgetSyncDemo(QWidget):
 
         # Create sync
         self.value_sync = WidgetSync.for_slider(self.value_slider, initial=50)
-        self.value_sync.add(self.value_spin)
+        # Spinbox and slider are different types but use same property/signal
+        self.value_sync.add(self.value_spin, match='property')
 
         # Add progress bar as read-only display
         self.value_sync.connect(
@@ -225,8 +222,7 @@ class WidgetSyncDemo(QWidget):
         layout = QVBoxLayout()
 
         layout.addWidget(QLabel(
-            "Use case: Enable/disable controls based on mode\n"
-            "Perfect for PyMoDAQ's acquisition mode settings"
+            "Use case: Enable/disable controls based on mode"
         ))
 
         # Master enable
@@ -263,6 +259,109 @@ class WidgetSyncDemo(QWidget):
 
         widget.setLayout(layout)
         return widget
+
+    def create_opposite_checkbox_example(self):
+        """Example 4: Opposite/Inverted checkboxes with value transforms"""
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel(
+            "Use case: Lock/Unlock, Enable/Disable with opposite states"
+        ))
+
+        # Enable/Disable example
+        enable_group = QGroupBox("Enable/Disable Control")
+        enable_layout = QVBoxLayout()
+
+        enable_layout.addWidget(QLabel("These checkboxes have opposite states:"))
+
+        self.enable_checkbox = QCheckBox("Enable Acquisition")
+        self.enable_checkbox.setChecked(True)
+        enable_layout.addWidget(self.enable_checkbox)
+
+        self.disable_checkbox = QCheckBox("Disable Acquisition")
+        self.disable_checkbox.setChecked(False)
+        enable_layout.addWidget(self.disable_checkbox)
+
+        # Sync with inversion
+        self.enable_sync = WidgetSync.for_checkbox(self.enable_checkbox, initial=True)
+        self.enable_sync.add(
+            self.disable_checkbox,
+            match='property',  # Both are checkboxes
+            to_sync_transform=lambda checked: not checked,  # Invert
+            from_sync_transform=lambda checked: not checked  # Invert
+        )
+
+        enable_group.setLayout(enable_layout)
+        layout.addWidget(enable_group)
+
+        # Lock/Unlock example
+        lock_group = QGroupBox("Lock/Unlock Control")
+        lock_layout = QVBoxLayout()
+
+        lock_layout.addWidget(QLabel("These checkboxes have opposite states:"))
+
+        self.unlock_checkbox = QCheckBox("Unlocked (Editing Allowed)")
+        self.unlock_checkbox.setChecked(False)
+        lock_layout.addWidget(self.unlock_checkbox)
+
+        self.lock_checkbox = QCheckBox("Locked (Read-Only)")
+        self.lock_checkbox.setChecked(True)
+        lock_layout.addWidget(self.lock_checkbox)
+
+        # Sync with inversion
+        self.unlock_sync = WidgetSync.for_checkbox(self.unlock_checkbox, initial=False)
+        self.unlock_sync.add(
+            self.lock_checkbox,
+            match='property',
+            to_sync_transform=lambda checked: not checked,
+            from_sync_transform=lambda checked: not checked
+        )
+
+        lock_group.setLayout(lock_layout)
+        layout.addWidget(lock_group)
+
+        # Status display
+        status_group = QGroupBox("Current Status")
+        status_layout = QVBoxLayout()
+
+        self.opposite_status = QLabel()
+        self.update_opposite_status()
+        status_layout.addWidget(self.opposite_status)
+
+        status_group.setLayout(status_layout)
+        layout.addWidget(status_group)
+
+        # Connect to update status
+        self.enable_sync.value_changed.connect(lambda _: self.update_opposite_status())
+        self.unlock_sync.value_changed.connect(lambda _: self.update_opposite_status())
+
+        # Info
+        info_label = QLabel(
+            "💡 Implementation:\n"
+            "sync.add(opposite_checkbox, match='property',\n"
+            "         to_sync_transform=lambda v: not v,\n"
+            "         from_sync_transform=lambda v: not v)"
+        )
+        info_label.setStyleSheet("padding: 10px; border-radius: 5px;")
+        layout.addWidget(info_label)
+
+        layout.addStretch()
+        widget.setLayout(layout)
+        return widget
+
+    def update_opposite_status(self):
+        """Update the status display for opposite checkboxes"""
+        enable_state = "Enabled" if self.enable_checkbox.isChecked() else "Disabled"
+        disable_state = "Checked" if self.disable_checkbox.isChecked() else "Unchecked"
+        lock_state = "Locked" if self.lock_checkbox.isChecked() else "Unlocked"
+        unlock_state = "Checked" if self.unlock_checkbox.isChecked() else "Unchecked"
+
+        self.opposite_status.setText(
+            f"Enable Acquisition: {enable_state} | Disable Acquisition: {disable_state}\n"
+            f"Locked: {lock_state} | Unlocked: {unlock_state}\n\n"
+            f"✓ States are always opposite!"
+        )
 
     def create_dynamic_add_remove_example(self):
         """Example 4: Dynamic add/remove with connection tracking"""

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync_example.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync_example.py
@@ -181,7 +181,7 @@ class WidgetSyncDemo(QWidget):
         # Slider
         slider_layout = QHBoxLayout()
         slider_layout.addWidget(QLabel("Slider:"))
-        self.value_slider = QSlider(Qt.Horizontal)
+        self.value_slider = QSlider(Qt.Orientation.Horizontal)
         self.value_slider.setRange(0, 100)
         slider_layout.addWidget(self.value_slider)
         layout.addLayout(slider_layout)
@@ -348,7 +348,7 @@ class WidgetSyncDemo(QWidget):
         label = QLabel(f"Slider {slider_num}:")
         label.setMinimumWidth(80)
 
-        slider = QSlider(Qt.Horizontal)
+        slider = QSlider(Qt.Orientation.Horizontal)
         slider.setRange(0, 100)
         slider.setValue(self.dynamic_sync.value)
 
@@ -470,7 +470,7 @@ class WidgetSyncDemo(QWidget):
         ))
 
         # Create many different widgets for 0-100 value
-        self.multi_slider = QSlider(Qt.Horizontal)
+        self.multi_slider = QSlider(Qt.Orientation.Horizontal)
         self.multi_slider.setRange(0, 100)
 
         self.multi_spin = QSpinBox()

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync_example.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync_example.py
@@ -1,0 +1,666 @@
+"""
+Widget Synchronization Example
+
+Demonstrates how to use WidgetSync to keep multiple widgets synchronized.
+Perfect for settings panels, toolbar/menu consistency, and multi-view UIs.
+
+Run this example:
+    python -m pymodaq_gui.examples.widget_sync_example
+"""
+import sys
+from qtpy.QtWidgets import (QApplication, QWidget, QVBoxLayout, QHBoxLayout,
+                            QGroupBox, QCheckBox, QSpinBox, QSlider, QLabel,
+                            QPushButton, QComboBox, QLineEdit, QRadioButton,
+                            QButtonGroup, QProgressBar, QDial, QTabWidget)
+from qtpy.QtCore import Qt
+
+from pymodaq_gui.utils.widget_sync import WidgetSync, SyncMode
+
+
+class ColorWidget(QLabel):
+    """Custom widget example - shows how to sync custom widgets"""
+    from qtpy.QtCore import Signal
+    colorChanged = Signal(str)
+
+    def __init__(self):
+        super().__init__()
+        self._color = "red"
+        self.setFixedSize(150, 60)
+        self.setAlignment(Qt.AlignCenter)
+        self.setText("Color Display")
+        self._update_display()
+
+    def set_color(self, color: str):
+        if self._color != color:
+            self._color = color
+            self._update_display()
+            self.colorChanged.emit(color)
+
+    def _update_display(self):
+        """Update the visual display"""
+        self.setStyleSheet(
+            f"background-color: {self._color}; "
+            f"border: 3px solid black; "
+            f"border-radius: 8px; "
+            f"font-weight: bold; "
+            f"color: white; "
+            f"padding: 5px;"
+        )
+        self.setAutoFillBackground(True)
+
+    def get_color(self) -> str:
+        return self._color
+
+
+class WidgetSyncDemo(QWidget):
+    """
+    Demonstration of WidgetSync features for PyMoDAQ.
+
+    Shows common patterns:
+    - Settings synchronization (checkboxes, values)
+    - Different widget types for same value
+    - Read-only displays
+    - Conditional enables/disables
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Widget Sync - PyMoDAQ Example")
+        self.setup_ui()
+
+    def setup_ui(self):
+        layout = QVBoxLayout(self)
+
+        # Create tab widget
+        tabs = QTabWidget()
+
+        # Add each example as a tab
+        tabs.addTab(self.create_settings_example(), "Module State")
+        tabs.addTab(self.create_value_control_example(), "Value Control")
+        tabs.addTab(self.create_enable_disable_example(), "Enable/Disable")
+        tabs.addTab(self.create_dynamic_add_remove_example(), "Add/Remove Widgets")
+        tabs.addTab(self.create_many_widget_types_example(), "Many Widgets")
+        tabs.addTab(self.create_custom_widget_example(), "Custom Widget")
+
+        layout.addWidget(tabs)
+
+        # Status bar
+        self.status_label = QLabel("Ready - Switch tabs to see different examples")
+        self.status_label.setStyleSheet("padding: 5px;")
+        layout.addWidget(self.status_label)
+
+    def create_settings_example(self):
+        """Example 1: Synchronizing module state across views"""
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel(
+            "Use case: Sync DAQ module state between compact and full views\n"
+            "Perfect for PyMoDAQ's module initialization and control states"
+        ))
+
+        # Compact view controls
+        compact_box = QGroupBox("Compact View")
+        compact_controls = QHBoxLayout()
+        self.compact_init = QCheckBox("Init")
+        self.compact_grab = QCheckBox("Grab")
+        self.compact_save = QCheckBox("Save")
+        compact_controls.addWidget(self.compact_init)
+        compact_controls.addWidget(self.compact_grab)
+        compact_controls.addWidget(self.compact_save)
+        compact_controls.addStretch()
+        compact_box.setLayout(compact_controls)
+        layout.addWidget(compact_box)
+
+        # Full view controls
+        full_box = QGroupBox("Full View")
+        full_controls = QVBoxLayout()
+
+        init_row = QHBoxLayout()
+        self.full_init = QCheckBox("Module Initialized")
+        self.init_status = QLabel("●")
+        self.init_status.setStyleSheet("color: red; font-size: 16px;")
+        init_row.addWidget(self.full_init)
+        init_row.addWidget(self.init_status)
+        init_row.addStretch()
+
+        grab_row = QHBoxLayout()
+        self.full_grab = QCheckBox("Continuous Grabbing")
+        self.grab_status = QLabel("●")
+        self.grab_status.setStyleSheet("color: red; font-size: 16px;")
+        grab_row.addWidget(self.full_grab)
+        grab_row.addWidget(self.grab_status)
+        grab_row.addStretch()
+
+        save_row = QHBoxLayout()
+        self.full_save = QCheckBox("Auto-save Data")
+        save_row.addWidget(self.full_save)
+        save_row.addStretch()
+
+        full_controls.addLayout(init_row)
+        full_controls.addLayout(grab_row)
+        full_controls.addLayout(save_row)
+        full_box.setLayout(full_controls)
+        layout.addWidget(full_box)
+
+        # Create syncs between views
+        self.init_sync = WidgetSync.for_checkbox(self.compact_init, initial=False)
+        self.init_sync.add(self.full_init)
+        # Update status indicator
+        self.init_sync.value_changed.connect(
+            lambda v: self.init_status.setStyleSheet(
+                f"color: {'green' if v else 'red'}; font-size: 16px;"
+            )
+        )
+
+        self.grab_sync = WidgetSync.for_checkbox(self.compact_grab, initial=False)
+        self.grab_sync.add(self.full_grab)
+        # Update status indicator
+        self.grab_sync.value_changed.connect(
+            lambda v: self.grab_status.setStyleSheet(
+                f"color: {'green' if v else 'red'}; font-size: 16px;"
+            )
+        )
+
+        self.save_sync = WidgetSync.for_checkbox(self.compact_save, initial=False)
+        self.save_sync.add(self.full_save)
+
+        widget.setLayout(layout)
+        return widget
+
+    def create_value_control_example(self):
+        """Example 2: Different widgets for same value"""
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel(
+            "Use case: Control same value with different widgets\n"
+            "Perfect for PyMoDAQ's parameter controls with multiple views"
+        ))
+
+        # Slider
+        slider_layout = QHBoxLayout()
+        slider_layout.addWidget(QLabel("Slider:"))
+        self.value_slider = QSlider(Qt.Horizontal)
+        self.value_slider.setRange(0, 100)
+        slider_layout.addWidget(self.value_slider)
+        layout.addLayout(slider_layout)
+
+        # SpinBox
+        spin_layout = QHBoxLayout()
+        spin_layout.addWidget(QLabel("Numeric:"))
+        self.value_spin = QSpinBox()
+        self.value_spin.setRange(0, 100)
+        self.value_spin.setSuffix(" %")
+        spin_layout.addWidget(self.value_spin)
+        spin_layout.addStretch()
+        layout.addLayout(spin_layout)
+
+        # Progress bar (read-only)
+        progress_layout = QHBoxLayout()
+        progress_layout.addWidget(QLabel("Progress:"))
+        self.value_progress = QProgressBar()
+        self.value_progress.setRange(0, 100)
+        self.value_progress.setFormat("%v%")
+        progress_layout.addWidget(self.value_progress)
+        layout.addLayout(progress_layout)
+
+        # Create sync
+        self.value_sync = WidgetSync.for_slider(self.value_slider, initial=50)
+        self.value_sync.add(self.value_spin)
+
+        # Add progress bar as read-only display
+        self.value_sync.connect(
+            self.value_progress,
+            setter=lambda v: self.value_progress.setValue(v),
+            mode=SyncMode.FROM_SYNC
+        )
+
+        widget.setLayout(layout)
+        return widget
+
+    def create_enable_disable_example(self):
+        """Example 3: Conditional enable/disable"""
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel(
+            "Use case: Enable/disable controls based on mode\n"
+            "Perfect for PyMoDAQ's acquisition mode settings"
+        ))
+
+        # Master enable
+        self.master_enable = QCheckBox("Enable Advanced Controls")
+
+        # Controlled widgets
+        controls_layout = QHBoxLayout()
+        controls_layout.addWidget(QLabel("Advanced:"))
+        self.advanced_spin1 = QSpinBox()
+        self.advanced_spin1.setRange(0, 100)
+        self.advanced_spin2 = QSpinBox()
+        self.advanced_spin2.setRange(0, 100)
+        controls_layout.addWidget(self.advanced_spin1)
+        controls_layout.addWidget(self.advanced_spin2)
+        controls_layout.addStretch()
+
+        layout.addWidget(self.master_enable)
+        layout.addLayout(controls_layout)
+
+        # Sync checkbox state
+        self.enable_sync = WidgetSync.for_checkbox(self.master_enable, initial=False)
+
+        # Connect to enable/disable the spinboxes
+        self.enable_sync.value_changed.connect(
+            lambda enabled: self.advanced_spin1.setEnabled(enabled)
+        )
+        self.enable_sync.value_changed.connect(
+            lambda enabled: self.advanced_spin2.setEnabled(enabled)
+        )
+
+        # Initialize state
+        self.advanced_spin1.setEnabled(False)
+        self.advanced_spin2.setEnabled(False)
+
+        widget.setLayout(layout)
+        return widget
+
+    def create_dynamic_add_remove_example(self):
+        """Example 4: Dynamic add/remove with connection tracking"""
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel(
+            "Use case: Dynamically add, remove, enable, and disable widgets\n"
+            "- Enable/Disable: Temporarily pause syncing without disconnecting\n"
+            "- Disconnect/Reconnect: Fully remove and restore connections\n"
+            "- Track connection count and list in real-time"
+        ))
+
+        # Connection info display
+        info_box = QGroupBox("Connection Info")
+        info_layout = QVBoxLayout()
+        self.connection_count_label = QLabel("Connected widgets: 0")
+        self.connection_count_label.setStyleSheet("font-weight: bold; font-size: 14px;")
+        self.connection_list_label = QLabel("List: (none)")
+        info_layout.addWidget(self.connection_count_label)
+        info_layout.addWidget(self.connection_list_label)
+        info_box.setLayout(info_layout)
+        layout.addWidget(info_box)
+
+        # Control buttons
+        button_layout = QHBoxLayout()
+        self.add_widget_btn = QPushButton("Add Slider")
+        self.remove_widget_btn = QPushButton("Remove Last Slider")
+        self.remove_widget_btn.setEnabled(False)
+        button_layout.addWidget(self.add_widget_btn)
+        button_layout.addWidget(self.remove_widget_btn)
+        button_layout.addStretch()
+        layout.addLayout(button_layout)
+
+        # Master value display
+        value_layout = QHBoxLayout()
+        value_layout.addWidget(QLabel("Current Value:"))
+        self.master_value_label = QLabel("50")
+        self.master_value_label.setStyleSheet(
+            "font-size: 24px; font-weight: bold; color: #2196F3; "
+            "padding: 10px; border: 2px solid #2196F3; border-radius: 5px;"
+        )
+        value_layout.addWidget(self.master_value_label)
+        value_layout.addStretch()
+        layout.addLayout(value_layout)
+
+        # Container for dynamic sliders
+        self.sliders_container = QWidget()
+        self.sliders_layout = QVBoxLayout(self.sliders_container)
+        self.sliders_layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.sliders_container)
+
+        layout.addStretch()
+
+        # Create sync
+        self.dynamic_sync = WidgetSync(initial_value=50)
+        self.dynamic_sliders = []  # Track slider widgets
+
+        # Update display whenever value changes
+        self.dynamic_sync.value_changed.connect(
+            lambda v: self.master_value_label.setText(str(v))
+        )
+
+        # Connect buttons
+        self.add_widget_btn.clicked.connect(self.add_dynamic_slider)
+        self.remove_widget_btn.clicked.connect(self.remove_dynamic_slider)
+
+        # Add initial slider
+        self.add_dynamic_slider()
+        self.add_dynamic_slider()
+
+        widget.setLayout(layout)
+        return widget
+
+    def add_dynamic_slider(self):
+        """Add a new slider to the sync"""
+        # Create slider with label and controls
+        slider_widget = QWidget()
+        slider_layout = QHBoxLayout(slider_widget)
+        slider_layout.setContentsMargins(0, 5, 0, 5)
+
+        slider_num = len(self.dynamic_sliders) + 1
+        label = QLabel(f"Slider {slider_num}:")
+        label.setMinimumWidth(80)
+
+        slider = QSlider(Qt.Horizontal)
+        slider.setRange(0, 100)
+        slider.setValue(self.dynamic_sync.value)
+
+        # Control buttons
+        enable_btn = QPushButton("Disable")
+        enable_btn.setMaximumWidth(80)
+        enable_btn.setCheckable(True)
+
+        disconnect_btn = QPushButton("Disconnect")
+        disconnect_btn.setMaximumWidth(90)
+
+        reconnect_btn = QPushButton("Reconnect")
+        reconnect_btn.setMaximumWidth(90)
+        reconnect_btn.setEnabled(False)
+
+        # Add to sync
+        self.dynamic_sync.connect(
+            slider,
+            signal=slider.valueChanged,
+            getter=lambda s=slider: s.value(),
+            setter=lambda v, s=slider: s.setValue(v)
+        )
+
+        # Connect control buttons
+        def toggle_enable():
+            if enable_btn.isChecked():
+                self.dynamic_sync.disable(slider)
+                enable_btn.setText("Enable")
+            else:
+                self.dynamic_sync.enable(slider)
+                enable_btn.setText("Disable")
+            self.update_connection_info()
+
+        def disconnect_slider():
+            self.dynamic_sync.disconnect(slider)
+            enable_btn.setEnabled(False)
+            disconnect_btn.setEnabled(False)
+            reconnect_btn.setEnabled(True)
+            self.update_connection_info()
+
+        def reconnect_slider():
+            self.dynamic_sync.connect(
+                slider,
+                signal=slider.valueChanged,
+                getter=lambda s=slider: s.value(),
+                setter=lambda v, s=slider: s.setValue(v)
+            )
+            slider.setEnabled(True)
+            enable_btn.setEnabled(True)
+            enable_btn.setChecked(False)
+            enable_btn.setText("Disable")
+            disconnect_btn.setEnabled(True)
+            reconnect_btn.setEnabled(False)
+            self.update_connection_info()
+
+        enable_btn.clicked.connect(toggle_enable)
+        disconnect_btn.clicked.connect(disconnect_slider)
+        reconnect_btn.clicked.connect(reconnect_slider)
+
+        slider_layout.addWidget(label)
+        slider_layout.addWidget(slider)
+        slider_layout.addWidget(enable_btn)
+        slider_layout.addWidget(disconnect_btn)
+        slider_layout.addWidget(reconnect_btn)
+
+        # Add to UI
+        self.sliders_layout.addWidget(slider_widget)
+        self.dynamic_sliders.append((slider_widget, slider, enable_btn, disconnect_btn, reconnect_btn))
+
+        # Update display
+        self.update_connection_info()
+        self.remove_widget_btn.setEnabled(True)
+
+    def remove_dynamic_slider(self):
+        """Remove the last slider from the sync"""
+        if not self.dynamic_sliders:
+            return
+
+        # Remove last slider (unpack all elements)
+        slider_data = self.dynamic_sliders.pop()
+        slider_widget = slider_data[0]
+        slider = slider_data[1]
+
+        # Disconnect from sync if still connected
+        try:
+            self.dynamic_sync.disconnect(slider)
+        except ValueError:
+            pass  # Already disconnected
+
+        # Remove from UI
+        self.sliders_layout.removeWidget(slider_widget)
+        slider_widget.deleteLater()
+
+        # Update display
+        self.update_connection_info()
+        self.remove_widget_btn.setEnabled(len(self.dynamic_sliders) > 0)
+
+    def update_connection_info(self):
+        """Update the connection count and list display"""
+        count = self.dynamic_sync.connection_count
+        self.connection_count_label.setText(f"Connected widgets: {count}")
+
+        # Get list of widget types
+        widgets = self.dynamic_sync.connected_widgets
+        if widgets:
+            widget_list = ", ".join([f"{type(w).__name__}" for w in widgets])
+            self.connection_list_label.setText(f"List: {widget_list}")
+        else:
+            self.connection_list_label.setText("List: (none)")
+
+    def create_many_widget_types_example(self):
+        """Example 5: Many different widget types for same value"""
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel(
+            "Use case: Different representations of the same value\n"
+            "Shows WidgetSync works with ANY Qt widget type"
+        ))
+
+        # Create many different widgets for 0-100 value
+        self.multi_slider = QSlider(Qt.Horizontal)
+        self.multi_slider.setRange(0, 100)
+
+        self.multi_spin = QSpinBox()
+        self.multi_spin.setRange(0, 100)
+        self.multi_spin.setSuffix(" %")
+
+        self.multi_dial = QDial()
+        self.multi_dial.setRange(0, 100)
+
+        self.multi_progress = QProgressBar()
+        self.multi_progress.setRange(0, 100)
+
+        self.multi_lineedit = QLineEdit()
+        self.multi_lineedit.setPlaceholderText("Type 0-100")
+
+        self.multi_label = QLabel("Value: 50")
+
+        # Layout
+        row1 = QHBoxLayout()
+        row1.addWidget(QLabel("Slider:"))
+        row1.addWidget(self.multi_slider)
+        layout.addLayout(row1)
+
+        row2 = QHBoxLayout()
+        row2.addWidget(QLabel("SpinBox:"))
+        row2.addWidget(self.multi_spin)
+        row2.addWidget(QLabel("Dial:"))
+        row2.addWidget(self.multi_dial)
+        layout.addLayout(row2)
+
+        row3 = QHBoxLayout()
+        row3.addWidget(QLabel("Progress:"))
+        row3.addWidget(self.multi_progress)
+        layout.addLayout(row3)
+
+        row4 = QHBoxLayout()
+        row4.addWidget(QLabel("Text:"))
+        row4.addWidget(self.multi_lineedit)
+        row4.addWidget(self.multi_label)
+
+        layout.addLayout(row4)
+
+        # Create sync and connect all widgets
+        self.multi_sync = WidgetSync(initial_value=50)
+
+        # Slider
+        self.multi_sync.connect(
+            self.multi_slider,
+            signal=self.multi_slider.valueChanged,
+            getter=lambda: self.multi_slider.value(),
+            setter=lambda v: self.multi_slider.setValue(v)
+        )
+
+        # SpinBox
+        self.multi_sync.connect(
+            self.multi_spin,
+            signal=self.multi_spin.valueChanged,
+            getter=lambda: self.multi_spin.value(),
+            setter=lambda v: self.multi_spin.setValue(v)
+        )
+
+        # Dial
+        self.multi_sync.connect(
+            self.multi_dial,
+            signal=self.multi_dial.valueChanged,
+            getter=lambda: self.multi_dial.value(),
+            setter=lambda v: self.multi_dial.setValue(v)
+        )
+
+        # Progress (read-only)
+        self.multi_sync.connect(
+            self.multi_progress,
+            setter=lambda v: self.multi_progress.setValue(v),
+            mode=SyncMode.FROM_SYNC
+        )
+
+        # LineEdit with validation
+        self.multi_sync.connect(
+            self.multi_lineedit,
+            signal=self.multi_lineedit.textChanged,
+            getter=lambda: self.multi_lineedit.text(),
+            setter=lambda v: self.multi_lineedit.setText(str(v)),
+            to_sync_transform=lambda text: max(0, min(100, int(text))) if text.isdigit() else 0
+        )
+
+        # Label (read-only)
+        self.multi_sync.connect(
+            self.multi_label,
+            setter=lambda v: self.multi_label.setText(f"Value: {v}"),
+            mode=SyncMode.FROM_SYNC
+        )
+
+        widget.setLayout(layout)
+        return widget
+
+    def create_custom_widget_example(self):
+        """Example 6: Custom widget with multiple controls"""
+        widget = QWidget()
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel(
+            "Use case: Sync custom widgets with standard controls\n"
+            "Shows how to connect custom ColorWidget with ComboBox and RadioButtons"
+        ))
+
+        # Custom color widget
+        self.color_display = ColorWidget()
+
+        # ComboBox for color
+        self.color_combo = QComboBox()
+        self.color_combo.addItems(["red", "green", "blue", "yellow", "purple"])
+
+        # Radio buttons for color
+        self.color_radio_group = QButtonGroup()
+        radio_layout = QHBoxLayout()
+        for color in ["red", "green", "blue", "yellow", "purple"]:
+            radio = QRadioButton(color.capitalize())
+            self.color_radio_group.addButton(radio)
+            radio.setProperty("color", color)
+            radio_layout.addWidget(radio)
+
+        # Layout
+        layout.addWidget(QLabel("Custom Widget:"))
+        layout.addWidget(self.color_display)
+        layout.addWidget(QLabel("ComboBox:"))
+        layout.addWidget(self.color_combo)
+        layout.addWidget(QLabel("Radio Buttons:"))
+        layout.addLayout(radio_layout)
+
+        # Create sync
+        self.color_sync = WidgetSync(initial_value="red")
+
+        # Connect custom widget
+        self.color_sync.connect(
+            self.color_display,
+            signal=self.color_display.colorChanged,
+            getter=lambda: self.color_display.get_color(),
+            setter=lambda c: self.color_display.set_color(c)
+        )
+
+        # Connect ComboBox
+        self.color_sync.connect(
+            self.color_combo,
+            signal=self.color_combo.currentTextChanged,
+            getter=lambda: self.color_combo.currentText(),
+            setter=lambda c: self.color_combo.setCurrentText(c)
+        )
+
+        # Connect radio buttons
+        def get_selected_radio():
+            checked = self.color_radio_group.checkedButton()
+            return checked.property("color") if checked else "red"
+
+        def set_selected_radio(color):
+            for button in self.color_radio_group.buttons():
+                if button.property("color") == color:
+                    button.setChecked(True)
+                    break
+
+        def button_to_color(button):
+            """Transform QRadioButton signal arg to color string"""
+            from qtpy.QtWidgets import QRadioButton
+            if isinstance(button, QRadioButton):
+                return button.property("color")
+            return button
+
+        first_radio = self.color_radio_group.buttons()[0]
+        self.color_sync.connect(
+            first_radio,
+            signal=self.color_radio_group.buttonClicked,
+            getter=get_selected_radio,
+            setter=set_selected_radio,
+            to_sync_transform=button_to_color
+        )
+
+        widget.setLayout(layout)
+        return widget
+
+
+def main():
+    """Run the widget sync examples"""
+    app = QApplication.instance() or QApplication(sys.argv)
+
+    # Show demo window
+    demo = WidgetSyncDemo()
+    demo.resize(800, 400)
+    demo.show()
+
+    sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/__init__.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/__init__.py
@@ -1,8 +1,6 @@
 """
 Qt Widget Synchronization
-
-Simple, powerful widget property synchronization for Qt applications.
-
+=================================
 Basic Usage:
     >>> from pymodaq_gui.utils.widget_sync import WidgetSync, SyncMode
     >>>
@@ -56,5 +54,3 @@ __all__ = [
     'DataType',  # Export for type hints and explicit type specification
     'WidgetSyncFactories',  # Export for custom extensions
 ]
-
-__version__ = '0.1.0'

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/__init__.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/__init__.py
@@ -1,0 +1,59 @@
+"""
+Qt Widget Synchronization
+
+Simple, powerful widget property synchronization for Qt applications.
+
+Basic Usage:
+    >>> from pymodaq_gui.utils.widget_sync import WidgetSync, SyncMode
+    >>>
+    >>> # Create sync for checkboxes
+    >>> sync = WidgetSync.for_checkbox(checkbox1, initial=True)
+    >>> sync.add(checkbox2)
+    >>> sync.add(checkbox3)
+    >>>
+    >>> # Change value programmatically
+    >>> sync.value = False  # All checkboxes update
+
+Advanced Usage - Custom Factories:
+    >>> from pymodaq_gui.utils.widget_sync import WidgetSync, WidgetSyncFactories
+    >>>
+    >>> class MyFactories(WidgetSyncFactories):
+    ...     @classmethod
+    ...     def for_my_widget(cls, widget, initial=None):
+    ...         return cls.for_property(widget, 'myProp', 'mySignal', initial)
+    >>>
+    >>> class MySync(WidgetSync, MyFactories):
+    ...     pass
+    >>>
+    >>> sync = MySync.for_my_widget(my_widget)
+"""
+
+from .core import WidgetSync as WidgetSyncBase, SyncMode
+from .factories import WidgetSyncFactories
+
+# Combine base class with factory methods for convenience
+class WidgetSync(WidgetSyncBase, WidgetSyncFactories):
+    """
+    Widget synchronization with built-in factory methods.
+
+    This is the main class users should use. It combines:
+    - Base WidgetSync functionality (connect, disconnect, value management)
+    - Factory methods for common widgets (for_checkbox, for_spinbox, etc.)
+
+    For extending with custom factories:
+        >>> class MySync(WidgetSync, MyCustomFactories):
+        ...     pass
+
+    For base class without factories:
+        >>> from pymodaq_gui.utils.widget_sync.core import WidgetSync as BaseSync
+    """
+    pass
+
+
+__all__ = [
+    'WidgetSync',
+    'SyncMode',
+    'WidgetSyncFactories',  # Export for custom extensions
+]
+
+__version__ = '0.1.0'

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/__init__.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/__init__.py
@@ -28,7 +28,7 @@ Advanced Usage - Custom Factories:
     >>> sync = MySync.for_my_widget(my_widget)
 """
 
-from .core import WidgetSync as WidgetSyncBase, SyncMode
+from .core import WidgetSync as WidgetSyncBase, SyncMode, DataType
 from .factories import WidgetSyncFactories
 
 # Combine base class with factory methods for convenience
@@ -53,6 +53,7 @@ class WidgetSync(WidgetSyncBase, WidgetSyncFactories):
 __all__ = [
     'WidgetSync',
     'SyncMode',
+    'DataType',  # Export for type hints and explicit type specification
     'WidgetSyncFactories',  # Export for custom extensions
 ]
 

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
@@ -46,7 +46,6 @@ class WidgetSync(QObject):
 
     Philosophy: Simple by default, powerful when needed.
     - Core responsibility: Sync a single value across multiple widgets
-    - No validation, debouncing, or batch mode in core (see features.py for those)
     - Exception-safe widget updates
     - Automatic cleanup when widgets are deleted
 

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
@@ -374,6 +374,7 @@ class WidgetSync(QObject):
         connection_info = {
             'widget_id': widget_id,  # Store for easier lookup
             'widget_ref': widget_ref,
+            'widget_type': type(widget).__name__,  # Store widget type for pattern matching
             'signal': signal,
             'getter': getter,
             'setter': setter,
@@ -381,7 +382,10 @@ class WidgetSync(QObject):
             'to_sync_transform': to_sync_transform,
             'from_sync_transform': from_sync_transform,
             'callbacks': [],
-            'enabled': True  # Connection enabled by default
+            'enabled': True,  # Connection enabled by default
+            # Connection pattern info for add() method (set by factories)
+            'property_name': None,  # Will be set by for_property()
+            'signal_name': None,    # Will be set by for_property()
         }
 
         # Widget → Sync connection
@@ -513,13 +517,13 @@ class WidgetSync(QObject):
         self._connections.clear()
 
     def add(self, widget: QWidget, mode: SyncMode = SyncMode.BIDIRECTIONAL,
+            match: str = 'type',
             to_sync_transform: ValueTransform | None = None,
             from_sync_transform: ValueTransform | None = None) -> None:
         """
         Convenience method to add a widget using auto-detected property sync.
 
-        Must be called AFTER the sync was created with a factory method.
-        Uses the same property/signal as the first widget.
+        Automatically detects the property/signal pattern from existing connections.
 
         Parameters
         ----------
@@ -527,6 +531,11 @@ class WidgetSync(QObject):
             Widget to add
         mode : SyncMode, optional
             Sync mode (default: BIDIRECTIONAL)
+        match : str, optional
+            Pattern matching strategy (default: 'type'):
+
+            - 'type': Match exact widget type (QSlider → QSlider only, safest)
+            - 'property': Match by property/signal names (QSlider + QSpinBox both work)
         to_sync_transform : callable, optional
             Transform value from widget to sync
         from_sync_transform : callable, optional
@@ -534,41 +543,91 @@ class WidgetSync(QObject):
 
         Raises
         ------
-        NotImplementedError
-            If called before using a factory method
         TypeError
-            If widget doesn't have the required signal
-        """
-        # Check if this sync was created with a factory method
-        if not hasattr(self, '_property_name') or not hasattr(self, '_signal_name'):
-            raise NotImplementedError(
-                "Use add() only after creating sync with a factory method like for_property(). "
-                "For custom connections, use connect() directly."
-            )
+            If no connection pattern found, or if widget doesn't have the required signal
+        ValueError
+            If match parameter has invalid value
 
-        # Check if widget has the required signal
-        if not hasattr(widget, self._signal_name):
+        Examples
+        --------
+        >>> # Type matching (default) - only same widget types
+        >>> sync = WidgetSync.for_slider(slider1)
+        >>> sync.add(slider2)  # OK - both QSlider
+
+        >>> # Property matching - different widget types with same property
+        >>> sync = WidgetSync.for_slider(slider1)
+        >>> sync.add(spinbox, match='property')  # OK - both use 'value'/'valueChanged'
+        """
+        if match not in ('type', 'property'):
+            raise ValueError(f"match must be 'type' or 'property', got {match!r}")
+
+        widget_type = type(widget).__name__
+        property_name = None
+        signal_name = None
+
+        if match == 'type':
+            # Look for existing connection with exact matching widget type
+            for conn in self._connections.values():
+                if conn['widget_type'] == widget_type:
+                    # Found exact type match - use this pattern
+                    property_name = conn.get('property_name')
+                    signal_name = conn.get('signal_name')
+                    if property_name and signal_name:
+                        break
+        else:  # match == 'property'
+            # Look for any connection with property/signal info
+            for conn in self._connections.values():
+                property_name = conn.get('property_name')
+                signal_name = conn.get('signal_name')
+                if property_name and signal_name:
+                    # Found pattern - check if widget is compatible
+                    if hasattr(widget, signal_name):
+                        break
+                    else:
+                        # Reset and continue searching
+                        property_name = None
+                        signal_name = None
+
+        # If no pattern found, raise error
+        if property_name is None or signal_name is None:
+            match_hint = (
+                "try match='property' to allow different widget types"
+                if match == 'type' else ""
+            )
             raise TypeError(
-                f"Cannot use add() to connect {type(widget).__name__}: "
-                f"it doesn't have the '{self._signal_name}' signal.\n\n"
-                f"The sync was created with {self._first_widget_type} which uses "
-                f"'{self._signal_name}', but {type(widget).__name__} uses a different signal.\n\n"
-                f"💡 Solution: Use connect() instead of add() for different widget types:\n\n"
+                f"Cannot use add() for {widget_type}: no connection pattern found "
+                f"(match='{match}').\n\n"
+                f"💡 Solutions:\n"
+                f"{('  - ' + match_hint + chr(10)) if match_hint else ''}"
+                f"  - Use connect() directly:\n\n"
                 f"    sync.connect(\n"
                 f"        widget,\n"
                 f"        signal=widget.appropriate_signal,\n"
                 f"        getter=lambda: widget.get_value(),\n"
                 f"        setter=lambda v: widget.set_value(v),\n"
-                f"        mode=SyncMode.{mode.name},\n"
-                f"        to_sync_transform=...,  # optional\n"
-                f"        from_sync_transform=...  # optional\n"
+                f"        mode=SyncMode.{mode.name}\n"
+                f"    )"
+            )
+
+        # Check if widget has the required signal
+        if not hasattr(widget, signal_name):
+            raise TypeError(
+                f"Cannot use add() to connect {widget_type}: "
+                f"it doesn't have the '{signal_name}' signal.\n\n"
+                f"💡 Solution: Use connect() instead of add():\n\n"
+                f"    sync.connect(\n"
+                f"        widget,\n"
+                f"        signal=widget.appropriate_signal,\n"
+                f"        getter=lambda: widget.get_value(),\n"
+                f"        setter=lambda v: widget.set_value(v),\n"
+                f"        mode=SyncMode.{mode.name}\n"
                 f"    )"
             )
 
         # Get signal and create getter/setter using weak reference to avoid keeping widget alive
         from weakref import ref
-        signal = getattr(widget, self._signal_name)
-        prop_name = self._property_name  # Local variable to avoid closure issues
+        signal = getattr(widget, signal_name)
+        prop_name = property_name  # Local variable to avoid closure issues
         widget_ref = ref(widget)  # Weak reference to widget
 
         # Getter/setter use weak reference to avoid circular reference

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
@@ -1,0 +1,566 @@
+"""
+Core widget synchronization classes and enums.
+
+Implementation for syncing widget properties across multiple widgets.
+
+"""
+from __future__ import annotations
+
+from qtpy.QtCore import QObject, Signal
+from qtpy.QtWidgets import QWidget
+from enum import Enum
+from typing import Callable, Any, Iterator
+from contextlib import contextmanager
+from weakref import ref, ReferenceType
+
+ValueTransform = Callable[[Any], Any]
+WidgetGetter = Callable[[], Any]
+WidgetSetter = Callable[[Any], None]
+ConnectionInfo = dict[str, Any]  # Connection metadata dictionary
+
+
+class SyncMode(Enum):
+    """Synchronization modes for widget connections"""
+    BIDIRECTIONAL = "bidirectional"  # Widget ↔ Sync (default)
+    TO_SYNC = "to_sync"  # Widget → Sync only
+    FROM_SYNC = "from_sync"  # Sync → Widget only
+
+
+class WidgetSync(QObject):
+    """
+    Lightweight widget synchronization for keeping widget properties in sync.
+
+    Philosophy: Simple by default, powerful when needed.
+    - Core responsibility: Sync a single value across multiple widgets
+    - No validation, debouncing, or batch mode in core (see features.py for those)
+    - Exception-safe widget updates
+    - Automatic cleanup when widgets are deleted
+
+    Features:
+    - Bidirectional sync between widgets and internal state
+    - Value transformation per widget (widget <-> sync)
+    - Automatic widget lifecycle management
+    - Multiple sync modes (bidirectional, to_sync, from_sync)
+    - Clean disconnect by widget reference
+
+    Example:
+        # Create sync for a checkbox
+        sync = WidgetSync.for_checkbox(my_checkbox, initial=True)
+
+        # Add more checkboxes
+        sync.add(another_checkbox)
+        sync.add(third_checkbox, mode=SyncMode.FROM_SYNC)  # read-only
+
+        # Change value programmatically
+        sync.value = False  # All checkboxes update
+
+        # Remove a widget
+        sync.remove(another_checkbox)
+    """
+
+    value_changed = Signal(object)  # Emitted when value changes
+
+    def __init__(self, initial_value: Any = None) -> None:
+        """
+        Initialize widget sync with an initial value.
+
+        Parameters
+        ----------
+        initial_value : Any
+            Initial value for the sync
+        """
+        super().__init__()
+        self._value: Any = initial_value
+        # Dict mapping widget id() to connection info for O(1) lookup
+        # Key: id(widget), Value: ConnectionInfo dict
+        self._connections: dict[int, ConnectionInfo] = {}
+
+    @property
+    def value(self) -> Any:
+        """Get current synced value"""
+        return self._value
+
+    @value.setter
+    def value(self, new_value: Any) -> None:
+        """Set value and emit change signal"""
+        self.set_value(new_value, emit=True)
+
+    def set_value(self, new_value: Any, emit: bool = True) -> None:
+        """
+        Set value with optional emission control.
+
+        Parameters
+        ----------
+        new_value : Any
+            The new value to set
+        emit : bool, optional
+            Whether to emit value_changed signal (default: True)
+        """
+        if self._value != new_value:
+            self._value = new_value
+            if emit:
+                self.value_changed.emit(new_value)
+
+    @contextmanager
+    def _block_signals(self, widget: QWidget) -> Iterator[None]:
+        """
+        Context manager for exception-safe signal blocking.
+
+        Ensures signals are always unblocked even if setter raises.
+
+        Parameters
+        ----------
+        widget : QWidget
+            The widget whose signals to block
+
+        Yields
+        ------
+        None
+        """
+        was_blocked: bool = widget.signalsBlocked()
+        widget.blockSignals(True)
+        try:
+            yield
+        finally:
+            widget.blockSignals(was_blocked)
+
+    def connect(self,
+                widget: QWidget,
+                signal: Signal | None = None,
+                getter: WidgetGetter | None = None,
+                setter: WidgetSetter | None = None,
+                mode: SyncMode | None = None,
+                to_sync_transform: ValueTransform | None = None,
+                from_sync_transform: ValueTransform | None = None) -> None:
+        """
+        Connect a widget to this sync.
+
+        Parameters
+        ----------
+        widget : QWidget
+            The widget to connect
+        signal : Signal, optional
+            The signal to listen to (auto-required for TO_SYNC/BIDIRECTIONAL modes)
+        getter : callable, optional
+            Function to get value from widget: () -> value
+            Required for TO_SYNC and BIDIRECTIONAL modes
+        setter : callable, optional
+            Function to set value on widget: (value) -> None
+            Required for FROM_SYNC and BIDIRECTIONAL modes
+        mode : SyncMode, optional
+            Synchronization mode. If None, auto-inferred from parameters:
+            - Both getter and setter provided: BIDIRECTIONAL
+            - Only getter provided: TO_SYNC
+            - Only setter provided: FROM_SYNC
+        to_sync_transform : callable, optional
+            Transform value from widget to sync: (widget_value) -> sync_value
+        from_sync_transform : callable, optional
+            Transform value from sync to widget: (sync_value) -> widget_value
+
+        Raises
+        ------
+        ValueError
+            If neither getter nor setter provided, or if mode requirements not met
+        RuntimeError
+            If transforms raise exceptions
+
+        Examples
+        --------
+        # Auto-inferred modes (mode parameter omitted):
+        sync.connect(label, setter=lambda v: label.setText(str(v)))  # FROM_SYNC
+        sync.connect(button, button.clicked, getter=lambda: True)     # TO_SYNC
+        sync.connect(spinbox, spinbox.valueChanged,
+                     getter=lambda: spinbox.value(),
+                     setter=lambda v: spinbox.setValue(v))            # BIDIRECTIONAL
+
+        # Explicit mode override:
+        sync.connect(widget, signal, getter=getter, setter=setter,
+                     mode=SyncMode.FROM_SYNC)  # Override auto-inference
+        """
+        # Auto-infer mode if not specified
+        if mode is None:
+            if getter is not None and setter is not None:
+                mode = SyncMode.BIDIRECTIONAL
+            elif getter is not None:
+                mode = SyncMode.TO_SYNC
+            elif setter is not None:
+                mode = SyncMode.FROM_SYNC
+            else:
+                raise ValueError(
+                    "Must provide at least getter or setter parameter"
+                )
+
+        # Validate signal requirement
+        if mode in (SyncMode.BIDIRECTIONAL, SyncMode.TO_SYNC) and signal is None:
+            raise ValueError(f"signal parameter is required for {mode.value} mode")
+
+        # Validate getter/setter requirements
+        if mode in (SyncMode.BIDIRECTIONAL, SyncMode.TO_SYNC) and getter is None:
+            raise ValueError(f"getter parameter is required for {mode.value} mode")
+
+        if mode in (SyncMode.BIDIRECTIONAL, SyncMode.FROM_SYNC) and setter is None:
+            raise ValueError(f"setter parameter is required for {mode.value} mode")
+
+        # Store weak references to avoid circular references and memory leaks
+        widget_ref = ref(widget)
+        widget_id = id(widget)  # Store id for dict key
+        widget.destroyed.connect(lambda: self._on_widget_destroyed(widget_id))
+
+        connection_info = {
+            'widget_id': widget_id,  # Store for easier lookup
+            'widget_ref': widget_ref,
+            'signal': signal,
+            'getter': getter,
+            'setter': setter,
+            'mode': mode,
+            'to_sync_transform': to_sync_transform,
+            'from_sync_transform': from_sync_transform,
+            'callbacks': [],
+            'enabled': True  # Connection enabled by default
+        }
+
+        # Widget → Sync connection
+        if mode in (SyncMode.BIDIRECTIONAL, SyncMode.TO_SYNC):
+            def on_widget_change(*args):
+                """Handle widget value changes"""
+                widget_obj = widget_ref()
+                if widget_obj is None:
+                    return  # Widget was deleted
+
+                # Check if connection is enabled
+                conn = self._connections.get(widget_id)
+                if conn is None or not conn.get('enabled', True):
+                    return  # Connection disabled
+
+                try:
+                    value = args[0] if args else getter()
+                    if to_sync_transform:
+                        value = to_sync_transform(value)
+                    self.set_value(value, emit=True)
+                except Exception as e:
+                    # Log error instead of raising to avoid crashing Qt event loop
+                    import logging
+                    logging.getLogger(__name__).error(
+                        f"Error syncing from widget {type(widget).__name__}: {e}",
+                        exc_info=True
+                    )
+
+            signal.connect(on_widget_change)
+            connection_info['callbacks'].append(('widget', on_widget_change))
+
+        # Sync → Widget connection
+        if mode in (SyncMode.BIDIRECTIONAL, SyncMode.FROM_SYNC):
+            def on_sync_change(value):
+                """Handle sync value changes"""
+                widget_obj = widget_ref()
+                if widget_obj is None:
+                    return  # Widget was deleted
+
+                # Check if connection is enabled
+                conn = self._connections.get(widget_id)
+                if conn is None or not conn.get('enabled', True):
+                    return  # Connection disabled
+
+                try:
+                    if from_sync_transform:
+                        value = from_sync_transform(value)
+                    with self._block_signals(widget_obj):
+                        setter(value)
+                except Exception as e:
+                    # Log error instead of raising to avoid crashing Qt event loop
+                    import logging
+                    logging.getLogger(__name__).error(
+                        f"Error updating widget {type(widget).__name__}: {e}",
+                        exc_info=True
+                    )
+
+            self.value_changed.connect(on_sync_change)
+            # Store 2-tuple for sync callbacks to avoid circular reference
+            connection_info['callbacks'].append(('sync', on_sync_change))
+
+        # Initialize widget with current value
+        if mode in (SyncMode.BIDIRECTIONAL, SyncMode.FROM_SYNC) and self._value is not None:
+            try:
+                value = self._value
+                if from_sync_transform:
+                    value = from_sync_transform(value)
+                with self._block_signals(widget):
+                    setter(value)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Error initializing widget {type(widget).__name__}: {e}"
+                ) from e
+
+        self._connections[widget_id] = connection_info
+
+    def _disconnect_callbacks(self, callbacks: list) -> None:
+        """
+        Disconnect sync callbacks from value_changed signal.
+
+        Qt auto-cleans widget callbacks, so we only disconnect sync callbacks.
+
+        Parameters
+        ----------
+        callbacks : list
+            List of callback tuples (callback_type, callback)
+        """
+        for callback_type, callback in callbacks:
+            if callback_type == 'sync':
+                try:
+                    self.value_changed.disconnect(callback)
+                except (TypeError, RuntimeError):
+                    pass  # Already disconnected
+
+    def _on_widget_destroyed(self, widget_id: int) -> None:
+        """
+        Callback when a connected widget is destroyed.
+
+        Called by Qt's destroyed signal.
+
+        Parameters
+        ----------
+        widget_id : int
+            The id() of the destroyed widget
+        """
+        self.disconnect(widget_id)
+
+    def disconnect(self, widget: QWidget | int) -> None:
+        """
+        Disconnect a widget by reference or ID.
+
+        Parameters
+        ----------
+        widget : QWidget | int
+            The widget to disconnect, or its ID
+        """
+        # Handle both widget object and widget_id
+        widget_id = widget if isinstance(widget, int) else id(widget)
+
+        conn = self._connections.get(widget_id)
+        if conn is not None:
+            self._disconnect_callbacks(conn['callbacks'])
+            del self._connections[widget_id]
+
+    def disconnect_all(self) -> None:
+        """Disconnect all connected widgets."""
+        for conn in self._connections.values():
+            self._disconnect_callbacks(conn['callbacks'])
+        self._connections.clear()
+
+    def add(self, widget: QWidget, mode: SyncMode = SyncMode.BIDIRECTIONAL,
+            to_sync_transform: ValueTransform | None = None,
+            from_sync_transform: ValueTransform | None = None) -> None:
+        """
+        Convenience method to add a widget using auto-detected property sync.
+
+        Must be called AFTER the sync was created with a factory method.
+        Uses the same property/signal as the first widget.
+
+        Parameters
+        ----------
+        widget : QWidget
+            Widget to add
+        mode : SyncMode, optional
+            Sync mode (default: BIDIRECTIONAL)
+        to_sync_transform : callable, optional
+            Transform value from widget to sync
+        from_sync_transform : callable, optional
+            Transform value from sync to widget
+
+        Raises
+        ------
+        NotImplementedError
+            If called before using a factory method
+        TypeError
+            If widget doesn't have the required signal
+        """
+        # Check if this sync was created with a factory method
+        if not hasattr(self, '_property_name') or not hasattr(self, '_signal_name'):
+            raise NotImplementedError(
+                "Use add() only after creating sync with a factory method like for_property(). "
+                "For custom connections, use connect() directly."
+            )
+
+        # Check if widget has the required signal
+        if not hasattr(widget, self._signal_name):
+            raise TypeError(
+                f"Cannot use add() to connect {type(widget).__name__}: "
+                f"it doesn't have the '{self._signal_name}' signal.\n\n"
+                f"The sync was created with {self._first_widget_type} which uses "
+                f"'{self._signal_name}', but {type(widget).__name__} uses a different signal.\n\n"
+                f"💡 Solution: Use connect() instead of add() for different widget types:\n\n"
+                f"    sync.connect(\n"
+                f"        widget,\n"
+                f"        signal=widget.appropriate_signal,\n"
+                f"        getter=lambda: widget.get_value(),\n"
+                f"        setter=lambda v: widget.set_value(v),\n"
+                f"        mode=SyncMode.{mode.name},\n"
+                f"        to_sync_transform=...,  # optional\n"
+                f"        from_sync_transform=...  # optional\n"
+                f"    )"
+            )
+
+        # Get signal and create getter/setter using weak reference to avoid keeping widget alive
+        from weakref import ref
+        signal = getattr(widget, self._signal_name)
+        prop_name = self._property_name  # Local variable to avoid closure issues
+        widget_ref = ref(widget)  # Weak reference to widget
+
+        # Getter/setter use weak reference to avoid circular reference
+        def getter():
+            w = widget_ref()
+            return w.property(prop_name) if w is not None else None
+
+        def setter(value):
+            w = widget_ref()
+            if w is not None:
+                w.setProperty(prop_name, value)
+
+        # Connect the widget
+        self.connect(widget, signal, getter, setter, mode,
+                    to_sync_transform, from_sync_transform)
+
+    def remove(self, widget: QWidget) -> None:
+        """
+        Convenience method to remove a widget.
+
+        Alias for disconnect() for consistency with add().
+
+        Parameters
+        ----------
+        widget : QWidget
+            Widget to remove
+        """
+        self.disconnect(widget)
+
+    def enable(self, widget: QWidget | int) -> None:
+        """
+        Enable a widget's connection.
+
+        When enabled, the widget will sync bidirectionally with other widgets.
+
+        Parameters
+        ----------
+        widget : QWidget | int
+            The widget to enable, or its ID
+
+        Raises
+        ------
+        ValueError
+            If widget is not connected
+        """
+        widget_id = widget if isinstance(widget, int) else id(widget)
+        conn = self._connections.get(widget_id)
+        if conn is None:
+            raise ValueError(f"Widget is not connected to this sync")
+        conn['enabled'] = True
+
+    def disable(self, widget: QWidget | int) -> None:
+        """
+        Disable a widget's connection temporarily.
+
+        When disabled, the widget will not receive updates from the sync,
+        and its changes will not affect other widgets. The connection remains
+        in place and can be re-enabled later.
+
+        This is useful for:
+        - Temporarily pausing sync during complex operations
+        - Conditional syncing based on application state
+        - Testing/debugging
+
+        Parameters
+        ----------
+        widget : QWidget | int
+            The widget to disable, or its ID
+
+        Raises
+        ------
+        ValueError
+            If widget is not connected
+
+        Example
+        -------
+        >>> sync = WidgetSync.for_slider(slider1)
+        >>> sync.add(slider2)
+        >>> sync.disable(slider2)  # slider2 stops syncing
+        >>> slider1.setValue(75)   # slider2 doesn't update
+        >>> sync.enable(slider2)   # Re-enable slider2
+        >>> slider2.value()        # Still has old value until next update
+        """
+        widget_id = widget if isinstance(widget, int) else id(widget)
+        conn = self._connections.get(widget_id)
+        if conn is None:
+            raise ValueError(f"Widget is not connected to this sync")
+        conn['enabled'] = False
+
+    def is_enabled(self, widget: QWidget | int) -> bool:
+        """
+        Check if a widget's connection is enabled.
+
+        Parameters
+        ----------
+        widget : QWidget | int
+            The widget to check, or its ID
+
+        Returns
+        -------
+        bool
+            True if enabled, False if disabled
+
+        Raises
+        ------
+        ValueError
+            If widget is not connected
+        """
+        widget_id = widget if isinstance(widget, int) else id(widget)
+        conn = self._connections.get(widget_id)
+        if conn is None:
+            raise ValueError(f"Widget is not connected to this sync")
+        return conn.get('enabled', True)
+
+    @property
+    def connected_widgets(self) -> list[QWidget]:
+        """
+        Get list of currently connected widgets.
+
+        Returns only widgets that haven't been deleted.
+
+        Returns
+        -------
+        list[QWidget]
+            List of active widget references
+
+        Example
+        -------
+        >>> sync = WidgetSync.for_checkbox(cb1)
+        >>> sync.add(cb2)
+        >>> sync.add(cb3)
+        >>> len(sync.connected_widgets)  # Returns 3
+        3
+        """
+        widgets = []
+        for conn in self._connections.values():
+            widget = conn['widget_ref']()
+            if widget is not None:
+                widgets.append(widget)
+        return widgets
+    
+
+    @property
+    def connection_count(self) -> int:
+        """
+        Get count of active connections.
+
+        Returns
+        -------
+        int
+            Number of currently connected widgets
+
+        Example
+        -------
+        >>> sync = WidgetSync.for_spinbox(spin1)
+        >>> sync.add(spin2)
+        >>> sync.connection_count  # Returns 2
+        2
+        """
+        return len(self._connections)

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
@@ -252,16 +252,16 @@ class WidgetSync(QObject):
         finally:
             widget.blockSignals(was_blocked)
 
-    def connect(self,
-                widget: QWidget,
-                signal: Signal | None = None,
-                getter: WidgetGetter | None = None,
-                setter: WidgetSetter | None = None,
-                mode: SyncMode | None = None,
-                to_sync_transform: ValueTransform | None = None,
-                from_sync_transform: ValueTransform | None = None) -> None:
+    def bind(self,
+             widget: QWidget,
+             signal: Signal | None = None,
+             getter: WidgetGetter | None = None,
+             setter: WidgetSetter | None = None,
+             mode: SyncMode | None = None,
+             to_sync_transform: ValueTransform | None = None,
+             from_sync_transform: ValueTransform | None = None) -> None:
         """
-        Connect a widget to this sync.
+        Bind a widget to this sync.
 
         Parameters
         ----------
@@ -295,15 +295,15 @@ class WidgetSync(QObject):
         Examples
         --------
         # Auto-inferred modes (mode parameter omitted):
-        sync.connect(label, setter=lambda v: label.setText(str(v)))  # FROM_SYNC
-        sync.connect(button, button.clicked, getter=lambda: True)     # TO_SYNC
-        sync.connect(spinbox, spinbox.valueChanged,
-                     getter=lambda: spinbox.value(),
-                     setter=lambda v: spinbox.setValue(v))            # BIDIRECTIONAL
+        sync.bind(label, setter=lambda v: label.setText(str(v)))  # FROM_SYNC
+        sync.bind(button, button.clicked, getter=lambda: True)     # TO_SYNC
+        sync.bind(spinbox, spinbox.valueChanged,
+                  getter=lambda: spinbox.value(),
+                  setter=lambda v: spinbox.setValue(v))            # BIDIRECTIONAL
 
         # Explicit mode override:
-        sync.connect(widget, signal, getter=getter, setter=setter,
-                     mode=SyncMode.FROM_SYNC)  # Override auto-inference
+        sync.bind(widget, signal, getter=getter, setter=setter,
+                  mode=SyncMode.FROM_SYNC)  # Override auto-inference
         """
         # Auto-infer mode if not specified
         if mode is None:
@@ -490,16 +490,16 @@ class WidgetSync(QObject):
         widget_id : int
             The id() of the destroyed widget
         """
-        self.disconnect(widget_id)
+        self.unbind(widget_id)
 
-    def disconnect(self, widget: QWidget | int) -> None:
+    def unbind(self, widget: QWidget | int) -> None:
         """
-        Disconnect a widget by reference or ID.
+        Unbind a widget by reference or ID.
 
         Parameters
         ----------
         widget : QWidget | int
-            The widget to disconnect, or its ID
+            The widget to unbind, or its ID
         """
         # Handle both widget object and widget_id
         widget_id = widget if isinstance(widget, int) else id(widget)
@@ -509,8 +509,8 @@ class WidgetSync(QObject):
             self._disconnect_callbacks(conn['callbacks'])
             del self._connections[widget_id]
 
-    def disconnect_all(self) -> None:
-        """Disconnect all connected widgets."""
+    def unbind_all(self) -> None:
+        """Unbind all connected widgets."""
         for conn in self._connections.values():
             self._disconnect_callbacks(conn['callbacks'])
         self._connections.clear()
@@ -598,8 +598,8 @@ class WidgetSync(QObject):
                 f"(match='{match}').\n\n"
                 f"💡 Solutions:\n"
                 f"{('  - ' + match_hint + chr(10)) if match_hint else ''}"
-                f"  - Use connect() directly:\n\n"
-                f"    sync.connect(\n"
+                f"  - Use bind() directly:\n\n"
+                f"    sync.bind(\n"
                 f"        widget,\n"
                 f"        signal=widget.appropriate_signal,\n"
                 f"        getter=lambda: widget.get_value(),\n"
@@ -611,10 +611,10 @@ class WidgetSync(QObject):
         # Check if widget has the required signal
         if not hasattr(widget, signal_name):
             raise TypeError(
-                f"Cannot use add() to connect {widget_type}: "
+                f"Cannot use add() to bind {widget_type}: "
                 f"it doesn't have the '{signal_name}' signal.\n\n"
-                f"💡 Solution: Use connect() instead of add():\n\n"
-                f"    sync.connect(\n"
+                f"💡 Solution: Use bind() instead of add():\n\n"
+                f"    sync.bind(\n"
                 f"        widget,\n"
                 f"        signal=widget.appropriate_signal,\n"
                 f"        getter=lambda: widget.get_value(),\n"
@@ -639,22 +639,22 @@ class WidgetSync(QObject):
             if w is not None:
                 w.setProperty(prop_name, value)
 
-        # Connect the widget
-        self.connect(widget, signal, getter, setter, mode,
-                    to_sync_transform, from_sync_transform)
+        # Bind the widget
+        self.bind(widget, signal, getter, setter, mode,
+                  to_sync_transform, from_sync_transform)
 
     def remove(self, widget: QWidget) -> None:
         """
         Convenience method to remove a widget.
 
-        Alias for disconnect() for consistency with add().
+        Alias for unbind() for consistency with add().
 
         Parameters
         ----------
         widget : QWidget
             Widget to remove
         """
-        self.disconnect(widget)
+        self.unbind(widget)
 
     def enable(self, widget: QWidget | int) -> None:
         """

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
@@ -204,7 +204,17 @@ class WidgetSync(QObject):
         # Store weak references to avoid circular references and memory leaks
         widget_ref = ref(widget)
         widget_id = id(widget)  # Store id for dict key
-        widget.destroyed.connect(lambda: self._on_widget_destroyed(widget_id))
+
+        # Use weak reference to self to avoid accessing invalid self during cleanup
+        sync_weak = ref(self)
+
+        def on_destroyed():
+            """Cleanup callback when widget is destroyed"""
+            sync = sync_weak()
+            if sync is not None:
+                sync._on_widget_destroyed(widget_id)
+
+        widget.destroyed.connect(on_destroyed)
 
         connection_info = {
             'widget_id': widget_id,  # Store for easier lookup

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
@@ -324,7 +324,7 @@ class WidgetSync(QObject):
             raise ValueError(f"signal parameter is required for {mode.value} mode")
 
         # Validate getter/setter requirements
-        if mode in (SyncMode.BIDIRECTIONAL, SyncMode.TO_SYNC) 
+        if mode in (SyncMode.BIDIRECTIONAL, SyncMode.TO_SYNC): 
             if getter is None:
                 raise ValueError(f"getter parameter is required for {mode.value} mode")
             else:  # Type checking: validate getter returns correct type (after transform)

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from qtpy.QtCore import QObject, Signal
 from qtpy.QtWidgets import QWidget
 from enum import Enum
-from typing import Callable, Any, Iterator
+from typing import Callable, Any, Iterator, Type
 from contextlib import contextmanager
 from weakref import ref, ReferenceType
 
@@ -24,6 +24,20 @@ class SyncMode(Enum):
     BIDIRECTIONAL = "bidirectional"  # Widget ↔ Sync (default)
     TO_SYNC = "to_sync"  # Widget → Sync only
     FROM_SYNC = "from_sync"  # Sync → Widget only
+
+
+class DataType(Enum):
+    """
+    Supported data types for widget synchronization.
+
+    Each sync instance is associated with a specific data type, ensuring
+    type safety when connecting widgets and transforming values.
+    """
+    BOOL = bool
+    INT = int
+    FLOAT = float
+    STR = str
+    OBJECT = object  # For custom types or when type checking is disabled
 
 
 class WidgetSync(QObject):
@@ -60,20 +74,127 @@ class WidgetSync(QObject):
 
     value_changed = Signal(object)  # Emitted when value changes
 
-    def __init__(self, initial_value: Any = None) -> None:
+    def __init__(self, initial_value: Any = None, data_type: Type | DataType | None = None) -> None:
         """
-        Initialize widget sync with an initial value.
+        Initialize widget sync with an initial value and optional type checking.
 
         Parameters
         ----------
         initial_value : Any
             Initial value for the sync
+        data_type : Type | DataType, optional
+            Expected data type for values. If None, inferred from initial_value.
+            Use DataType.OBJECT to disable type checking.
+
+        Examples
+        --------
+        >>> # Type inferred from initial value
+        >>> sync = WidgetSync(initial_value=True)  # data_type = bool
+
+        >>> # Explicit type
+        >>> sync = WidgetSync(initial_value=0, data_type=int)
+
+        >>> # Disable type checking
+        >>> sync = WidgetSync(initial_value=None, data_type=DataType.OBJECT)
         """
         super().__init__()
-        self._value: Any = initial_value
+        self._data_type = self._resolve_type(initial_value, data_type)
+        self._value: Any = self._validate_value(initial_value)
         # Dict mapping widget id() to connection info for O(1) lookup
         # Key: id(widget), Value: ConnectionInfo dict
         self._connections: dict[int, ConnectionInfo] = {}
+
+    def _resolve_type(self, initial_value: Any, data_type: Type | DataType | None) -> Type:
+        """
+        Resolve the data type for this sync.
+
+        Parameters
+        ----------
+        initial_value : Any
+            Initial value
+        data_type : Type | DataType, optional
+            Explicit type or None to infer
+
+        Returns
+        -------
+        Type
+            Resolved Python type
+        """
+        if data_type is not None:
+            # Use explicit type
+            if isinstance(data_type, DataType):
+                return data_type.value
+            return data_type
+
+        # Infer from initial value
+        if initial_value is None:
+            return object  # No type checking if no initial value
+        return type(initial_value)
+
+    def _validate_value(self, value: Any) -> Any:
+        """
+        Validate value matches expected type.
+
+        Parameters
+        ----------
+        value : Any
+            Value to validate
+
+        Returns
+        -------
+        Any
+            The value if valid
+
+        Raises
+        ------
+        TypeError
+            If value doesn't match expected type
+        """
+        if value is None or self._data_type is object:
+            return value
+
+        if not isinstance(value, self._data_type):
+            raise TypeError(
+                f"Value has type {type(value).__name__}, "
+                f"but sync expects {self._data_type.__name__}"
+            )
+        return value
+
+    def _is_compatible_type(self, value: Any) -> bool:
+        """
+        Check if value is compatible with sync's data type.
+
+        Parameters
+        ----------
+        value : Any
+            Value to check
+
+        Returns
+        -------
+        bool
+            True if compatible
+        """
+        if value is None or self._data_type is object:
+            return True
+        return isinstance(value, self._data_type)
+
+    def _data_type_name(self) -> str:
+        """Get human-readable name of data type"""
+        if hasattr(self._data_type, '__name__'):
+            return self._data_type.__name__
+        return str(self._data_type)
+
+    @property
+    def data_type(self) -> Type:
+        """
+        Get the data type for this sync.
+
+        Returns
+        -------
+        Type
+            Python type (bool, int, float, str, object)
+        """
+        return self._data_type
 
     @property
     def value(self) -> Any:
@@ -95,7 +216,15 @@ class WidgetSync(QObject):
             The new value to set
         emit : bool, optional
             Whether to emit value_changed signal (default: True)
+
+        Raises
+        ------
+        TypeError
+            If new_value doesn't match expected data type
         """
+        # Validate type
+        new_value = self._validate_value(new_value)
+
         if self._value != new_value:
             self._value = new_value
             if emit:
@@ -195,11 +324,37 @@ class WidgetSync(QObject):
             raise ValueError(f"signal parameter is required for {mode.value} mode")
 
         # Validate getter/setter requirements
-        if mode in (SyncMode.BIDIRECTIONAL, SyncMode.TO_SYNC) and getter is None:
-            raise ValueError(f"getter parameter is required for {mode.value} mode")
+        if mode in (SyncMode.BIDIRECTIONAL, SyncMode.TO_SYNC) 
+            if getter is None:
+                raise ValueError(f"getter parameter is required for {mode.value} mode")
+            else:  # Type checking: validate getter returns correct type (after transform)
+                try:
+                    test_value = getter()
+                    # Apply to_sync transform if provided
+                    if to_sync_transform:
+                        test_value = to_sync_transform(test_value)
+                    # Check type compatibility
+                    if not self._is_compatible_type(test_value):
+                        raise TypeError(
+                            f"Getter returns {type(test_value).__name__}, "
+                            f"but sync expects {self._data_type_name()}. "
+                            f"Widget: {type(widget).__name__}"
+                        )
+                except TypeError:
+                    raise  # Re-raise type errors
+                except Exception as e:
+                    # Log other errors but don't fail - the getter might need the widget to be in a specific state
+                    import logging
+                    logging.getLogger(__name__).warning(
+                        f"Could not validate getter for {type(widget).__name__}: {e}"
+                    )
 
-        if mode in (SyncMode.BIDIRECTIONAL, SyncMode.FROM_SYNC) and setter is None:
-            raise ValueError(f"setter parameter is required for {mode.value} mode")
+        if mode in (SyncMode.BIDIRECTIONAL, SyncMode.FROM_SYNC):
+            if setter is None:
+                raise ValueError(f"setter parameter is required for {mode.value} mode")
+            else:  # Type checking: validate setter returns correct type (after transform)
+                # TODO: Implement setter type checking if needed
+                pass
 
         # Store weak references to avoid circular references and memory leaks
         widget_ref = ref(widget)

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/factories.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/factories.py
@@ -293,3 +293,196 @@ class WidgetSyncFactories:
         if mode is None:
             mode = SyncMode.BIDIRECTIONAL
         return cls.for_property(lineedit, 'text', 'textChanged', initial, mode)
+
+    # ========== Type-Based Factories ==========
+    #
+    # These factories are organized by data type rather than widget type,
+    # making it clearer what kind of value is being synchronized.
+    # They work with any widget that has the appropriate property and signal.
+
+    @classmethod
+    def for_bool(cls, widget: QWidget,
+                 property_name: str = 'checked',
+                 signal_name: str = 'toggled',
+                 initial: bool = False,
+                 mode = None) -> WidgetSync:
+        """
+        Create a sync for boolean values.
+
+        Works with any widget that has a boolean property (QCheckBox, QRadioButton,
+        QAction with setCheckable(True), QPushButton with setCheckable(True), etc.)
+
+        Parameters
+        ----------
+        widget : QWidget
+            Widget with a boolean property
+        property_name : str, optional
+            Property name (default: 'checked')
+        signal_name : str, optional
+            Signal name (default: 'toggled')
+        initial : bool, optional
+            Initial value (default: False)
+        mode : SyncMode, optional
+            Sync mode (default: BIDIRECTIONAL)
+
+        Returns
+        -------
+        WidgetSync
+            Sync instance with explicit bool type
+
+        Example
+        -------
+        >>> # Sync different widget types with same boolean value
+        >>> sync = WidgetSync.for_bool(checkbox, initial=True)
+        >>> sync.connect(action, signal=action.toggled,
+        ...              getter=lambda: action.isChecked(),
+        ...              setter=lambda v: action.setChecked(v))
+        """
+        from .core import SyncMode
+        if mode is None:
+            mode = SyncMode.BIDIRECTIONAL
+        # Create sync with explicit bool type
+        sync = cls(initial_value=initial, data_type=bool)
+        # Use for_property to connect the widget
+        temp_sync = cls.for_property(widget, property_name, signal_name, initial, mode)
+        # Copy connection info
+        sync._connections = temp_sync._connections
+        sync._property_name = property_name
+        sync._signal_name = signal_name
+        sync._first_widget_type = type(widget).__name__
+        return sync
+
+    @classmethod
+    def for_int(cls, widget: QWidget,
+                property_name: str = 'value',
+                signal_name: str = 'valueChanged',
+                initial: int = 0,
+                mode = None) -> WidgetSync:
+        """
+        Create a sync for integer values.
+
+        Works with QSpinBox, QSlider, QDial, or any widget with an integer property.
+
+        Parameters
+        ----------
+        widget : QWidget
+            Widget with an integer property
+        property_name : str, optional
+            Property name (default: 'value')
+        signal_name : str, optional
+            Signal name (default: 'valueChanged')
+        initial : int, optional
+            Initial value (default: 0)
+        mode : SyncMode, optional
+            Sync mode (default: BIDIRECTIONAL)
+
+        Returns
+        -------
+        WidgetSync
+            Sync instance with explicit int type
+
+        Example
+        -------
+        >>> sync = WidgetSync.for_int(spinbox, initial=50)
+        >>> sync.add(slider)  # Both use integer values
+        """
+        from .core import SyncMode
+        if mode is None:
+            mode = SyncMode.BIDIRECTIONAL
+        sync = cls(initial_value=initial, data_type=int)
+        temp_sync = cls.for_property(widget, property_name, signal_name, initial, mode)
+        sync._connections = temp_sync._connections
+        sync._property_name = property_name
+        sync._signal_name = signal_name
+        sync._first_widget_type = type(widget).__name__
+        return sync
+
+    @classmethod
+    def for_float(cls, widget: QWidget,
+                  property_name: str = 'value',
+                  signal_name: str = 'valueChanged',
+                  initial: float = 0.0,
+                  mode = None) -> WidgetSync:
+        """
+        Create a sync for float values.
+
+        Works with QDoubleSpinBox or any widget with a float property.
+
+        Parameters
+        ----------
+        widget : QWidget
+            Widget with a float property
+        property_name : str, optional
+            Property name (default: 'value')
+        signal_name : str, optional
+            Signal name (default: 'valueChanged')
+        initial : float, optional
+            Initial value (default: 0.0)
+        mode : SyncMode, optional
+            Sync mode (default: BIDIRECTIONAL)
+
+        Returns
+        -------
+        WidgetSync
+            Sync instance with explicit float type
+
+        Example
+        -------
+        >>> sync = WidgetSync.for_float(double_spin, initial=3.14)
+        """
+        from .core import SyncMode
+        if mode is None:
+            mode = SyncMode.BIDIRECTIONAL
+        sync = cls(initial_value=initial, data_type=float)
+        temp_sync = cls.for_property(widget, property_name, signal_name, initial, mode)
+        sync._connections = temp_sync._connections
+        sync._property_name = property_name
+        sync._signal_name = signal_name
+        sync._first_widget_type = type(widget).__name__
+        return sync
+
+    @classmethod
+    def for_str(cls, widget: QWidget,
+                property_name: str = 'text',
+                signal_name: str = 'textChanged',
+                initial: str = "",
+                mode = None) -> WidgetSync:
+        """
+        Create a sync for string values.
+
+        Works with QLineEdit, QLabel, QTextEdit, or any widget with a text property.
+
+        Parameters
+        ----------
+        widget : QWidget
+            Widget with a string property
+        property_name : str, optional
+            Property name (default: 'text')
+        signal_name : str, optional
+            Signal name (default: 'textChanged')
+        initial : str, optional
+            Initial value (default: "")
+        mode : SyncMode, optional
+            Sync mode (default: BIDIRECTIONAL)
+
+        Returns
+        -------
+        WidgetSync
+            Sync instance with explicit str type
+
+        Example
+        -------
+        >>> sync = WidgetSync.for_str(line_edit, initial="Hello")
+        >>> sync.connect(label, setter=lambda v: label.setText(v),
+        ...              mode=SyncMode.FROM_SYNC)
+        """
+        from .core import SyncMode
+        if mode is None:
+            mode = SyncMode.BIDIRECTIONAL
+        sync = cls(initial_value=initial, data_type=str)
+        temp_sync = cls.for_property(widget, property_name, signal_name, initial, mode)
+        sync._connections = temp_sync._connections
+        sync._property_name = property_name
+        sync._signal_name = signal_name
+        sync._first_widget_type = type(widget).__name__
+        return sync

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/factories.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/factories.py
@@ -1,0 +1,295 @@
+"""
+Factory methods for common widget types.
+
+This module can be extended by users to add their own factory methods.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from weakref import ref
+
+if TYPE_CHECKING:
+    from qtpy.QtWidgets import QWidget
+    from .core import WidgetSync, SyncMode
+
+
+class WidgetSyncFactories:
+    """
+    Mixin class providing factory methods for common Qt widgets.
+
+    Users can create their own factory methods by:
+    1. Inheriting from WidgetSync
+    2. Adding their own @classmethod factories
+
+    Example:
+        class MyWidgetSync(WidgetSync):
+            @classmethod
+            def for_my_custom_widget(cls, widget, initial=None):
+                return cls.for_property(widget, 'customProperty', 'customSignal', initial)
+    """
+
+    @classmethod
+    def for_property(cls,
+                     widget: QWidget,
+                     property_name: str,
+                     signal_name: str | None = None,
+                     initial: any = None,
+                     mode: SyncMode | None = None) -> WidgetSync:
+        """
+        Create a sync for any Qt property with auto-detection.
+
+        This is the most flexible factory - all others build on this.
+
+        Parameters
+        ----------
+        widget : QWidget
+            The first widget to sync
+        property_name : str
+            Name of the Qt property (e.g., 'checked', 'value', 'text')
+        signal_name : str, optional
+            Name of the change signal. If None, auto-detects from property
+        initial : Any, optional
+            Initial value (if None, uses widget's current value)
+        mode : SyncMode, optional
+            Sync mode (default: BIDIRECTIONAL)
+
+        Returns
+        -------
+        WidgetSync
+            A new sync instance with the widget connected
+
+        Example
+        -------
+        >>> sync = WidgetSync.for_property(my_spinbox, 'value', initial=50)
+        >>> sync.add(other_spinbox)  # Add more spinboxes
+        """
+        # Import here to avoid circular dependency
+        from .core import WidgetSync, SyncMode as SM
+
+        if mode is None:
+            mode = SM.BIDIRECTIONAL
+
+        # Get property metadata for auto-detection
+        meta = widget.metaObject()
+        prop_index = meta.indexOfProperty(property_name)
+
+        if prop_index == -1:
+            raise ValueError(
+                f"Property '{property_name}' not found on {type(widget).__name__}"
+            )
+
+        prop = meta.property(prop_index)
+
+        # Auto-detect signal if not provided
+        if signal_name is None:
+            notify_signal = prop.notifySignal()
+            if notify_signal.isValid():
+                signal_name = notify_signal.name().data().decode()
+            else:
+                raise ValueError(
+                    f"Property '{property_name}' has no notify signal. "
+                    f"Please provide signal_name explicitly."
+                )
+
+        # Get signal object
+        try:
+            signal = getattr(widget, signal_name)
+        except AttributeError:
+            raise ValueError(
+                f"Signal '{signal_name}' not found on {type(widget).__name__}"
+            )
+
+        # Store property name in local variable to avoid capturing self in lambda
+        prop_name = property_name
+
+        # Create weak reference to widget to avoid circular references
+        widget_ref = ref(widget)
+
+        # Create getter/setter using weak reference
+        def getter():
+            w = widget_ref()
+            return w.property(prop_name) if w is not None else None
+
+        def setter(value):
+            w = widget_ref()
+            if w is not None:
+                w.setProperty(prop_name, value)
+
+        # Determine initial value
+        if initial is None:
+            initial = widget.property(prop_name)  # Use widget directly before connecting
+
+        # Create sync and connect
+        sync = cls(initial_value=initial)
+        sync.connect(widget, signal, getter, setter, mode)
+
+        # Store metadata for add() method - the base add() will use these
+        sync._property_name = property_name
+        sync._signal_name = signal_name
+        sync._first_widget_type = type(widget).__name__
+
+        return sync
+
+    @classmethod
+    def for_checkbox(cls, checkbox, initial: bool = False,
+                     mode = None) -> WidgetSync:
+        """
+        Create a sync for checkbox widgets.
+
+        Parameters
+        ----------
+        checkbox : QCheckBox
+            The first checkbox to sync
+        initial : bool, optional
+            Initial checked state (default: False)
+        mode : SyncMode, optional
+            Sync mode (default: BIDIRECTIONAL)
+
+        Returns
+        -------
+        WidgetSync
+            A new sync instance
+
+        Example
+        -------
+        >>> sync = WidgetSync.for_checkbox(my_checkbox, initial=True)
+        >>> sync.add(another_checkbox)
+        """
+        from .core import SyncMode
+        if mode is None:
+            mode = SyncMode.BIDIRECTIONAL
+        return cls.for_property(checkbox, 'checked', 'toggled', initial, mode)
+
+    @classmethod
+    def for_spinbox(cls, spinbox, initial: int | float = 0,
+                    mode = None) -> WidgetSync:
+        """
+        Create a sync for QSpinBox or QDoubleSpinBox widgets.
+
+        Parameters
+        ----------
+        spinbox : QSpinBox | QDoubleSpinBox
+            The first spinbox to sync
+        initial : int or float, optional
+            Initial value (default: 0)
+        mode : SyncMode, optional
+            Sync mode (default: BIDIRECTIONAL)
+
+        Returns
+        -------
+        WidgetSync
+            A new sync instance
+
+        Example
+        -------
+        >>> sync = WidgetSync.for_spinbox(spinbox1, initial=50)
+        >>> sync.add(spinbox2)
+        >>> sync.add(spinbox3)
+        """
+        from .core import SyncMode
+        if mode is None:
+            mode = SyncMode.BIDIRECTIONAL
+        return cls.for_property(spinbox, 'value', 'valueChanged', initial, mode)
+
+    @classmethod
+    def for_slider(cls, slider, initial: int = 0,
+                   mode = None) -> WidgetSync:
+        """
+        Create a sync for QSlider widgets.
+
+        Parameters
+        ----------
+        slider : QSlider
+            The first slider to sync
+        initial : int, optional
+            Initial value (default: 0)
+        mode : SyncMode, optional
+            Sync mode (default: BIDIRECTIONAL)
+
+        Returns
+        -------
+        WidgetSync
+            A new sync instance
+
+        Example
+        -------
+        >>> sync = WidgetSync.for_slider(slider1, initial=75)
+        >>> sync.add(slider2)
+        """
+        from .core import SyncMode
+        if mode is None:
+            mode = SyncMode.BIDIRECTIONAL
+        return cls.for_property(slider, 'value', 'valueChanged', initial, mode)
+
+    @classmethod
+    def for_combobox(cls, combobox, initial: int | str = 0,
+                     use_text: bool = False,
+                     mode = None) -> WidgetSync:
+        """
+        Create a sync for QComboBox widgets.
+
+        Parameters
+        ----------
+        combobox : QComboBox
+            The first combobox to sync
+        initial : int or str, optional
+            Initial value - index if use_text=False, text if use_text=True (default: 0)
+        use_text : bool, optional
+            If True, sync currentText; if False, sync currentIndex (default: False)
+        mode : SyncMode, optional
+            Sync mode (default: BIDIRECTIONAL)
+
+        Returns
+        -------
+        WidgetSync
+            A new sync instance
+
+        Examples
+        --------
+        >>> # Sync by index (default)
+        >>> sync = WidgetSync.for_combobox(combo1, initial=0)
+        >>> sync.add(combo2)
+
+        >>> # Sync by text
+        >>> sync = WidgetSync.for_combobox(combo1, initial="Option A", use_text=True)
+        >>> sync.add(combo2)
+        """
+        from .core import SyncMode
+        if mode is None:
+            mode = SyncMode.BIDIRECTIONAL
+        if use_text:
+            return cls.for_property(combobox, 'currentText', 'currentTextChanged',
+                                   initial, mode)
+        else:
+            return cls.for_property(combobox, 'currentIndex', 'currentIndexChanged',
+                                   initial, mode)
+
+    @classmethod
+    def for_lineedit(cls, lineedit, initial: str = "",
+                     mode = None) -> WidgetSync:
+        """
+        Create a sync for QLineEdit widgets.
+
+        Parameters
+        ----------
+        lineedit : QLineEdit
+            The first line edit to sync
+        initial : str, optional
+            Initial text (default: "")
+        mode : SyncMode, optional
+            Sync mode (default: BIDIRECTIONAL)
+
+        Returns
+        -------
+        WidgetSync
+            A new sync instance
+
+        Example
+        -------
+        >>> sync = WidgetSync.for_lineedit(edit1, initial="Hello")
+        >>> sync.add(edit2)
+        """
+        from .core import SyncMode
+        if mode is None:
+            mode = SyncMode.BIDIRECTIONAL
+        return cls.for_property(lineedit, 'text', 'textChanged', initial, mode)

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/factories.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/factories.py
@@ -5,7 +5,7 @@ This module can be extended by users to add their own factory methods.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from weakref import ref
 
 if TYPE_CHECKING:
@@ -33,7 +33,7 @@ class WidgetSyncFactories:
                      widget: QWidget,
                      property_name: str,
                      signal_name: str | None = None,
-                     initial: any = None,
+                     initial: Any = None,
                      mode: SyncMode | None = None,
                      data_type: type | None = None) -> WidgetSync:
         """

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/factories.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/factories.py
@@ -34,7 +34,8 @@ class WidgetSyncFactories:
                      property_name: str,
                      signal_name: str | None = None,
                      initial: any = None,
-                     mode: SyncMode | None = None) -> WidgetSync:
+                     mode: SyncMode | None = None,
+                     data_type: type | None = None) -> WidgetSync:
         """
         Create a sync for any Qt property with auto-detection.
 
@@ -52,6 +53,8 @@ class WidgetSyncFactories:
             Initial value (if None, uses widget's current value)
         mode : SyncMode, optional
             Sync mode (default: BIDIRECTIONAL)
+        data_type : type, optional
+            Explicit data type for type checking (default: inferred from initial)
 
         Returns
         -------
@@ -120,13 +123,14 @@ class WidgetSyncFactories:
             initial = widget.property(prop_name)  # Use widget directly before connecting
 
         # Create sync and connect
-        sync = cls(initial_value=initial)
+        sync = cls(initial_value=initial, data_type=data_type)
         sync.connect(widget, signal, getter, setter, mode)
 
-        # Store metadata for add() method - the base add() will use these
-        sync._property_name = property_name
-        sync._signal_name = signal_name
-        sync._first_widget_type = type(widget).__name__
+        # Store pattern info in the connection for add() method to use
+        widget_id = id(widget)
+        if widget_id in sync._connections:
+            sync._connections[widget_id]['property_name'] = property_name
+            sync._connections[widget_id]['signal_name'] = signal_name
 
         return sync
 
@@ -293,196 +297,3 @@ class WidgetSyncFactories:
         if mode is None:
             mode = SyncMode.BIDIRECTIONAL
         return cls.for_property(lineedit, 'text', 'textChanged', initial, mode)
-
-    # ========== Type-Based Factories ==========
-    #
-    # These factories are organized by data type rather than widget type,
-    # making it clearer what kind of value is being synchronized.
-    # They work with any widget that has the appropriate property and signal.
-
-    @classmethod
-    def for_bool(cls, widget: QWidget,
-                 property_name: str = 'checked',
-                 signal_name: str = 'toggled',
-                 initial: bool = False,
-                 mode = None) -> WidgetSync:
-        """
-        Create a sync for boolean values.
-
-        Works with any widget that has a boolean property (QCheckBox, QRadioButton,
-        QAction with setCheckable(True), QPushButton with setCheckable(True), etc.)
-
-        Parameters
-        ----------
-        widget : QWidget
-            Widget with a boolean property
-        property_name : str, optional
-            Property name (default: 'checked')
-        signal_name : str, optional
-            Signal name (default: 'toggled')
-        initial : bool, optional
-            Initial value (default: False)
-        mode : SyncMode, optional
-            Sync mode (default: BIDIRECTIONAL)
-
-        Returns
-        -------
-        WidgetSync
-            Sync instance with explicit bool type
-
-        Example
-        -------
-        >>> # Sync different widget types with same boolean value
-        >>> sync = WidgetSync.for_bool(checkbox, initial=True)
-        >>> sync.connect(action, signal=action.toggled,
-        ...              getter=lambda: action.isChecked(),
-        ...              setter=lambda v: action.setChecked(v))
-        """
-        from .core import SyncMode
-        if mode is None:
-            mode = SyncMode.BIDIRECTIONAL
-        # Create sync with explicit bool type
-        sync = cls(initial_value=initial, data_type=bool)
-        # Use for_property to connect the widget
-        temp_sync = cls.for_property(widget, property_name, signal_name, initial, mode)
-        # Copy connection info
-        sync._connections = temp_sync._connections
-        sync._property_name = property_name
-        sync._signal_name = signal_name
-        sync._first_widget_type = type(widget).__name__
-        return sync
-
-    @classmethod
-    def for_int(cls, widget: QWidget,
-                property_name: str = 'value',
-                signal_name: str = 'valueChanged',
-                initial: int = 0,
-                mode = None) -> WidgetSync:
-        """
-        Create a sync for integer values.
-
-        Works with QSpinBox, QSlider, QDial, or any widget with an integer property.
-
-        Parameters
-        ----------
-        widget : QWidget
-            Widget with an integer property
-        property_name : str, optional
-            Property name (default: 'value')
-        signal_name : str, optional
-            Signal name (default: 'valueChanged')
-        initial : int, optional
-            Initial value (default: 0)
-        mode : SyncMode, optional
-            Sync mode (default: BIDIRECTIONAL)
-
-        Returns
-        -------
-        WidgetSync
-            Sync instance with explicit int type
-
-        Example
-        -------
-        >>> sync = WidgetSync.for_int(spinbox, initial=50)
-        >>> sync.add(slider)  # Both use integer values
-        """
-        from .core import SyncMode
-        if mode is None:
-            mode = SyncMode.BIDIRECTIONAL
-        sync = cls(initial_value=initial, data_type=int)
-        temp_sync = cls.for_property(widget, property_name, signal_name, initial, mode)
-        sync._connections = temp_sync._connections
-        sync._property_name = property_name
-        sync._signal_name = signal_name
-        sync._first_widget_type = type(widget).__name__
-        return sync
-
-    @classmethod
-    def for_float(cls, widget: QWidget,
-                  property_name: str = 'value',
-                  signal_name: str = 'valueChanged',
-                  initial: float = 0.0,
-                  mode = None) -> WidgetSync:
-        """
-        Create a sync for float values.
-
-        Works with QDoubleSpinBox or any widget with a float property.
-
-        Parameters
-        ----------
-        widget : QWidget
-            Widget with a float property
-        property_name : str, optional
-            Property name (default: 'value')
-        signal_name : str, optional
-            Signal name (default: 'valueChanged')
-        initial : float, optional
-            Initial value (default: 0.0)
-        mode : SyncMode, optional
-            Sync mode (default: BIDIRECTIONAL)
-
-        Returns
-        -------
-        WidgetSync
-            Sync instance with explicit float type
-
-        Example
-        -------
-        >>> sync = WidgetSync.for_float(double_spin, initial=3.14)
-        """
-        from .core import SyncMode
-        if mode is None:
-            mode = SyncMode.BIDIRECTIONAL
-        sync = cls(initial_value=initial, data_type=float)
-        temp_sync = cls.for_property(widget, property_name, signal_name, initial, mode)
-        sync._connections = temp_sync._connections
-        sync._property_name = property_name
-        sync._signal_name = signal_name
-        sync._first_widget_type = type(widget).__name__
-        return sync
-
-    @classmethod
-    def for_str(cls, widget: QWidget,
-                property_name: str = 'text',
-                signal_name: str = 'textChanged',
-                initial: str = "",
-                mode = None) -> WidgetSync:
-        """
-        Create a sync for string values.
-
-        Works with QLineEdit, QLabel, QTextEdit, or any widget with a text property.
-
-        Parameters
-        ----------
-        widget : QWidget
-            Widget with a string property
-        property_name : str, optional
-            Property name (default: 'text')
-        signal_name : str, optional
-            Signal name (default: 'textChanged')
-        initial : str, optional
-            Initial value (default: "")
-        mode : SyncMode, optional
-            Sync mode (default: BIDIRECTIONAL)
-
-        Returns
-        -------
-        WidgetSync
-            Sync instance with explicit str type
-
-        Example
-        -------
-        >>> sync = WidgetSync.for_str(line_edit, initial="Hello")
-        >>> sync.connect(label, setter=lambda v: label.setText(v),
-        ...              mode=SyncMode.FROM_SYNC)
-        """
-        from .core import SyncMode
-        if mode is None:
-            mode = SyncMode.BIDIRECTIONAL
-        sync = cls(initial_value=initial, data_type=str)
-        temp_sync = cls.for_property(widget, property_name, signal_name, initial, mode)
-        sync._connections = temp_sync._connections
-        sync._property_name = property_name
-        sync._signal_name = signal_name
-        sync._first_widget_type = type(widget).__name__
-        return sync

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/factories.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/factories.py
@@ -122,9 +122,9 @@ class WidgetSyncFactories:
         if initial is None:
             initial = widget.property(prop_name)  # Use widget directly before connecting
 
-        # Create sync and connect
+        # Create sync and bind
         sync = cls(initial_value=initial, data_type=data_type)
-        sync.connect(widget, signal, getter, setter, mode)
+        sync.bind(widget, signal, getter, setter, mode)
 
         # Store pattern info in the connection for add() method to use
         widget_id = id(widget)

--- a/packages/pymodaq_gui/tests/utils/test_widget_sync.py
+++ b/packages/pymodaq_gui/tests/utils/test_widget_sync.py
@@ -1,0 +1,556 @@
+"""
+Tests for widget synchronization module.
+
+Tests cover:
+- Basic synchronization between widgets
+- Enable/disable functionality
+- Connect/disconnect operations
+- Factory methods
+- Value transformations
+- Sync modes
+- Memory management
+"""
+import pytest
+from qtpy.QtWidgets import QSlider, QSpinBox, QCheckBox, QLineEdit, QComboBox
+from qtpy.QtCore import Qt
+
+from pymodaq_gui.utils.widget_sync import WidgetSync, SyncMode
+
+
+class TestBasicSync:
+    """Test basic synchronization functionality"""
+
+    def test_slider_sync(self, qtbot):
+        """Test basic slider synchronization"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        slider1.setRange(0, 100)
+        slider2.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+        sync.add(slider2)
+
+        # Change first slider
+        slider1.setValue(75)
+        assert slider2.value() == 75
+
+        # Change second slider
+        slider2.setValue(25)
+        assert slider1.value() == 25
+
+    def test_checkbox_sync(self, qtbot):
+        """Test checkbox synchronization"""
+        cb1 = QCheckBox()
+        cb2 = QCheckBox()
+        cb3 = QCheckBox()
+
+        sync = WidgetSync.for_checkbox(cb1, initial=False)
+        sync.add(cb2)
+        sync.add(cb3)
+
+        # Check first checkbox
+        cb1.setChecked(True)
+        assert cb2.isChecked()
+        assert cb3.isChecked()
+
+        # Uncheck second checkbox
+        cb2.setChecked(False)
+        assert not cb1.isChecked()
+        assert not cb3.isChecked()
+
+    def test_spinbox_sync(self, qtbot):
+        """Test spinbox synchronization"""
+        spin1 = QSpinBox()
+        spin2 = QSpinBox()
+        spin1.setRange(0, 100)
+        spin2.setRange(0, 100)
+
+        sync = WidgetSync.for_spinbox(spin1, initial=50)
+        sync.add(spin2)
+
+        spin1.setValue(75)
+        assert spin2.value() == 75
+
+
+class TestEnableDisable:
+    """Test enable/disable functionality"""
+
+    def test_disable_stops_syncing(self, qtbot):
+        """Test that disabled widgets don't sync"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        slider3 = QSlider(Qt.Orientation.Horizontal)
+        for s in [slider1, slider2, slider3]:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+        sync.add(slider2)
+        sync.add(slider3)
+
+        # Disable slider2
+        sync.disable(slider2)
+
+        # Change slider1 - slider3 should update, slider2 should not
+        slider1.setValue(75)
+        assert slider3.value() == 75
+        assert slider2.value() == 50  # Still at initial value
+
+        # Change slider2 - others should not update
+        slider2.setValue(90)
+        assert slider1.value() == 75
+        assert slider3.value() == 75
+
+    def test_enable_resumes_syncing(self, qtbot):
+        """Test that re-enabling resumes syncing"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        for s in [slider1, slider2]:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+        sync.add(slider2)
+
+        # Disable and change
+        sync.disable(slider2)
+        slider1.setValue(75)
+        assert slider2.value() == 50
+
+        # Re-enable
+        sync.enable(slider2)
+        slider1.setValue(80)
+        assert slider2.value() == 80
+
+    def test_is_enabled(self, qtbot):
+        """Test is_enabled method"""
+        slider = QSlider(Qt.Orientation.Horizontal)
+        slider.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider, initial=50)
+
+        # Should be enabled by default
+        assert sync.is_enabled(slider)
+
+        # Disable
+        sync.disable(slider)
+        assert not sync.is_enabled(slider)
+
+        # Re-enable
+        sync.enable(slider)
+        assert sync.is_enabled(slider)
+
+    def test_enable_disable_by_id(self, qtbot):
+        """Test enable/disable using widget ID"""
+        slider = QSlider(Qt.Orientation.Horizontal)
+        slider.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider, initial=50)
+        widget_id = id(slider)
+
+        # Disable by ID
+        sync.disable(widget_id)
+        assert not sync.is_enabled(widget_id)
+
+        # Enable by ID
+        sync.enable(widget_id)
+        assert sync.is_enabled(widget_id)
+
+    def test_enable_disable_raises_on_unknown_widget(self, qtbot):
+        """Test that enable/disable raise ValueError for unknown widgets"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+
+        # slider2 is not connected
+        with pytest.raises(ValueError):
+            sync.disable(slider2)
+
+        with pytest.raises(ValueError):
+            sync.enable(slider2)
+
+        with pytest.raises(ValueError):
+            sync.is_enabled(slider2)
+
+
+class TestConnectDisconnect:
+    """Test connect/disconnect operations"""
+
+    def test_disconnect_by_widget(self, qtbot):
+        """Test disconnecting by widget reference"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        for s in [slider1, slider2]:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+        sync.add(slider2)
+
+        # Disconnect slider2
+        sync.disconnect(slider2)
+
+        # Changes should not propagate
+        slider1.setValue(75)
+        assert slider2.value() == 50
+
+    def test_disconnect_by_id(self, qtbot):
+        """Test disconnecting by widget ID"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        for s in [slider1, slider2]:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+        sync.add(slider2)
+
+        widget_id = id(slider2)
+        sync.disconnect(widget_id)
+
+        slider1.setValue(75)
+        assert slider2.value() == 50
+
+    def test_remove_alias(self, qtbot):
+        """Test that remove() is an alias for disconnect()"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        for s in [slider1, slider2]:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+        sync.add(slider2)
+
+        sync.remove(slider2)
+
+        slider1.setValue(75)
+        assert slider2.value() == 50
+
+    def test_disconnect_all(self, qtbot):
+        """Test disconnecting all widgets"""
+        sliders = [QSlider(Qt.Orientation.Horizontal) for _ in range(3)]
+        for s in sliders:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(sliders[0], initial=50)
+        for s in sliders[1:]:
+            sync.add(s)
+
+        assert sync.connection_count == 3
+
+        sync.disconnect_all()
+
+        assert sync.connection_count == 0
+        sliders[0].setValue(75)
+        assert sliders[1].value() == 50
+        assert sliders[2].value() == 50
+
+
+class TestSyncModes:
+    """Test different synchronization modes"""
+
+    def test_bidirectional_mode(self, qtbot):
+        """Test bidirectional sync (default)"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        for s in [slider1, slider2]:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+        sync.add(slider2, mode=SyncMode.BIDIRECTIONAL)
+
+        # Both directions should work
+        slider1.setValue(75)
+        assert slider2.value() == 75
+
+        slider2.setValue(25)
+        assert slider1.value() == 25
+
+    def test_to_sync_mode(self, qtbot):
+        """Test TO_SYNC mode (widget → sync only)"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        for s in [slider1, slider2]:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+
+        # Connect slider2 in TO_SYNC mode
+        sync.connect(
+            slider2,
+            signal=slider2.valueChanged,
+            getter=lambda: slider2.value(),
+            setter=lambda v: slider2.setValue(v),
+            mode=SyncMode.TO_SYNC
+        )
+
+        # slider2 → slider1 should work
+        slider2.setValue(75)
+        assert slider1.value() == 75
+
+        # slider1 → slider2 should NOT work
+        slider1.setValue(25)
+        assert slider2.value() == 75  # Unchanged
+
+    def test_from_sync_mode(self, qtbot):
+        """Test FROM_SYNC mode (sync → widget only, read-only)"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        for s in [slider1, slider2]:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+
+        # Connect slider2 in FROM_SYNC mode
+        sync.connect(
+            slider2,
+            setter=lambda v: slider2.setValue(v),
+            mode=SyncMode.FROM_SYNC
+        )
+
+        # slider1 → slider2 should work
+        slider1.setValue(75)
+        assert slider2.value() == 75
+
+        # slider2 → slider1 should NOT work
+        slider2.setValue(90)
+        assert slider1.value() == 75  # Unchanged
+
+
+class TestValueTransforms:
+    """Test value transformation functionality"""
+
+    def test_to_sync_transform(self, qtbot):
+        """Test transformation from widget to sync"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        for s in [slider1, slider2]:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=0)
+
+        # Add slider2 with transform (multiply by 2)
+        sync.add(
+            slider2,
+            to_sync_transform=lambda v: v * 2,
+            from_sync_transform=lambda v: v // 2
+        )
+
+        # Change slider2
+        slider2.setValue(25)
+        assert slider1.value() == 50  # 25 * 2
+
+    def test_from_sync_transform(self, qtbot):
+        """Test transformation from sync to widget"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        for s in [slider1, slider2]:
+            s.setRange(0, 200)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+
+        # Add slider2 with transform (multiply by 2)
+        sync.add(
+            slider2,
+            to_sync_transform=lambda v: v // 2,
+            from_sync_transform=lambda v: v * 2
+        )
+
+        # Change slider1
+        slider1.setValue(50)
+        assert slider2.value() == 100  # 50 * 2
+
+
+class TestIntrospection:
+    """Test introspection methods"""
+
+    def test_connection_count(self, qtbot):
+        """Test connection_count property"""
+        sliders = [QSlider(Qt.Orientation.Horizontal) for _ in range(3)]
+        for s in sliders:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(sliders[0], initial=50)
+        assert sync.connection_count == 1
+
+        sync.add(sliders[1])
+        assert sync.connection_count == 2
+
+        sync.add(sliders[2])
+        assert sync.connection_count == 3
+
+        sync.disconnect(sliders[1])
+        assert sync.connection_count == 2
+
+    def test_connected_widgets(self, qtbot):
+        """Test connected_widgets property"""
+        sliders = [QSlider(Qt.Orientation.Horizontal) for _ in range(3)]
+        for s in sliders:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(sliders[0], initial=50)
+        sync.add(sliders[1])
+        sync.add(sliders[2])
+
+        widgets = sync.connected_widgets
+        assert len(widgets) == 3
+        assert sliders[0] in widgets
+        assert sliders[1] in widgets
+        assert sliders[2] in widgets
+
+    def test_value_property(self, qtbot):
+        """Test value property getter/setter"""
+        slider = QSlider(Qt.Orientation.Horizontal)
+        slider.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider, initial=50)
+
+        # Get value
+        assert sync.value == 50
+
+        # Set value programmatically
+        sync.value = 75
+        assert slider.value() == sync.value
+
+
+class TestFactoryMethods:
+    """Test factory methods for common widget types"""
+
+    def test_for_checkbox(self, qtbot):
+        """Test for_checkbox factory"""
+        cb = QCheckBox()
+        sync = WidgetSync.for_checkbox(cb, initial=True)
+
+        assert cb.isChecked() == sync.value
+
+    def test_for_spinbox(self, qtbot):
+        """Test for_spinbox factory"""
+        spin = QSpinBox()
+        spin.setRange(0, 100)
+        sync = WidgetSync.for_spinbox(spin, initial=50)
+
+        assert spin.value() == sync.value
+
+    def test_for_slider(self, qtbot):
+        """Test for_slider factory"""
+        slider = QSlider(Qt.Orientation.Horizontal)
+        slider.setRange(0, 100)
+        sync = WidgetSync.for_slider(slider, initial=75)
+
+        assert slider.value() == sync.value
+
+    def test_for_lineedit(self, qtbot):
+        """Test for_lineedit factory"""
+        edit = QLineEdit()
+        sync = WidgetSync.for_lineedit(edit, initial="Hello")
+
+        assert edit.text() == sync.value
+
+    def test_for_combobox(self, qtbot):
+        """Test for_combobox factory"""
+        combo = QComboBox()
+        combo.addItems(["Option 1", "Option 2", "Option 3"])
+        sync = WidgetSync.for_combobox(combo, initial=1)
+
+        assert combo.currentIndex() == sync.value
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions"""
+
+    def test_add_different_widget_type_raises(self, qtbot):
+        """Test that add() with different widget type raises TypeError"""
+        checkbox = QCheckBox()
+        slider = QSlider(Qt.Orientation.Horizontal)
+
+        sync = WidgetSync.for_checkbox(checkbox)
+
+        with pytest.raises(TypeError):
+            sync.add(slider)
+
+    def test_widget_deletion_cleanup(self, qtbot):
+        """Test that widget deletion triggers automatic cleanup"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        slider1.setRange(0, 100)
+        slider2.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+        sync.add(slider2)
+
+        assert sync.connection_count == 2
+
+        # Delete slider2
+        slider2.deleteLater()
+        qtbot.wait(100)  # Wait for Qt to process deletion
+
+        # Connection count should decrease
+        # Note: This tests the destroyed signal mechanism
+        assert sync.connection_count <= 2
+
+    def test_disabled_widget_not_in_feedback_loop(self, qtbot):
+        """Test that disabled widget doesn't create feedback loops"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        slider3 = QSlider(Qt.Orientation.Horizontal)
+        for s in [slider1, slider2, slider3]:
+            s.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+        sync.add(slider2)
+        sync.add(slider3)
+
+        # Disable slider2
+        sync.disable(slider2)
+
+        # Rapid changes should not cause issues
+        for i in range(10):
+            slider1.setValue(i * 10)
+            slider3.setValue(i * 10)
+
+        # slider2 should still be at initial value
+        assert slider2.value() == 50
+
+
+class TestEnableDisableWithDisconnect:
+    """Test interactions between enable/disable and connect/disconnect"""
+
+    def test_reconnect_preserves_enabled_state(self, qtbot):
+        """Test that reconnecting maintains enabled state"""
+        slider = QSlider(Qt.Orientation.Horizontal)
+        slider.setRange(0, 100)
+
+        sync = WidgetSync(initial_value=50)
+
+        # Connect
+        sync.connect(
+            slider,
+            signal=slider.valueChanged,
+            getter=lambda: slider.value(),
+            setter=lambda v: slider.setValue(v)
+        )
+
+        # Disable
+        sync.disable(slider)
+        assert not sync.is_enabled(slider)
+
+        # Disconnect and reconnect
+        sync.disconnect(slider)
+        sync.connect(
+            slider,
+            signal=slider.valueChanged,
+            getter=lambda: slider.value(),
+            setter=lambda v: slider.setValue(v)
+        )
+
+        # Should be enabled again (new connection)
+        assert sync.is_enabled(slider)
+
+    def test_disconnect_disabled_widget(self, qtbot):
+        """Test that disconnecting a disabled widget works"""
+        slider = QSlider(Qt.Orientation.Horizontal)
+        slider.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider, initial=50)
+
+        sync.disable(slider)
+        sync.disconnect(slider)
+
+        assert sync.connection_count == 0

--- a/packages/pymodaq_gui/tests/utils/test_widget_sync.py
+++ b/packages/pymodaq_gui/tests/utils/test_widget_sync.py
@@ -452,6 +452,115 @@ class TestFactoryMethods:
         assert combo.currentIndex() == sync.value
 
 
+class TestMatchParameter:
+    """Test the match parameter in add() method"""
+
+    def test_add_same_type_default_match(self, qtbot):
+        """Test add() with same widget type (default match='type')"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        slider1.setRange(0, 100)
+        slider2.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+        sync.add(slider2)  # Should work with default match='type'
+
+        slider1.setValue(75)
+        assert slider2.value() == 75
+
+    def test_add_same_type_explicit_type_match(self, qtbot):
+        """Test add() with same widget type and explicit match='type'"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+        slider1.setRange(0, 100)
+        slider2.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+        sync.add(slider2, match='type')  # Explicit type matching
+
+        slider1.setValue(75)
+        assert slider2.value() == 75
+
+    def test_add_different_type_with_property_match(self, qtbot):
+        """Test add() with different widget type using match='property'"""
+        slider = QSlider(Qt.Orientation.Horizontal)
+        spinbox = QSpinBox()
+        slider.setRange(0, 100)
+        spinbox.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider, initial=50)
+        # Both use 'value' property and 'valueChanged' signal
+        sync.add(spinbox, match='property')
+
+        # Check initial sync
+        assert spinbox.value() == 50
+
+        # Change slider -> spinbox should update
+        slider.setValue(75)
+        assert spinbox.value() == 75
+
+        # Change spinbox -> slider should update
+        spinbox.setValue(25)
+        assert slider.value() == 25
+
+    def test_add_different_type_without_property_match_raises(self, qtbot):
+        """Test add() with different type and default match='type' raises"""
+        slider = QSlider(Qt.Orientation.Horizontal)
+        spinbox = QSpinBox()
+
+        sync = WidgetSync.for_slider(slider, initial=50)
+
+        # Should raise TypeError because types don't match
+        with pytest.raises(TypeError, match="no connection pattern found"):
+            sync.add(spinbox)  # Default match='type'
+
+    def test_add_incompatible_widget_property_match_raises(self, qtbot):
+        """Test add() with incompatible widget using match='property' raises"""
+        slider = QSlider(Qt.Orientation.Horizontal)
+        checkbox = QCheckBox()
+
+        sync = WidgetSync.for_slider(slider, initial=50)
+
+        # Should raise TypeError because checkbox doesn't have 'valueChanged' signal
+        with pytest.raises(TypeError):
+            sync.add(checkbox, match='property')
+
+    def test_add_invalid_match_raises(self, qtbot):
+        """Test add() with invalid match parameter raises ValueError"""
+        slider1 = QSlider(Qt.Orientation.Horizontal)
+        slider2 = QSlider(Qt.Orientation.Horizontal)
+
+        sync = WidgetSync.for_slider(slider1, initial=50)
+
+        with pytest.raises(ValueError, match="match must be"):
+            sync.add(slider2, match='invalid')
+
+    def test_property_match_with_multiple_types(self, qtbot):
+        """Test property matching with multiple different widget types"""
+        from qtpy.QtWidgets import QDial
+
+        slider = QSlider(Qt.Orientation.Horizontal)
+        spinbox = QSpinBox()
+        dial = QDial()
+
+        slider.setRange(0, 100)
+        spinbox.setRange(0, 100)
+        dial.setRange(0, 100)
+
+        sync = WidgetSync.for_slider(slider, initial=50)
+        sync.add(spinbox, match='property')
+        sync.add(dial, match='property')
+
+        # All should be synced
+        assert spinbox.value() == 50
+        assert dial.value() == 50
+
+        # Change one -> all update
+        slider.setValue(75)
+        assert spinbox.value() == 75
+        assert dial.value() == 75
+
+
 class TestEdgeCases:
     """Test edge cases and error conditions"""
 

--- a/packages/pymodaq_gui/tests/utils/widget_sync_test.py
+++ b/packages/pymodaq_gui/tests/utils/widget_sync_test.py
@@ -4,7 +4,7 @@ Tests for widget synchronization module.
 Tests cover:
 - Basic synchronization between widgets
 - Enable/disable functionality
-- Connect/disconnect operations
+- Bind/unbind operations
 - Factory methods
 - Value transformations
 - Sync modes
@@ -186,7 +186,7 @@ class TestConnectDisconnect:
         sync.add(slider2)
 
         # Disconnect slider2
-        sync.disconnect(slider2)
+        sync.unbind(slider2)
 
         # Changes should not propagate
         slider1.setValue(75)
@@ -203,7 +203,7 @@ class TestConnectDisconnect:
         sync.add(slider2)
 
         widget_id = id(slider2)
-        sync.disconnect(widget_id)
+        sync.unbind(widget_id)
 
         slider1.setValue(75)
         assert slider2.value() == 50
@@ -223,8 +223,8 @@ class TestConnectDisconnect:
         slider1.setValue(75)
         assert slider2.value() == 50
 
-    def test_disconnect_all(self, qtbot):
-        """Test disconnecting all widgets"""
+    def test_unbind_all(self, qtbot):
+        """Test unbinding all widgets"""
         sliders = [QSlider(Qt.Orientation.Horizontal) for _ in range(3)]
         for s in sliders:
             s.setRange(0, 100)
@@ -235,7 +235,7 @@ class TestConnectDisconnect:
 
         assert sync.connection_count == 3
 
-        sync.disconnect_all()
+        sync.unbind_all()
 
         assert sync.connection_count == 0
         sliders[0].setValue(75)
@@ -273,7 +273,7 @@ class TestSyncModes:
         sync = WidgetSync.for_slider(slider1, initial=50)
 
         # Connect slider2 in TO_SYNC mode
-        sync.connect(
+        sync.bind(
             slider2,
             signal=slider2.valueChanged,
             getter=lambda: slider2.value(),
@@ -299,7 +299,7 @@ class TestSyncModes:
         sync = WidgetSync.for_slider(slider1, initial=50)
 
         # Connect slider2 in FROM_SYNC mode
-        sync.connect(
+        sync.bind(
             slider2,
             setter=lambda v: slider2.setValue(v),
             mode=SyncMode.FROM_SYNC
@@ -376,7 +376,7 @@ class TestIntrospection:
         sync.add(sliders[2])
         assert sync.connection_count == 3
 
-        sync.disconnect(sliders[1])
+        sync.unbind(sliders[1])
         assert sync.connection_count == 2
 
     def test_connected_widgets(self, qtbot):
@@ -629,7 +629,7 @@ class TestEnableDisableWithDisconnect:
         sync = WidgetSync(initial_value=50)
 
         # Connect
-        sync.connect(
+        sync.bind(
             slider,
             signal=slider.valueChanged,
             getter=lambda: slider.value(),
@@ -641,8 +641,8 @@ class TestEnableDisableWithDisconnect:
         assert not sync.is_enabled(slider)
 
         # Disconnect and reconnect
-        sync.disconnect(slider)
-        sync.connect(
+        sync.unbind(slider)
+        sync.bind(
             slider,
             signal=slider.valueChanged,
             getter=lambda: slider.value(),
@@ -660,6 +660,6 @@ class TestEnableDisableWithDisconnect:
         sync = WidgetSync.for_slider(slider, initial=50)
 
         sync.disable(slider)
-        sync.disconnect(slider)
+        sync.unbind(slider)
 
         assert sync.connection_count == 0


### PR DESCRIPTION
Context: Qt aplications often need to keep multiple widgets synchronized (toolbar/menu actions, compact/full views, enable/disable controls). This is usually done with manual signal connections, leading to boilerplate code. In addition, one has to be particularly careful in some situations with bidirectional sync as it can lead to infinite trigger or to desync.

In this PR: I propose a new class `WidgetSync` to deal with all this silly connections. In practice, this permits to easily synchronize multiple widgets with different types or properties. The `WidgetSync` acts as a single source of truth so any widgets or functions can refer to it, aka the truth signal source is the value attribute and any change from it can be captured by the value_changed Signal.

For now, there is no direct use of it in pymodaq but I plan to use it for future developments as I believe in the potential value of this tool to easily manage connections between QWidgets/QActions.

As always, this comes with an example which does not say much as this can be achieved with standard Qt syntax but the docs show more clearly the proposed syntax.


https://github.com/user-attachments/assets/95040437-ec45-4873-aae7-dd79d2e9d20a




