### PR TITLE
Bugfix/daq move dataset

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
@@ -20,6 +20,7 @@ from qtpy import QtWidgets
 
 from easydict import EasyDict as edict
 
+from pymodaq.utils.h5modules.module_saving import ActuatorSaver
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.utils import find_keys_from_val
 from pymodaq_utils import utils
@@ -166,7 +167,6 @@ class DAQ_Move(ParameterControlModule):
         if len(ACTUATOR_TYPES) > 0:  # will be 0 if no valid plugins are installed
             self.actuator = kwargs.get("actuator", ACTUATOR_TYPES[0])
 
-        self.module_and_data_saver = module_saving.ActuatorTimeSaver(self)
 
         self._move_done_bool = True
 
@@ -564,6 +564,10 @@ class DAQ_Move(ParameterControlModule):
                     "show_graph"
                 ):
                     self.ui.show_data(DataToExport(name=self.title, data=[data_act]))
+                if self.ui.has_action("refresh_value") and self.ui.is_action_checked('refresh_value'):
+                    data_node = self.module_and_data_saver.get_set_node()
+                    self.module_and_data_saver.add_data(data_node, DataToExport('Actuator', data=[data_act]))
+
             self._current_value = data_act
             self.current_value_signal.emit(self._current_value)
             if (
@@ -685,12 +689,14 @@ class DAQ_Move(ParameterControlModule):
         The current timer period is set by the refresh value *'refresh_timeout'* in the actuator main settings.
         """
         if get_value:
+            self.module_and_data_saver = module_saving.ActuatorTimeSaver(self)
             self._refresh_timer.setInterval(
                 self.settings["main_settings", "refresh_timeout"]
             )
             self._refresh_timer.start()
         else:
             self._refresh_timer.stop()
+            self.module_and_data_saver.h5saver.close_file()
 
     @property
     def actuator(self):

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
@@ -30,6 +30,7 @@ from pymodaq_utils.warnings import deprecation_msg
 from pymodaq.utils.data import DataToExport, DataActuator
 from pymodaq_data.h5modules.backends import Node
 
+from pymodaq_gui.h5modules.saving import H5Saver
 from pymodaq_gui.parameter import ioxml, Parameter
 from pymodaq_gui.parameter import utils as putils
 from pymodaq_gui.utils.utils import mkQApp
@@ -115,7 +116,9 @@ class DAQ_Move(ParameterControlModule):
     current_value_signal = Signal(DataActuator)
     bounds_signal = Signal(bool)
 
-    params = daq_move_params
+    params = daq_move_params +  [
+        {'title': 'Saver Settings:', 'name': 'saver_settings', 'type': 'group',
+         'visible': False, 'children': H5Saver.params}]
 
     listener_class = MoveActorListener
     ui: Optional[DAQ_Move_UI_Base]
@@ -165,6 +168,13 @@ class DAQ_Move(ParameterControlModule):
             self.actuator = kwargs.get("actuator", ACTUATOR_TYPES[0])
 
         self._module_and_data_saver: module_saving.ActuatorTimeSaver = None
+        for hidden_param in ('custom_name',
+                            'current_scan_name',
+                            'current_scan_path',
+                            'current_h5_file',
+                            'new_file',
+                            'base_name'):
+            self.settings.child('saver_settings', hidden_param).setOpts(visible=False)
 
         self._move_done_bool = True
 
@@ -266,7 +276,7 @@ class DAQ_Move(ParameterControlModule):
         if dte is None:
             dte = DataToExport(name=self.title, data=[self._current_value])
         self._add_data_to_saver(dte, where=where)
-        # todo: test this for logging
+        self.settings.child('saver_settings', 'N_saved').setValue(self.settings['saver_settings', 'N_saved'] + 1)
 
     def _add_data_to_saver(self, data: DataToExport, where=None, **kwargs):
         """Adds DataToExport data to the current node using the declared module_and_data_saver
@@ -480,11 +490,43 @@ class DAQ_Move(ParameterControlModule):
     def value_changed(self, param: Parameter):
         """Apply changes of value in the settings"""
         super().value_changed(param=param)
+        path = self.settings.childPath(param)
 
         if param.name() == "refresh_timeout":
             self._refresh_timer.setInterval(param.value())
 
+        elif param.name() == 'continuous_saving_opt':
+            self.settings.child('saver_settings').setOpts(visible=param.value())
+
+        elif param.name() in putils.iter_children(self.settings.child('saver_settings'), []):
+            if param.name() == 'do_save':
+                self.setup_continuous_saving(param.value())
+            self.h5saver.settings.child(*path[1:]).setValue(param.value())
+
         self._update_settings(param=param)
+
+    def setup_continuous_saving(self, init: bool = True):
+        """Configure the objects dealing with the continuous saving mode"""
+        if init:
+            self.module_and_data_saver = module_saving.ActuatorTimeSaver(self)
+            self.module_and_data_saver.h5saver = self.h5saver
+            self.h5saver.settings.child('do_save').sigValueChanged.connect(self._init_continuous_save)
+        else:
+            self.h5saver.close_file()
+
+    def _init_continuous_save(self):
+        """ Initialize the continuous saving H5Saver object
+
+        Update the module_and_data_saver attribute as :class:`DetectorTimeSaver` object
+        """
+        if self.settings.child('saver_settings', 'do_save').value():
+
+            self.settings.child('saver_settings', 'base_name').setValue('Data')
+            self.settings.child('saver_settings', 'N_saved').show()
+            self.settings.child('saver_settings', 'N_saved').setValue(0)
+            self.h5saver.init_file(update_h5=True)
+        else:
+            self.settings.child('saver_settings', 'N_saved').hide()
 
     def param_deleted(self, param):
         """Apply deletion of settings"""
@@ -562,14 +604,14 @@ class DAQ_Move(ParameterControlModule):
                     "show_graph"
                 ):
                     self.ui.show_data(DataToExport(name=self.title, data=[data_act]))
