### PR TITLE
Remove QObject double inheritance in CalibrationCamera and DockArea

### DIFF
--- a/packages/pymodaq/src/pymodaq/utils/calibration_camera.py
+++ b/packages/pymodaq/src/pymodaq/utils/calibration_camera.py
@@ -20,7 +20,7 @@ if not os.path.isdir(calib_path):
     os.makedirs(calib_path)
 
 
-class CalibrationCamera(QtWidgets.QWidget, QObject):
+class CalibrationCamera(QtWidgets.QWidget):
     def __init__(self, parent=None, h5filepath=None):
 
         

--- a/packages/pymodaq/src/pymodaq/utils/tcp_ip/tcp_server_client.py
+++ b/packages/pymodaq/src/pymodaq/utils/tcp_ip/tcp_server_client.py
@@ -323,13 +323,12 @@ class TCPClient(TCPClientTemplate, QObject):
         self.send_data(data)
 
 
-class TCPServer(QObject):
+class TCPServer:
     """
     Abstract class to be used as inherited by DAQ_Viewer_TCP or DAQ_Move_TCP
     """
 
     def __init__(self, client_type='GRABBER'):
-        QObject.__init__(self)
         self.serversocket: Socket = None
         self.connected_clients = []
         self.listening = True
@@ -673,11 +672,12 @@ class TCPServer(QObject):
             self.settings.child('infos', info).setValue(data)
 
 
-class MockServer(TCPServer):
+class MockServer(TCPServer, QObject):
     params = []
 
     def __init__(self, client_type='GRABBER'):
-        super().__init__(client_type)
+        QObject.__init__(self)
+        TCPServer.__init__(self, client_type)
 
         self.settings = Parameter.create(name='settings', type='group', children=tcp_parameters)
 

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/dock.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/dock.py
@@ -41,7 +41,7 @@ class Dock(Dock):
                 self.updateStyle()
 
 
-class DockArea(DockArea, QObject):
+class DockArea(DockArea):
     """
     Custom Dockarea class subclassing from the standard DockArea class and QObject so it can emit a signal when docks
     are moved around (one subclassed method: moveDock)


### PR DESCRIPTION
Solves #810 

Not complete, as I didn't run a check on "hidden" double inheritance