-                if self.ui.has_action("refresh_value") and self.ui.is_action_checked('refresh_value'):
-                    data_node = self.module_and_data_saver.get_set_node()
-                    self.module_and_data_saver.add_data(data_node, DataToExport('Actuator', data=[data_act]))
 
             self._current_value = data_act
+            if self.settings['saver_settings', 'do_save']:
+                self.append_data()
+
             self.current_value_signal.emit(self._current_value)
             if (
-                self.settings["main_settings", "tcpip", "tcp_connected"]
+                    self.settings["main_settings", "tcpip", "tcp_connected"]
                 and self._send_to_tcpip
             ):
                 self._command_tcpip.emit(ThreadCommand("position_is", data_act))
@@ -687,14 +729,12 @@ class DAQ_Move(ParameterControlModule):
         The current timer period is set by the refresh value *'refresh_timeout'* in the actuator main settings.
         """
         if get_value:
-            self.module_and_data_saver = module_saving.ActuatorTimeSaver(self)
             self._refresh_timer.setInterval(
                 self.settings["main_settings", "refresh_timeout"]
             )
             self._refresh_timer.start()
         else:
             self._refresh_timer.stop()
-            self.module_and_data_saver.h5saver.close_file()
 
     @property
     def actuator(self):

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
@@ -20,7 +20,6 @@ from qtpy import QtWidgets
 
 from easydict import EasyDict as edict
 
-from pymodaq.utils.h5modules.module_saving import ActuatorSaver
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.utils import find_keys_from_val
 from pymodaq_utils import utils
@@ -78,8 +77,6 @@ logger = set_logger(get_module_name(__file__))
 
 config_utils = config_mod.Config()
 config = ControlModulesConfig()
-
-HardwareController = TypeVar("HardwareController")
 
 HardwareController = TypeVar("HardwareController")
 

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
@@ -167,6 +167,7 @@ class DAQ_Move(ParameterControlModule):
         if len(ACTUATOR_TYPES) > 0:  # will be 0 if no valid plugins are installed
             self.actuator = kwargs.get("actuator", ACTUATOR_TYPES[0])
 
+        self._module_and_data_saver: module_saving.ActuatorTimeSaver = None
 
         self._move_done_bool = True
 

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
@@ -103,7 +103,9 @@ class DAQ_Viewer(ParameterControlModule):
     data_saved = Signal()
     grab_status = Signal(bool)
 
-    params = daq_viewer_params
+    params = daq_viewer_params + [
+        {'title': 'Saver Settings:', 'name': 'saver_settings', 'type': 'group',
+         'visible': False, 'children': H5Saver.params}]
 
     listener_class = ViewerActorListener
     ui: Optional[DAQ_Viewer_UI]
@@ -162,7 +164,6 @@ class DAQ_Viewer(ParameterControlModule):
                                           module_saving.DetectorExtendedSaver] = None
         self._h5saver_continuous: Optional[H5Saver] = None
         self._ind_continuous_grab = 0
-        self.setup_continuous_saving()
 
         self.settings.child('main_settings', 'DAQ_type').setValue(self.daq_type.name)
         self._detectors: List[str] = [det_dict['name'] for det_dict in DET_TYPES[self.daq_type.name]]
@@ -171,6 +172,13 @@ class DAQ_Viewer(ParameterControlModule):
         else:
             raise DetectorError('No detected Detector')
         self.settings.child('main_settings', 'detector_type').setValue(self._detector)
+        for hided_param in ('custom_name',
+                            'current_scan_name',
+                            'current_scan_path',
+                            'current_h5_file',
+                            'new_file',
+                            'base_name'):
+            self.settings.child('saver_settings', hided_param).setOpts(visible=False)
 
         self._grabing: bool = False
         self._do_bkg: bool = False
@@ -199,14 +207,15 @@ class DAQ_Viewer(ParameterControlModule):
     def __repr__(self):
         return f'{self.__class__.__name__}: {self.title} ({self.daq_type}/{self.detector}'
 
-    def setup_continuous_saving(self):
+    def setup_continuous_saving(self, init: bool = True):
         """Configure the objects dealing with the continuous saving mode"""
-        self.module_and_data_saver = module_saving.DetectorSaver(self)
-        self._h5saver_continuous = H5Saver(save_type='detector')
-        self._h5saver_continuous.show_settings(False)
-        self._h5saver_continuous.settings.child('do_save').sigValueChanged.connect(self._init_continuous_save)
-        if self.ui is not None:
-            self.ui.add_setting_tree(self._h5saver_continuous.settings_tree)
+        if init:
+            self.module_and_data_saver = module_saving.DetectorSaver(self)
+            self._h5saver_continuous = H5Saver(save_type='detector')
+            self._h5saver_continuous.settings.child('do_save').sigValueChanged.connect(self._init_continuous_save)
+        else:
+            self._h5saver_continuous.close_file()
+
 
     def process_ui_cmds(self, cmd: utils.ThreadCommand):
         """Process commands sent by actions done in the ui
@@ -632,9 +641,9 @@ class DAQ_Viewer(ParameterControlModule):
         """
         if self._h5saver_continuous.settings.child('do_save').value():
 
-            self._h5saver_continuous.settings.child('base_name').setValue('Data')
-            self._h5saver_continuous.settings.child('N_saved').show()
-            self._h5saver_continuous.settings.child('N_saved').setValue(0)
+            self.settings.child('saver_settings', 'base_name').setValue('Data')
+            self.settings.child('saver_settings', 'N_saved').show()
+            self.settings.child('saver_settings', 'N_saved').setValue(0)
             self.module_and_data_saver.h5saver = self._h5saver_continuous
             self._h5saver_continuous.init_file(update_h5=True)
 
@@ -645,7 +654,7 @@ class DAQ_Viewer(ParameterControlModule):
             self.grab_done_signal.connect(self.append_data)
         else:
             self._do_continuous_save = False
-            self._h5saver_continuous.settings.child('N_saved').hide()
+            self.settings.child('saver_settings', 'N_saved').hide()
             self.grab_done_signal.disconnect(self.append_data)
 
             try:
@@ -674,13 +683,13 @@ class DAQ_Viewer(ParameterControlModule):
             dte = self._data_to_save_export
         init_step = kwargs.pop('init_step', None)
         if init_step is None:
-            init_step = self._h5saver_continuous.settings['N_saved'] == 0
+            init_step = self.settings['saver_settings', 'N_saved'] == 0
         self._add_data_to_saver(dte,
                                 init_step=init_step,
                                 where=where,
                                 **kwargs)
 
-        self._h5saver_continuous.settings.child('N_saved').setValue(self._h5saver_continuous.settings['N_saved'] + 1)
+        self.settings.child('saver_settings', 'N_saved').setValue(self.settings['saver_settings', 'N_saved'] + 1)
 
     def insert_data(self, indexes: Tuple[int], where: Union[Node, str] = None,
                     distribution=DataDistribution['uniform']):
@@ -960,7 +969,7 @@ class DAQ_Viewer(ParameterControlModule):
 
         path = self.settings.childPath(param)
         if param.name() == 'DAQ_type':
-            self._h5saver_continuous.settings.child('do_save').setValue(False)
+            self.settings.child('saver_settings', 'do_save').setValue(False)
             self.settings.child('main_settings', 'axes').show(param.value() == 'DAQ2D')
 
         elif param.name() == 'show_averaging':
@@ -992,11 +1001,17 @@ class DAQ_Viewer(ParameterControlModule):
                         viewer.x_axis, viewer.y_axis = self.get_scaling_options()
 
         elif param.name() == 'continuous_saving_opt':
-            self._h5saver_continuous.show_settings(param.value())
+            self.settings.child('saver_settings').setOpts(visible=param.value())
+
 
         elif param.name() == 'wait_time':
             self.command_hardware.emit(ThreadCommand(ControlToHardwareViewer.UPDATE_WAIT_TIME,
                                                      [param.value()]))
+
+        elif param.name() in putils.iter_children(self.settings.child('saver_settings'), []):
+            if param.name() == 'do_save':
+                self.setup_continuous_saving(param.value())
+            self._h5saver_continuous.settings.child(*path[1:]).setValue(param.value())
 
         self._update_settings(param=param)
 

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
@@ -172,13 +172,13 @@ class DAQ_Viewer(ParameterControlModule):
         else:
             raise DetectorError('No detected Detector')
         self.settings.child('main_settings', 'detector_type').setValue(self._detector)
-        for hided_param in ('custom_name',
+        for hidden_param in ('custom_name',
                             'current_scan_name',
                             'current_scan_path',
                             'current_h5_file',
                             'new_file',
                             'base_name'):
-            self.settings.child('saver_settings', hided_param).setOpts(visible=False)
+            self.settings.child('saver_settings', hidden_param).setOpts(visible=False)
 
         self._grabing: bool = False
         self._do_bkg: bool = False

--- a/packages/pymodaq/src/pymodaq/control_modules/mocks.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/mocks.py
@@ -17,6 +17,8 @@ class MockDAQViewer:
         self.h5saver = h5saver
         self.title = title
         self.module_and_data_saver = DetectorSaver(self)
+        self.module_and_data_saver.h5saver = h5saver
+        self._module_and_data_saver = self.module_and_data_saver
         self.ui = None
 
 
@@ -28,6 +30,8 @@ class MockDAQMove:
         self.h5saver = h5saver
         self.title = title
         self.module_and_data_saver = ActuatorTimeSaver(self)
+        self.module_and_data_saver.h5saver = h5saver
+        self._module_and_data_saver = self.module_and_data_saver
         self.ui = None
 
 
@@ -35,6 +39,8 @@ class ModulesManagerMock:
     def __init__(self, actuators, detectors):
         self.modules_all = actuators + detectors
         self.modules = actuators + detectors
+        self.detectors_all = detectors
+        self.actuators_all = actuators
 
 
 class MockScan:

--- a/packages/pymodaq/src/pymodaq/control_modules/move_utility_classes.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/move_utility_classes.py
@@ -194,6 +194,8 @@ params = [
 
         {'title': 'Refresh value (ms):', 'name': 'refresh_timeout', 'type': 'int',
          'value': config('actuator', 'refresh_timeout_ms')},
+        {'title': 'Continuous saving:', 'name': 'continuous_saving_opt', 'type': 'bool', 'default': False,
+         'value': False},
         {'title': 'TCP/IP options:', 'name': 'tcpip', 'type': 'group', 'visible': True, 'expanded': False,
          'children': [
              {'title': 'Connect to server:', 'name': 'connect_server', 'type': 'bool_push', 'label': 'Connect',

--- a/packages/pymodaq/src/pymodaq/control_modules/utils.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/utils.py
@@ -177,7 +177,6 @@ class ControlModule(QObject):
         self._module_and_data_saver = mod
         self._module_and_data_saver.h5saver = self.h5saver
 
-
     def custom_command(self, command: str, **kwargs):
         self.command_hardware.emit(ThreadCommand(command, kwargs))
 

--- a/packages/pymodaq/src/pymodaq/control_modules/utils.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/utils.py
@@ -168,7 +168,7 @@ class ControlModule(QObject):
 
     @property
     def module_and_data_saver(self):
-        if not self._module_and_data_saver.h5saver.isopen():
+        if self._module_and_data_saver.h5saver is None or not self._module_and_data_saver.h5saver.isopen():
             self._module_and_data_saver.h5saver = self.h5saver
         return self._module_and_data_saver
 

--- a/packages/pymodaq/src/pymodaq/extensions/daq_scan.py
+++ b/packages/pymodaq/src/pymodaq/extensions/daq_scan.py
@@ -151,23 +151,23 @@ class DAQScan(QObject, ParameterManager):
         self.plot_colors = utils.plot_colors
 
         self.runner_thread: QThread = None
-        self._h5saver: H5Saver = None
-        self._module_and_data_saver: module_saving.ScanSaver = None
 
         self.modules_manager = ModulesManager(self.dashboard.detector_modules, self.dashboard.actuators_modules)
         self.modules_manager.settings.child('data_dimensions').setOpts(expanded=False)
         self.modules_manager.settings.child('actuators_positions').setOpts(expanded=False)
         self.modules_manager.detectors_changed.connect(self.clear_plot_from)
 
-        self.module_and_data_saver = module_saving.ScanSaver(self)
+
+        self._h5saver = H5Saver(backend=config_utils('general', 'hdf5_backend'))
+        self._h5saver.settings.child('do_save').hide()
+        self._h5saver.settings.child('custom_name').hide()
+        self._h5saver.new_file_sig.connect(self.create_new_file)
+
+        self._module_and_data_saver: module_saving.ScanSaver = module_saving.ScanSaver(self)
 
         self.extended_saver: data_saving.DataToExportExtendedSaver = None
         self.h5temp: H5Saver = None
         self.temp_path: tempfile.TemporaryDirectory = None
-
-        self.h5saver.settings.child('do_save').hide()
-        self.h5saver.settings.child('custom_name').hide()
-        self.h5saver.new_file_sig.connect(self.create_new_file)
 
         self.scanner = Scanner(actuators=self.modules_manager.actuators)  # , adaptive_losses=adaptive_losses)
         self.scan_parameters = None
@@ -202,7 +202,7 @@ class DAQScan(QObject, ParameterManager):
         self.settings.child('plot_options', 'plot_1d').setValue(data1D)
 
     def setup_ui(self):
-        self.ui.populate_toolbox_widget([self.settings_tree, self.h5saver.settings_tree],
+        self.ui.populate_toolbox_widget([self.settings_tree, self._h5saver.settings_tree],
                                         ['General Settings', 'Save Settings'])
 
         self.ui.set_scanner_settings(self.scanner.parent_widget)
@@ -526,6 +526,9 @@ class DAQScan(QObject, ParameterManager):
     def h5saver(self):
         if self._h5saver is None:
             self._h5saver = H5Saver(backend=config_utils('general', 'hdf5_backend'))
+            self._h5saver.settings.child('do_save').hide()
+            self._h5saver.settings.child('custom_name').hide()
+            self._h5saver.new_file_sig.connect(self.create_new_file)
         if self._h5saver.h5_file is None:
             self._h5saver.init_file(update_h5=True)
         if not self._h5saver.isopen():
@@ -794,6 +797,7 @@ class DAQScan(QObject, ParameterManager):
         In case the dialog is cancelled, return False and aborts the scan
         """
         try:
+
             res = self.update_scan_info()
             if not res:
                 return False
@@ -820,17 +824,6 @@ class DAQScan(QObject, ParameterManager):
                 messagebox(
                     text="There are not enough or too much selected move modules for this scan")
                 return False
-
-            ## TODO the stuff about adaptive scans have to be moved into a dedicated extension. M
-            ## Most similat to the Bayesian one!
-            if self.scanner.scan_sub_type == 'Adaptive':
-                #todo include this in scanners objects for the adaptive scanners
-                if len(self.modules_manager.get_selected_probed_data('0D')) == 0:
-                    messagebox(
-                        text="In adaptive mode, you have to pick a 0D signal from which the "
-                             "algorithm will determine the next positions to scan, see 'probe_data'"
-                             " in the modules selector panel")
-                    return False
 
             self.ui.n_scan_steps = self.scanner.n_steps
 
@@ -906,6 +899,7 @@ class DAQScan(QObject, ParameterManager):
         if self.ui.is_action_checked('move_at'):
             self.ui.get_action('move_at').trigger()
 
+        self._module_and_data_saver.h5saver = self.h5saver
         res = self.set_scan()
         if res:
             # deactivate module controls using remote_control
@@ -925,9 +919,9 @@ class DAQScan(QObject, ParameterManager):
             else:
                 scan_shape = self.scanner.get_scan_shape()
             for det in self.modules_manager.detectors:
-                det.module_and_data_saver = (
+                det._module_and_data_saver = (
                     module_saving.DetectorExtendedSaver(det, scan_shape))
-            self.module_and_data_saver.h5saver = self.h5saver  # force the update as the h5saver ill also be set on each detectors
+            self._module_and_data_saver.h5saver = self.h5saver  # force the update as the h5saver will also be set on each detectors
 
             # mandatory to deal with multithreads
             if self.runner_thread is not None:

--- a/packages/pymodaq/src/pymodaq/utils/h5modules/module_saving.py
+++ b/packages/pymodaq/src/pymodaq/utils/h5modules/module_saving.py
@@ -377,10 +377,15 @@ class ScanSaver(ModuleSaver):
         self._module: DAQScan = module
         self._h5saver = None
 
+        for detector in self._module.modules_manager.detectors_all:
+            detector._module_and_data_saver = DetectorSaver(detector)
+        for actuator in self._module.modules_manager.actuators_all:
+            actuator._module_and_data_saver = ActuatorSaver(actuator)
+
     def update_after_h5changed(self):
         for module in self._module.modules_manager.modules_all:
-            if hasattr(module, 'module_and_data_saver'):
-                module.module_and_data_saver.h5saver = self.h5saver
+            if hasattr(module, '_module_and_data_saver'):
+                module._module_and_data_saver.h5saver = self.h5saver
 
     def forget_h5(self):
         for module in self._module.modules_manager.modules_all:

--- a/packages/pymodaq/src/pymodaq/utils/managers/modules_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/modules_manager.py
@@ -194,14 +194,13 @@ class ModulesManager(QObject, ParameterManager):
         return self.get_mods_from_names(self.selected_detectors_name)
 
     @property
-    def detectors_all(self):
+    def detectors_all(self)  -> List['DAQ_Viewer']:
         """Get/Set the list of all detectors"""
         return self._detectors
 
     @detectors_all.setter
     def detectors_all(self, detectors: List['DAQ_Viewer']):
         self._detectors = detectors
-
 
     @property
     def actuators(self) -> List['DAQ_Move']:


### PR DESCRIPTION
fixes #815 

The DAQ_Move created at instanciation an instance of a H5Saver to store DataActuator data when looping the get_actuator_value. But it's not needed at startup, it should be started only when looping.

Data were not even saved... now they are stored everytime one clicks the loop action