### PR TITLE
Feature/widget synchronizer: Adding bind_parameter method

### DIFF
--- a/docs/src/developer_folder/widget_sync.rst
+++ b/docs/src/developer_folder/widget_sync.rst
@@ -750,11 +750,12 @@ WidgetSync automatically detects when to use DictSync:
 DictSync Binding Methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-DictSync provides three binding methods:
+DictSync provides four binding methods:
 
 1. **bind()** - For widgets that work with entire dict (JSON editors, displays)
-2. **bind_properties()** - For multiple properties of ONE widget
-3. **bind_dict()** - For DIFFERENT widgets mapped to dict keys
+2. **bind_properties()** - For multiple properties of ONE widget (regular Qt widgets)
+3. **bind_parameter()** - For pyqtgraph Parameters (avoids blockSignals issue)
+4. **bind_dict()** - For DIFFERENT widgets mapped to dict keys
 
 Method 1: bind() - Entire Dict
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -895,6 +896,210 @@ For mapping different widgets to different dictionary keys:
             }
         }
     )
+
+Binding Parameters with bind_parameter()
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``bind_parameter()`` method is specifically designed for binding pyqtgraph Parameters
+to DictSync. Unlike ``bind_properties()``, it avoids the ``blockSignals()`` issue that
+prevents parameter tree widgets from updating visually.
+
+**When to Use Which Method:**
+
+- Use ``bind_properties()`` for regular Qt widgets (QSpinBox, QComboBox, etc.)
+- Use ``bind_parameter()`` for pyqtgraph Parameters
+
+**Why bind_parameter() Exists:**
+
+The ``blockSignals()`` mechanism used by ``bind_properties()`` prevents feedback loops,
+but it also prevents parameter tree widgets from updating. Parameters manage their own
+internal widgets, so we need callback disconnection instead of signal blocking.
+
+Basic Parameter Binding
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    from pymodaq_gui.parameter import Parameter, ParameterTree
+    from pymodaq_gui.utils.widget_sync import WidgetSync, SyncMode
+
+    # Create parameters
+    params = [
+        {'title': 'Threshold:', 'name': 'threshold', 'type': 'float',
+         'value': 0.5, 'limits': (0.0, 1.0)},
+        {'title': 'Buffer Size:', 'name': 'buffer_size', 'type': 'int',
+         'value': 1024, 'limits': (128, 8192)},
+    ]
+
+    settings = Parameter.create(name='settings', type='group',
+                               children=params)
+    tree = ParameterTree()
+    tree.setParameters(settings)
+
+    # Create sync with toolbar widgets
+    sync = WidgetSync(initial_value={
+        'threshold': 0.5,
+        'buffer_size': 1024
+    })
+
+    # Bind toolbar widgets (regular Qt widgets)
+    sync.bind_properties(
+        threshold_spinbox,
+        property_map={'threshold': {'property': 'value'}}
+    )
+
+    sync.bind_properties(
+        buffer_spinbox,
+        property_map={'buffer_size': {'property': 'value'}}
+    )
+
+    # Bind parameters (use bind_parameter - NOT bind_properties!)
+    sync.bind_parameter(
+        settings.child('threshold'),
+        property_map={
+            'threshold': {
+                'signal': settings.child('threshold').sigValueChanged,
+                'getter': settings.child('threshold').value,
+                'setter': settings.child('threshold').setValue,
+            }
+        }
+    )
+
+    sync.bind_parameter(
+        settings.child('buffer_size'),
+        property_map={
+            'buffer_size': {
+                'signal': settings.child('buffer_size').sigValueChanged,
+                'getter': settings.child('buffer_size').value,
+                'setter': settings.child('buffer_size').setValue,
+            }
+        }
+    )
+
+Now changing values in the toolbar spinboxes updates the parameter tree, and vice versa!
+
+Shortcut Syntax for Simple Parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For simple parameter value synchronization, use the shortcut syntax:
+
+.. code-block:: python
+
+    # Shortcut: Auto-generates sigValueChanged, value(), setValue()
+    sync.bind_parameter(
+        threshold_param,
+        property_map={
+            'threshold': {'param': threshold_param}
+        }
+    )
+
+    # Equivalent to:
+    sync.bind_parameter(
+        threshold_param,
+        property_map={
+            'threshold': {
+                'signal': threshold_param.sigValueChanged,
+                'getter': threshold_param.value,
+                'setter': threshold_param.setValue,
+                'mode': SyncMode.BIDIRECTIONAL
+            }
+        }
+    )
+
+The shortcut syntax is ideal for simple cases where you just want to sync the parameter value.
+
+Binding List Parameters (ComboBox)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+List parameters require syncing both the options (limits) and the selected value:
+
+.. code-block:: python
+
+    # Create a list parameter
+    params = [
+        {'title': 'Algorithm:', 'name': 'algorithm', 'type': 'list',
+         'limits': ['FFT', 'Wavelet', 'Correlation'], 'value': 'FFT'},
+    ]
+
+    settings = Parameter.create(name='settings', type='group',
+                               children=params)
+    algorithm_param = settings.child('algorithm')
+
+    # Create sync for both limits and value
+    sync = WidgetSync(initial_value={
+        'algorithms': ['FFT', 'Wavelet', 'Correlation'],
+        'algorithm': 'FFT'
+    })
+
+    # Bind toolbar combobox (regular Qt widget)
+    sync.bind_properties(
+        algorithm_combo,
+        property_map={
+            'algorithms': {
+                'signal': None,  # FROM_SYNC only
+                'getter': lambda: [algorithm_combo.itemText(i)
+                                  for i in range(algorithm_combo.count())],
+                'setter': lambda items: (algorithm_combo.clear(),
+                                        algorithm_combo.addItems(items)),
+                'mode': SyncMode.FROM_SYNC
+            },
+            'algorithm': {
+                'signal': algorithm_combo.currentTextChanged,
+                'getter': lambda: algorithm_combo.currentText(),
+                'setter': lambda text: algorithm_combo.setCurrentText(text),
+            }
+        }
+    )
+
+    # Bind parameter (use bind_parameter!)
+    sync.bind_parameter(
+        algorithm_param,
+        property_map={
+            'algorithms': {
+                'getter': lambda: algorithm_param.opts['limits'],
+                'setter': algorithm_param.setLimits,
+                'mode': SyncMode.FROM_SYNC,
+            },
+            'algorithm': {
+                'signal': algorithm_param.sigValueChanged,
+                'getter': algorithm_param.value,
+                'setter': algorithm_param.setValue,
+            }
+        }
+    )
+
+Now the combobox, parameter value, and parameter tree all stay synchronized!
+
+Parameter Signal Details
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Important:** Parameter signals emit ``(param, value)`` tuples, not just values:
+
+.. code-block:: python
+
+    # Parameter signals emit (param, value)
+    def on_param_changed(param, value):
+        print(f"{param.name()} changed to {value}")
+
+    my_param.sigValueChanged.connect(on_param_changed)
+
+The ``bind_parameter()`` method automatically handles this by extracting the value
+from the ``(param, value)`` tuple before passing it to the sync system.
+
+Complete Example
+^^^^^^^^^^^^^^^^
+
+See ``pymodaq_gui/examples/widget_sync/6_parameter_binding_example.py`` for a complete
+working example showing:
+
+- Syncing multiple parameter types (list, int, float, bool)
+- Toolbar + parameter tree staying synchronized
+- Both shortcut and manual syntax
+- Programmatic value changes
+
+.. code-block:: bash
+
+    python -m pymodaq_gui.examples.widget_sync.6_parameter_binding_example
 
 Validation with DictSync
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1463,6 +1668,9 @@ Complete examples demonstrating widget synchronization are available:
 
     # Level 5: Extending widget_sync (custom factories, validators, sync classes)
     python -m pymodaq_gui.examples.widget_sync.5_extending_sync_example
+
+    # Level 6: Parameter binding (pyqtgraph Parameters with bind_parameter())
+    python -m pymodaq_gui.examples.widget_sync.6_parameter_binding_example
 
 See Also
 --------

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync/6_parameter_binding_example.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync/6_parameter_binding_example.py
@@ -1,0 +1,491 @@
+"""
+Example 6: Parameter Binding with bind_parameter()
+===================================================
+
+Demonstrates how to bind pyqtgraph Parameters to WidgetSync using the new
+bind_parameter() method, which avoids the blockSignals() issue that prevents
+parameter tree widgets from updating.
+
+Key Concepts
+------------
+- Use bind_parameter() for pyqtgraph Parameters (not bind_properties())
+- Sync both parameter opts (limits) and values
+- Bidirectional synchronization between parameter tree and external widgets
+- Clean API without manual signal connection boilerplate
+- Multiple tabs with different parameter groups
+
+Run
+---
+python -m pymodaq_gui.examples.widget_sync.6_parameter_binding_example
+"""
+
+import sys
+from qtpy.QtWidgets import (QApplication, QWidget, QVBoxLayout, QHBoxLayout,
+                             QLabel, QComboBox, QSpinBox, QCheckBox,
+                             QGroupBox, QMainWindow, QDockWidget,
+                             QPushButton, QDoubleSpinBox, QTabWidget, QLineEdit,
+                             QFormLayout)
+from qtpy.QtCore import Qt
+
+from pymodaq_gui.parameter import Parameter, ParameterTree
+from pymodaq_gui.utils.widget_sync import WidgetSync, SyncMode
+
+
+class ParameterBindingExample(QMainWindow):
+    """
+    Example showing how to use bind_parameter() to sync Parameters with widgets.
+
+    Demonstrates:
+    - Syncing list parameters (opts + value)
+    - Syncing numeric parameters (int, float)
+    - Syncing boolean and string parameters
+    - Multiple tabs with different parameter groups
+    - Parameter tree staying synchronized with all tabs
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Example 6: Parameter Binding with Tabs")
+        self.resize(1200, 700)
+
+        # Data lists
+        self.algorithms = ['FFT', 'Wavelet', 'Correlation', 'ML-Enhanced', 'Adaptive']
+        self.modes = ['Continuous', 'Single Shot', 'Triggered']
+        self.units = ['mm', 'µm', 'nm']
+
+        # Create central widget
+        central = QWidget()
+        self.setCentralWidget(central)
+        layout = QVBoxLayout(central)
+
+        # Description
+        desc = QLabel(
+            "bind_parameter() Method for Parameters\n"
+            "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+            "• Use bind_parameter() for pyqtgraph Parameters\n"
+            "• Use bind_properties() for regular Qt widgets\n"
+            "• Change values in any tab → parameter tree updates\n"
+            "• Change values in tree → all tabs update\n"
+            "• No manual signal connections needed!"
+        )
+        desc.setStyleSheet("font-family: monospace; padding: 10px;")
+        layout.addWidget(desc)
+
+        # Create tab widget for different control groups
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs)
+
+        # Create parameters
+        self.params = [
+            {'title': 'Processing:', 'name': 'processing', 'type': 'group', 'children': [
+                {'title': 'Algorithm:', 'name': 'algorithm', 'type': 'list',
+                 'limits': self.algorithms, 'value': 'FFT'},
+                {'title': 'Buffer Size:', 'name': 'buffer_size', 'type': 'int',
+                 'value': 1024, 'limits': (128, 8192), 'step': 128},
+                {'title': 'Threshold:', 'name': 'threshold', 'type': 'float',
+                 'value': 0.5, 'limits': (0.0, 1.0), 'step': 0.1},
+                {'title': 'Auto Process:', 'name': 'auto_process', 'type': 'bool',
+                 'value': True},
+            ]},
+            {'title': 'Acquisition:', 'name': 'acquisition', 'type': 'group', 'children': [
+                {'title': 'Mode:', 'name': 'mode', 'type': 'list',
+                 'limits': self.modes, 'value': 'Continuous'},
+                {'title': 'Samples:', 'name': 'samples', 'type': 'int',
+                 'value': 100, 'limits': (10, 10000)},
+                {'title': 'Averaging:', 'name': 'averaging', 'type': 'int',
+                 'value': 1, 'limits': (1, 100)},
+                {'title': 'Enable Trigger:', 'name': 'enable_trigger', 'type': 'bool',
+                 'value': False},
+            ]},
+            {'title': 'Position:', 'name': 'position', 'type': 'group', 'children': [
+                {'title': 'Units:', 'name': 'units', 'type': 'list',
+                 'limits': self.units, 'value': 'mm'},
+                {'title': 'Target:', 'name': 'target', 'type': 'float',
+                 'value': 10.0, 'limits': (0.0, 100.0), 'step': 0.1},
+                {'title': 'Speed:', 'name': 'speed', 'type': 'float',
+                 'value': 1.0, 'limits': (0.1, 10.0), 'step': 0.1},
+                {'title': 'Label:', 'name': 'label', 'type': 'str',
+                 'value': 'Position 1'},
+            ]},
+        ]
+
+        self.settings = Parameter.create(name='settings', type='group',
+                                        children=self.params, showTop=False)
+
+        # Create tab pages with widgets
+        self.create_processing_tab()
+        self.create_acquisition_tab()
+        self.create_position_tab()
+
+        # Create parameter tree in dock
+        self.settings_dock = QDockWidget("Full Parameter Tree", self)
+        self.tree = ParameterTree()
+        self.tree.setParameters(self.settings, showTop=False)
+        self.settings_dock.setWidget(self.tree)
+        self.addDockWidget(Qt.RightDockWidgetArea, self.settings_dock)
+
+        # Status display
+        status_group = QGroupBox("Synchronization Status")
+        status_layout = QVBoxLayout(status_group)
+        self.status_label = QLabel()
+        self.status_label.setStyleSheet("padding: 10px; font-family: monospace;")
+        status_layout.addWidget(self.status_label)
+        layout.addWidget(status_group)
+
+        # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+        # ✅ SETUP SYNCHRONIZATION
+        # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+        # Create DictSync with initial parameter values
+        self.sync = WidgetSync(initial_value={
+            # Processing
+            'algorithms': self.algorithms,
+            'algorithm': 'FFT',
+            'buffer_size': 1024,
+            'threshold': 0.5,
+            'auto_process': True,
+            # Acquisition
+            'modes': self.modes,
+            'mode': 'Continuous',
+            'samples': 100,
+            'averaging': 1,
+            'enable_trigger': False,
+            # Position
+            'units_list': self.units,
+            'units': 'mm',
+            'target': 10.0,
+            'speed': 1.0,
+            'label': 'Position 1',
+        })
+
+        # Bind all widgets and parameters
+        self.bind_processing()
+        self.bind_acquisition()
+        self.bind_position()
+
+        # Update status when sync changes
+        self.sync.value_changed.connect(self.update_status)
+        self.update_status(self.sync.value)
+
+    def create_processing_tab(self):
+        """Create Processing tab with widgets"""
+        tab = QWidget()
+        layout = QFormLayout(tab)
+
+        # Algorithm combo
+        self.algorithm_combo = QComboBox()
+        self.algorithm_combo.addItems(self.algorithms)
+        self.algorithm_combo.setCurrentText('FFT')
+        layout.addRow("Algorithm:", self.algorithm_combo)
+
+        # Buffer size spinner
+        self.buffer_spin = QSpinBox()
+        self.buffer_spin.setRange(128, 8192)
+        self.buffer_spin.setSingleStep(128)
+        self.buffer_spin.setValue(1024)
+        self.buffer_spin.setSuffix(" samples")
+        layout.addRow("Buffer Size:", self.buffer_spin)
+
+        # Threshold spinner
+        self.threshold_spin = QDoubleSpinBox()
+        self.threshold_spin.setRange(0.0, 1.0)
+        self.threshold_spin.setSingleStep(0.1)
+        self.threshold_spin.setValue(0.5)
+        self.threshold_spin.setDecimals(2)
+        layout.addRow("Threshold:", self.threshold_spin)
+
+        # Auto process checkbox
+        self.auto_check = QCheckBox()
+        self.auto_check.setChecked(True)
+        layout.addRow("Auto Process:", self.auto_check)
+
+        # Test button
+        test_btn = QPushButton("Set Test Values")
+        test_btn.clicked.connect(self.set_test_values)
+        layout.addRow("", test_btn)
+
+        self.tabs.addTab(tab, "Processing")
+
+    def create_acquisition_tab(self):
+        """Create Acquisition tab with widgets"""
+        tab = QWidget()
+        layout = QFormLayout(tab)
+
+        # Mode combo
+        self.mode_combo = QComboBox()
+        self.mode_combo.addItems(self.modes)
+        self.mode_combo.setCurrentText('Continuous')
+        layout.addRow("Mode:", self.mode_combo)
+
+        # Samples spinner
+        self.samples_spin = QSpinBox()
+        self.samples_spin.setRange(10, 10000)
+        self.samples_spin.setValue(100)
+        layout.addRow("Samples:", self.samples_spin)
+
+        # Averaging spinner
+        self.averaging_spin = QSpinBox()
+        self.averaging_spin.setRange(1, 100)
+        self.averaging_spin.setValue(1)
+        layout.addRow("Averaging:", self.averaging_spin)
+
+        # Enable trigger checkbox
+        self.trigger_check = QCheckBox()
+        self.trigger_check.setChecked(False)
+        layout.addRow("Enable Trigger:", self.trigger_check)
+
+        self.tabs.addTab(tab, "Acquisition")
+
+    def create_position_tab(self):
+        """Create Position tab with widgets"""
+        tab = QWidget()
+        layout = QFormLayout(tab)
+
+        # Units combo
+        self.units_combo = QComboBox()
+        self.units_combo.addItems(self.units)
+        self.units_combo.setCurrentText('mm')
+        layout.addRow("Units:", self.units_combo)
+
+        # Target spinner
+        self.target_spin = QDoubleSpinBox()
+        self.target_spin.setRange(0.0, 100.0)
+        self.target_spin.setSingleStep(0.1)
+        self.target_spin.setValue(10.0)
+        self.target_spin.setDecimals(1)
+        layout.addRow("Target:", self.target_spin)
+
+        # Speed spinner
+        self.speed_spin = QDoubleSpinBox()
+        self.speed_spin.setRange(0.1, 10.0)
+        self.speed_spin.setSingleStep(0.1)
+        self.speed_spin.setValue(1.0)
+        self.speed_spin.setDecimals(1)
+        layout.addRow("Speed:", self.speed_spin)
+
+        # Label edit
+        self.label_edit = QLineEdit()
+        self.label_edit.setText('Position 1')
+        layout.addRow("Label:", self.label_edit)
+
+        self.tabs.addTab(tab, "Position")
+
+    def bind_processing(self):
+        """Bind Processing tab widgets and parameters"""
+        processing_group = self.settings.child('processing')
+
+        # Bind widgets (regular Qt widgets - use bind_properties)
+        self.sync.bind_properties(
+            self.algorithm_combo,
+            property_map={
+                'algorithms': {
+                    'signal': None,
+                    'getter': lambda: [self.algorithm_combo.itemText(i)
+                                      for i in range(self.algorithm_combo.count())],
+                    'setter': lambda items: (self.algorithm_combo.clear(),
+                                            self.algorithm_combo.addItems(items)),
+                    'mode': SyncMode.FROM_SYNC,
+                },
+                'algorithm': {
+                    'signal': self.algorithm_combo.currentTextChanged,
+                    'getter': lambda: self.algorithm_combo.currentText(),
+                    'setter': lambda text: self.algorithm_combo.setCurrentText(text),
+                }
+            }
+        )
+
+        self.sync.bind_properties(
+            self.buffer_spin,
+            property_map={'buffer_size': {'property': 'value'}}
+        )
+
+        self.sync.bind_properties(
+            self.threshold_spin,
+            property_map={'threshold': {'property': 'value'}}
+        )
+
+        self.sync.bind_properties(
+            self.auto_check,
+            property_map={'auto_process': {'property': 'checked'}}
+        )
+
+        # Bind parameters (use bind_parameter - NOT bind_properties!)
+        self.sync.bind_parameter(
+            processing_group.child('algorithm'),
+            property_map={
+                'algorithms': {
+                    'getter': lambda: processing_group.child('algorithm').opts['limits'],
+                    'setter': lambda limits: processing_group.child('algorithm').setLimits(limits),
+                    'mode': SyncMode.FROM_SYNC,
+                },
+                'algorithm': {'param': processing_group.child('algorithm')}
+            }
+        )
+
+        self.sync.bind_parameter(
+            processing_group.child('buffer_size'),
+            property_map={'buffer_size': {'param': processing_group.child('buffer_size')}}
+        )
+
+        self.sync.bind_parameter(
+            processing_group.child('threshold'),
+            property_map={'threshold': {'param': processing_group.child('threshold')}}
+        )
+
+        self.sync.bind_parameter(
+            processing_group.child('auto_process'),
+            property_map={'auto_process': {'param': processing_group.child('auto_process')}}
+        )
+
+    def bind_acquisition(self):
+        """Bind Acquisition tab widgets and parameters"""
+        acquisition_group = self.settings.child('acquisition')
+
+        # Bind widgets
+        self.sync.bind_properties(
+            self.mode_combo,
+            property_map={
+                'modes': {
+                    'signal': None,
+                    'getter': lambda: [self.mode_combo.itemText(i)
+                                      for i in range(self.mode_combo.count())],
+                    'setter': lambda items: (self.mode_combo.clear(),
+                                            self.mode_combo.addItems(items)),
+                    'mode': SyncMode.FROM_SYNC,
+                },
+                'mode': {'property': 'currentText'}
+            }
+        )
+
+        self.sync.bind_properties(self.samples_spin, property_map={'samples': {'property': 'value'}})
+        self.sync.bind_properties(self.averaging_spin, property_map={'averaging': {'property': 'value'}})
+        self.sync.bind_properties(self.trigger_check, property_map={'enable_trigger': {'property': 'checked'}})
+
+        # Bind parameters
+        self.sync.bind_parameter(
+            acquisition_group.child('mode'),
+            property_map={
+                'modes': {
+                    'getter': lambda: acquisition_group.child('mode').opts['limits'],
+                    'setter': lambda limits: acquisition_group.child('mode').setLimits(limits),
+                    'mode': SyncMode.FROM_SYNC,
+                },
+                'mode': {'param': acquisition_group.child('mode')}
+            }
+        )
+
+        self.sync.bind_parameter(acquisition_group.child('samples'),
+                                property_map={'samples': {'param': acquisition_group.child('samples')}})
+        self.sync.bind_parameter(acquisition_group.child('averaging'),
+                                property_map={'averaging': {'param': acquisition_group.child('averaging')}})
+        self.sync.bind_parameter(acquisition_group.child('enable_trigger'),
+                                property_map={'enable_trigger': {'param': acquisition_group.child('enable_trigger')}})
+
+    def bind_position(self):
+        """Bind Position tab widgets and parameters"""
+        position_group = self.settings.child('position')
+
+        # Bind widgets
+        self.sync.bind_properties(
+            self.units_combo,
+            property_map={
+                'units_list': {
+                    'signal': None,
+                    'getter': lambda: [self.units_combo.itemText(i)
+                                      for i in range(self.units_combo.count())],
+                    'setter': lambda items: (self.units_combo.clear(),
+                                            self.units_combo.addItems(items)),
+                    'mode': SyncMode.FROM_SYNC,
+                },
+                'units': {'property': 'currentText'}
+            }
+        )
+
+        self.sync.bind_properties(self.target_spin, property_map={'target': {'property': 'value'}})
+        self.sync.bind_properties(self.speed_spin, property_map={'speed': {'property': 'value'}})
+        self.sync.bind_properties(self.label_edit, property_map={'label': {'property': 'text'}})
+
+        # Bind parameters
+        self.sync.bind_parameter(
+            position_group.child('units'),
+            property_map={
+                'units_list': {
+                    'getter': lambda: position_group.child('units').opts['limits'],
+                    'setter': lambda limits: position_group.child('units').setLimits(limits),
+                    'mode': SyncMode.FROM_SYNC,
+                },
+                'units': {'param': position_group.child('units')}
+            }
+        )
+
+        self.sync.bind_parameter(position_group.child('target'),
+                                property_map={'target': {'param': position_group.child('target')}})
+        self.sync.bind_parameter(position_group.child('speed'),
+                                property_map={'speed': {'param': position_group.child('speed')}})
+        self.sync.bind_parameter(position_group.child('label'),
+                                property_map={'label': {'param': position_group.child('label')}})
+
+    def set_test_values(self):
+        """Programmatically change values to test synchronization"""
+        self.sync.value = {
+            # Processing
+            'algorithms': self.algorithms,
+            'algorithm': 'Wavelet',
+            'buffer_size': 2048,
+            'threshold': 0.8,
+            'auto_process': False,
+            # Acquisition
+            'modes': self.modes,
+            'mode': 'Triggered',
+            'samples': 500,
+            'averaging': 5,
+            'enable_trigger': True,
+            # Position
+            'units_list': self.units,
+            'units': 'µm',
+            'target': 50.0,
+            'speed': 5.0,
+            'label': 'Test Position',
+        }
+
+    def update_status(self, value_dict):
+        """Update status display"""
+        status_text = f"""
+Sync State:
+  Processing:
+    Algorithm:    {value_dict.get('algorithm', 'N/A')}
+    Buffer Size:  {value_dict.get('buffer_size', 'N/A')}
+    Threshold:    {value_dict.get('threshold', 'N/A')}
+    Auto Process: {value_dict.get('auto_process', 'N/A')}
+
+  Acquisition:
+    Mode:          {value_dict.get('mode', 'N/A')}
+    Samples:       {value_dict.get('samples', 'N/A')}
+    Averaging:     {value_dict.get('averaging', 'N/A')}
+    Enable Trigger:{value_dict.get('enable_trigger', 'N/A')}
+
+  Position:
+    Units:   {value_dict.get('units', 'N/A')}
+    Target:  {value_dict.get('target', 'N/A')}
+    Speed:   {value_dict.get('speed', 'N/A')}
+    Label:   {value_dict.get('label', 'N/A')}
+
+✅ All synchronized across tabs and parameter tree!
+        """
+        self.status_label.setText(status_text.strip())
+
+
+def main():
+    """Run the example"""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication(sys.argv)
+
+    window = ParameterBindingExample()
+    window.show()
+
+    sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
@@ -290,18 +290,31 @@ class BaseWidgetSync(QObject):
         connection_info['property_key'] = property_key
         self._connections[(widget_id, property_key)] = connection_info
 
-    def _remove_connection(self, widget_id: int, property_key: str | None = None) -> None:
-        """Remove connection and disconnect callbacks."""
+    def _remove_connection(self, widget_id: int, property_key: str | None = None,
+                          is_destruction: bool = False) -> None:
+        """
+        Remove connection and disconnect callbacks.
+
+        Parameters
+        ----------
+        widget_id : int
+            Widget ID
+        property_key : str | None
+            Property key
+        is_destruction : bool
+            True if called during widget destruction (skip parameter signal disconnection)
+        """
         key = (widget_id, property_key)
         if conn := self._connections.get(key):
-            self._disconnect_callbacks(conn['callbacks'])
+            param_callbacks = conn.get('param_callbacks') if not is_destruction else None
+            self._disconnect_callbacks(conn['callbacks'], param_callbacks)
             del self._connections[key]
 
     def _get_connection_keys_for_widget(self, widget_id: int) -> list[tuple[int, str | None]]:
         """Get all connection keys for a widget."""
         return [k for k in self._connections if k[0] == widget_id]
 
-    def _disconnect_callbacks(self, callbacks: list) -> None:
+    def _disconnect_callbacks(self, callbacks: list, param_callbacks: dict = None) -> None:
         """
         Disconnect sync callbacks from value_changed signal.
 
@@ -311,6 +324,8 @@ class BaseWidgetSync(QObject):
         ----------
         callbacks : list
             List of callback tuples (callback_type, callback)
+        param_callbacks : dict, optional
+            Dict of parameter-specific callbacks to disconnect (for bind_parameter)
         """
         for callback_type, callback in callbacks:
             if callback_type == 'sync':
@@ -318,6 +333,21 @@ class BaseWidgetSync(QObject):
                     self.value_changed.disconnect(callback)
                 except (TypeError, RuntimeError):
                     pass  # Already disconnected
+
+        # Disconnect parameter signal callbacks (only if param_callbacks is provided)
+        # Note: param_callbacks is None during widget destruction to avoid Qt warnings
+        # when the Parameter is being destroyed. Qt automatically disconnects signals
+        # during object destruction, so explicit disconnection is not needed and can
+        # cause warnings.
+        if param_callbacks:
+            for key, value in list(param_callbacks.items()):
+                if key[1] == 'param_to_sync':
+                    # value is (signal, callback)
+                    signal, callback = value
+                    try:
+                        signal.disconnect(callback)
+                    except (TypeError, RuntimeError):
+                        pass  # Already disconnected
 
     # Widget Lifecycle Methods
 
@@ -333,7 +363,8 @@ class BaseWidgetSync(QObject):
             sync = sync_weak()
             if sync is not None:
                 for key in connection_keys:
-                    sync._remove_connection(key[0], key[1])
+                    # Pass is_destruction=True to skip parameter signal disconnection
+                    sync._remove_connection(key[0], key[1], is_destruction=True)
 
         widget.destroyed.connect(on_destroyed)
 
@@ -1550,6 +1581,195 @@ class DictSync(BaseWidgetSync):
 
         # Setup widget destruction callback once for all properties
         self._setup_widget_destruction_callback(widget, all_connection_keys)
+
+    def bind_parameter(self, parameter, property_map: dict[str, dict[str, Any]],
+                      init_from: InitFrom = 'sync') -> None:
+        """
+        Bind multiple properties of a Parameter to different dict keys.
+
+        **IMPORTANT**: Use this method instead of bind_properties() for pyqtgraph
+        Parameters. bind_properties() uses blockSignals() which prevents parameter
+        tree widgets from updating. This method uses callback disconnection instead.
+
+        Parameters
+        ----------
+        parameter : Parameter
+            The pyqtgraph Parameter to bind
+        property_map : dict[str, dict]
+            Mapping of dict keys to parameter property configurations.
+            Each key maps to a dict with:
+
+            **Shortcut for parameter value** (most common case):
+            - 'param': Parameter - Automatically uses sigValueChanged, value(), setValue()
+              This is equivalent to specifying signal/getter/setter manually
+
+            **OR Manual specification**:
+            - 'getter': callable () -> value - Function to get parameter value
+            - 'setter': callable (value) -> None - Function to set parameter value
+            - 'signal': Signal (optional) - Parameter signal for bidirectional sync
+              (Note: Parameter signals emit (param, value), this is handled automatically)
+            - 'mode': SyncMode (optional) - BIDIRECTIONAL, TO_SYNC, or FROM_SYNC
+              (default: BIDIRECTIONAL if signal provided, else FROM_SYNC)
+
+        init_from : InitFrom, optional
+            Initialization source: 'sync' (default), 'widget', or 'none'
+
+        Raises
+        ------
+        TypeError
+            If sync value is not a dict
+        ValueError
+            If property configuration is invalid
+
+        Examples
+        --------
+        >>> # Shortcut syntax (recommended for simple value sync)
+        >>> sync = WidgetSync(initial_value={'threshold': 0.5})
+        >>> sync.bind_parameter(
+        ...     threshold_param,
+        ...     property_map={'threshold': {'param': threshold_param}}
+        ... )
+
+        >>> # Manual syntax (for custom getter/setter or limits)
+        >>> algo_sync = WidgetSync(initial_value={'algorithms': [...], 'algorithm': 'FFT'})
+        >>> algo_sync.bind_parameter(
+        ...     algorithm_param,
+        ...     property_map={
+        ...         'algorithms': {
+        ...             'getter': lambda: algorithm_param.opts['limits'],
+        ...             'setter': algorithm_param.setLimits,
+        ...             'mode': SyncMode.FROM_SYNC,
+        ...         },
+        ...         'algorithm': {'param': algorithm_param}  # Shortcut for value
+        ...     }
+        ... )
+
+        See Also
+        --------
+        bind_properties : For regular Qt widgets (uses blockSignals)
+        bind_dict : For binding different widgets to different dict keys
+        """
+        if not isinstance(self.value, dict):
+            raise TypeError(
+                f"bind_parameter() requires DictSync (sync value must be dict). "
+                f"Got {type(self.value).__name__}"
+            )
+
+        param_id = id(parameter)
+        param_ref = ref(parameter)
+
+        # Collect all connection keys for destruction callback
+        all_connection_keys = [(param_id, prop_key) for prop_key in property_map.keys()]
+
+        # Store param callbacks for feedback loop prevention across all properties
+        # This dict is shared across all properties of this parameter
+        all_param_callbacks = {}
+
+        for property_key, config in property_map.items():
+            # Check for shortcut syntax
+            if 'param' in config:
+                # Shortcut: {'param': parameter} auto-generates signal/getter/setter
+                param_obj = config['param']
+                signal = param_obj.sigValueChanged
+                getter = param_obj.value
+                setter = param_obj.setValue
+                mode = config.get('mode', SyncMode.BIDIRECTIONAL)
+            else:
+                # Manual specification
+                signal = config.get('signal')
+                getter = config.get('getter')
+                setter = config.get('setter')
+                mode = config.get('mode', SyncMode.BIDIRECTIONAL if signal else SyncMode.FROM_SYNC)
+
+                if not getter and not setter:
+                    raise ValueError(
+                        f"Property '{property_key}': Must provide at least 'getter' or 'setter', "
+                        f"or use shortcut syntax with 'param'"
+                    )
+
+            # Initialize value based on init_from
+            if init_from == 'sync' and setter:
+                initial_value = self.value.get(property_key)
+                if initial_value is not None and getter:
+                    current_value = getter()
+                    if initial_value != current_value:
+                        setter(initial_value)
+            elif init_from == 'widget' and getter:
+                initial_value = getter()
+                if property_key not in self.value or self.value[property_key] != initial_value:
+                    new_dict = self.value.copy()
+                    new_dict[property_key] = initial_value
+                    self.value = new_dict
+
+            # Create connection info for this property
+            connection_info: ConnectionInfo = {
+                'widget': parameter,
+                'widget_ref': param_ref,
+                'callbacks': [],
+                'enabled': True,
+                'property_key': property_key,
+                'param_callbacks': all_param_callbacks  # Share across all properties
+            }
+
+            # Parameter → Sync (TO_SYNC or BIDIRECTIONAL)
+            if mode in (SyncMode.TO_SYNC, SyncMode.BIDIRECTIONAL) and signal and getter:
+                def make_param_to_sync_callback(key, get_fn, callbacks_ref):
+                    def on_param_change(param, value):
+                        # Get actual value using getter
+                        actual_value = get_fn()
+                        if actual_value != self.value.get(key):
+                            new_dict = self.value.copy()
+                            new_dict[key] = actual_value
+                            # Get the reverse callback to disconnect it
+                            reverse_cb = callbacks_ref.get((key, 'sync_to_param'))
+                            if reverse_cb:
+                                self.value_changed.disconnect(reverse_cb)
+                            try:
+                                self.value = new_dict
+                            finally:
+                                if reverse_cb:
+                                    self.value_changed.connect(reverse_cb)
+                    return on_param_change
+
+                callback = make_param_to_sync_callback(property_key, getter, all_param_callbacks)
+                signal.connect(callback)
+                all_param_callbacks[(property_key, 'param_to_sync')] = (signal, callback)
+                # Note: Don't add to connection_info['callbacks'] - Qt auto-disconnects
+
+            # Sync → Parameter (FROM_SYNC or BIDIRECTIONAL)
+            if mode in (SyncMode.FROM_SYNC, SyncMode.BIDIRECTIONAL) and setter:
+                def make_sync_to_param_callback(key, set_fn, get_fn, sig, mode_val, callbacks_ref):
+                    def on_sync_change(value_dict):
+                        new_value = value_dict.get(key)
+                        if new_value is not None:
+                            # Check if value changed
+                            current_value = get_fn() if get_fn else None
+                            if new_value != current_value:
+                                # Get the forward callback to disconnect it
+                                if sig and mode_val == SyncMode.BIDIRECTIONAL:
+                                    forward_cb_info = callbacks_ref.get((key, 'param_to_sync'))
+                                    if forward_cb_info:
+                                        sig.disconnect(forward_cb_info[1])
+                                    try:
+                                        set_fn(new_value)
+                                    finally:
+                                        if forward_cb_info:
+                                            sig.connect(forward_cb_info[1])
+                                else:
+                                    # FROM_SYNC mode - no disconnection needed
+                                    set_fn(new_value)
+                    return on_sync_change
+
+                callback = make_sync_to_param_callback(property_key, setter, getter, signal, mode, all_param_callbacks)
+                self.value_changed.connect(callback)
+                all_param_callbacks[(property_key, 'sync_to_param')] = callback
+                connection_info['callbacks'].append(('sync', callback))
+
+            # Store this property's connection
+            self._set_connection(param_id, property_key, connection_info)
+
+        # Setup parameter destruction callback once for all properties
+        self._setup_widget_destruction_callback(parameter, all_connection_keys)
 
     def bind_dict(self, property_map: dict[str, dict[str, Any]],
                  init_from: InitFrom = 'sync') -> None:

--- a/packages/pymodaq_gui/tests/utils/widget_sync_test.py
+++ b/packages/pymodaq_gui/tests/utils/widget_sync_test.py
@@ -13,6 +13,7 @@ Tests cover:
 - Sync modes
 - Memory management
 - Dict synchronization with bind_properties() and bind_dict()
+- Parameter binding with bind_parameter()
 """
 import pytest
 from qtpy.QtWidgets import (
@@ -1190,3 +1191,448 @@ class TestInitFromParameter:
 
         # Widget should be initialized with sync's value (backward compatible)
         assert spinbox.value() == 42
+
+
+class TestBindParameter:
+    """Test bind_parameter() method for pyqtgraph Parameters"""
+
+    def test_bind_parameter_basic(self, qtbot):
+        """Test basic parameter binding with manual specification"""
+        from pymodaq_gui.parameter import Parameter
+
+        # Create parameter
+        params = [
+            {'title': 'Value:', 'name': 'value', 'type': 'int', 'value': 42}
+        ]
+        settings = Parameter.create(name='settings', type='group', children=params)
+        value_param = settings.child('value')
+
+        # Create sync
+        sync = WidgetSync(initial_value={'value': 42})
+
+        # Bind parameter
+        sync.bind_parameter(
+            value_param,
+            property_map={
+                'value': {
+                    'signal': value_param.sigValueChanged,
+                    'getter': value_param.value,
+                    'setter': value_param.setValue,
+                }
+            }
+        )
+
+        # Check initial sync
+        assert value_param.value() == 42
+
+        # Change parameter -> sync updates
+        value_param.setValue(99)
+        assert sync.value['value'] == 99
+
+        # Change sync -> parameter updates
+        sync.value = {'value': 50}
+        assert value_param.value() == 50
+
+    def test_bind_parameter_shortcut_syntax(self, qtbot):
+        """Test bind_parameter() with shortcut syntax"""
+        from pymodaq_gui.parameter import Parameter
+
+        # Create parameter
+        params = [
+            {'title': 'Threshold:', 'name': 'threshold', 'type': 'float', 'value': 0.5}
+        ]
+        settings = Parameter.create(name='settings', type='group', children=params)
+        threshold_param = settings.child('threshold')
+
+        # Create sync
+        sync = WidgetSync(initial_value={'threshold': 0.5})
+
+        # Bind using shortcut syntax
+        sync.bind_parameter(
+            threshold_param,
+            property_map={
+                'threshold': {'param': threshold_param}
+            }
+        )
+
+        # Check initial sync
+        assert threshold_param.value() == 0.5
+
+        # Change parameter -> sync updates
+        threshold_param.setValue(0.8)
+        assert sync.value['threshold'] == 0.8
+
+        # Change sync -> parameter updates
+        sync.value = {'threshold': 0.2}
+        assert threshold_param.value() == 0.2
+
+    def test_bind_parameter_list_with_limits(self, qtbot):
+        """Test bind_parameter() with list parameter (sync both limits and value)"""
+        from pymodaq_gui.parameter import Parameter
+
+        algorithms = ['FFT', 'Wavelet', 'Correlation']
+
+        # Create parameter
+        params = [
+            {'title': 'Algorithm:', 'name': 'algorithm', 'type': 'list',
+             'limits': algorithms, 'value': 'FFT'}
+        ]
+        settings = Parameter.create(name='settings', type='group', children=params)
+        algorithm_param = settings.child('algorithm')
+
+        # Create sync for both limits and value
+        sync = WidgetSync(initial_value={
+            'algorithms': algorithms,
+            'algorithm': 'FFT'
+        })
+
+        # Bind parameter for both limits and value
+        sync.bind_parameter(
+            algorithm_param,
+            property_map={
+                'algorithms': {
+                    'getter': lambda: algorithm_param.opts['limits'],
+                    'setter': algorithm_param.setLimits,
+                    'mode': SyncMode.FROM_SYNC,
+                },
+                'algorithm': {
+                    'signal': algorithm_param.sigValueChanged,
+                    'getter': algorithm_param.value,
+                    'setter': algorithm_param.setValue,
+                }
+            }
+        )
+
+        # Check initial sync
+        assert algorithm_param.opts['limits'] == algorithms
+        assert algorithm_param.value() == 'FFT'
+
+        # Change sync value -> parameter updates
+        sync.value = {'algorithms': algorithms, 'algorithm': 'Wavelet'}
+        assert algorithm_param.value() == 'Wavelet'
+
+        # Change parameter value -> sync updates
+        algorithm_param.setValue('Correlation')
+        assert sync.value['algorithm'] == 'Correlation'
+
+        # Update limits via sync
+        new_algorithms = ['FFT', 'Wavelet', 'ML-Enhanced']
+        sync.value = {'algorithms': new_algorithms, 'algorithm': 'FFT'}
+        assert algorithm_param.opts['limits'] == new_algorithms
+        assert algorithm_param.value() == 'FFT'
+
+    def test_bind_parameter_multiple_types(self, qtbot):
+        """Test bind_parameter() with multiple parameter types"""
+        from pymodaq_gui.parameter import Parameter
+
+        # Create parameters
+        params = [
+            {'title': 'Int:', 'name': 'int_val', 'type': 'int', 'value': 42},
+            {'title': 'Float:', 'name': 'float_val', 'type': 'float', 'value': 3.14},
+            {'title': 'Bool:', 'name': 'bool_val', 'type': 'bool', 'value': True},
+            {'title': 'String:', 'name': 'str_val', 'type': 'str', 'value': 'test'},
+        ]
+        settings = Parameter.create(name='settings', type='group', children=params)
+
+        # Create sync
+        sync = WidgetSync(initial_value={
+            'int_val': 42,
+            'float_val': 3.14,
+            'bool_val': True,
+            'str_val': 'test'
+        })
+
+        # Bind all parameters using shortcut syntax
+        for param_name in ['int_val', 'float_val', 'bool_val', 'str_val']:
+            param = settings.child(param_name)
+            sync.bind_parameter(
+                param,
+                property_map={param_name: {'param': param}}
+            )
+
+        # Check initial sync
+        assert settings.child('int_val').value() == 42
+        assert settings.child('float_val').value() == 3.14
+        assert settings.child('bool_val').value() == True
+        assert settings.child('str_val').value() == 'test'
+
+        # Change sync -> all parameters update
+        sync.value = {
+            'int_val': 99,
+            'float_val': 2.71,
+            'bool_val': False,
+            'str_val': 'updated'
+        }
+        assert settings.child('int_val').value() == 99
+        assert settings.child('float_val').value() == 2.71
+        assert settings.child('bool_val').value() == False
+        assert settings.child('str_val').value() == 'updated'
+
+        # Change parameters -> sync updates
+        settings.child('int_val').setValue(50)
+        settings.child('float_val').setValue(1.41)
+        assert sync.value['int_val'] == 50
+        assert sync.value['float_val'] == 1.41
+
+    def test_bind_parameter_feedback_prevention(self, qtbot):
+        """Test that bind_parameter() prevents feedback loops without blockSignals()"""
+        from pymodaq_gui.parameter import Parameter
+
+        # Create parameter
+        params = [
+            {'title': 'Value:', 'name': 'value', 'type': 'int', 'value': 10}
+        ]
+        settings = Parameter.create(name='settings', type='group', children=params)
+        value_param = settings.child('value')
+
+        # Track setValue calls
+        setter_calls = {'count': 0}
+        original_setValue = value_param.setValue
+
+        def tracked_setValue(value):
+            setter_calls['count'] += 1
+            original_setValue(value)
+
+        value_param.setValue = tracked_setValue
+
+        # Create sync
+        sync = WidgetSync(initial_value={'value': 10})
+
+        # Bind parameter
+        sync.bind_parameter(
+            value_param,
+            property_map={
+                'value': {
+                    'signal': value_param.sigValueChanged,
+                    'getter': value_param.value,
+                    'setter': lambda v: value_param.setValue(v),
+                }
+            }
+        )
+
+        # Reset counter after initial sync
+        setter_calls['count'] = 0
+
+        # Change parameter value using original setter to trigger signal
+        original_setValue(50)
+
+        # Setter should NOT be called (feedback prevention)
+        # Only the sync should be updated
+        assert setter_calls['count'] == 0
+        assert sync.value['value'] == 50
+
+    def test_bind_parameter_with_widget_sync(self, qtbot):
+        """Test sync between parameter and regular Qt widget"""
+        from pymodaq_gui.parameter import Parameter
+
+        # Create parameter
+        params = [
+            {'title': 'Value:', 'name': 'value', 'type': 'int', 'value': 50}
+        ]
+        settings = Parameter.create(name='settings', type='group', children=params)
+        value_param = settings.child('value')
+
+        # Create Qt widget
+        spinbox = QSpinBox()
+        spinbox.setRange(0, 100)
+        spinbox.setValue(50)
+
+        # Create sync
+        sync = WidgetSync(initial_value={'value': 50})
+
+        # Bind both parameter and widget
+        sync.bind_parameter(
+            value_param,
+            property_map={
+                'value': {
+                    'signal': value_param.sigValueChanged,
+                    'getter': value_param.value,
+                    'setter': value_param.setValue,
+                }
+            }
+        )
+
+        sync.bind_properties(
+            spinbox,
+            property_map={'value': {'property': 'value'}}
+        )
+
+        # All should be in sync
+        assert value_param.value() == 50
+        assert spinbox.value() == 50
+        assert sync.value['value'] == 50
+
+        # Change parameter -> widget updates
+        value_param.setValue(75)
+        assert spinbox.value() == 75
+        assert sync.value['value'] == 75
+
+        # Change widget -> parameter updates
+        spinbox.setValue(25)
+        assert value_param.value() == 25
+        assert sync.value['value'] == 25
+
+        # Change sync -> both update
+        sync.value = {'value': 60}
+        assert value_param.value() == 60
+        assert spinbox.value() == 60
+
+    def test_bind_parameter_from_sync_mode(self, qtbot):
+        """Test bind_parameter() with FROM_SYNC mode (read-only)"""
+        from pymodaq_gui.parameter import Parameter
+
+        # Create parameter
+        params = [
+            {'title': 'Value:', 'name': 'value', 'type': 'int', 'value': 10}
+        ]
+        settings = Parameter.create(name='settings', type='group', children=params)
+        value_param = settings.child('value')
+
+        # Create sync
+        sync = WidgetSync(initial_value={'value': 10})
+
+        # Bind parameter in FROM_SYNC mode (read-only)
+        sync.bind_parameter(
+            value_param,
+            property_map={
+                'value': {
+                    'setter': value_param.setValue,
+                    'mode': SyncMode.FROM_SYNC,
+                }
+            }
+        )
+
+        # Sync -> parameter should work
+        sync.value = {'value': 50}
+        assert value_param.value() == 50
+
+        # Parameter -> sync should NOT work
+        value_param.setValue(99)
+        assert sync.value['value'] == 50  # Unchanged
+
+    def test_bind_parameter_to_sync_mode(self, qtbot):
+        """Test bind_parameter() with TO_SYNC mode (write-only to sync)"""
+        from pymodaq_gui.parameter import Parameter
+
+        # Create parameter
+        params = [
+            {'title': 'Value:', 'name': 'value', 'type': 'int', 'value': 10}
+        ]
+        settings = Parameter.create(name='settings', type='group', children=params)
+        value_param = settings.child('value')
+
+        # Create sync
+        sync = WidgetSync(initial_value={'value': 10})
+
+        # Bind parameter in TO_SYNC mode
+        sync.bind_parameter(
+            value_param,
+            property_map={
+                'value': {
+                    'signal': value_param.sigValueChanged,
+                    'getter': value_param.value,
+                    'mode': SyncMode.TO_SYNC,
+                }
+            }
+        )
+
+        # Parameter -> sync should work
+        value_param.setValue(75)
+        assert sync.value['value'] == 75
+
+        # Sync -> parameter should NOT work
+        sync.value = {'value': 99}
+        assert value_param.value() == 75  # Unchanged
+
+    def test_bind_parameter_init_from_widget(self, qtbot):
+        """Test bind_parameter() with init_from='widget'"""
+        from pymodaq_gui.parameter import Parameter
+
+        # Create parameter with different value than sync
+        params = [
+            {'title': 'Value:', 'name': 'value', 'type': 'int', 'value': 99}
+        ]
+        settings = Parameter.create(name='settings', type='group', children=params)
+        value_param = settings.child('value')
+
+        # Create sync with different value
+        sync = WidgetSync(initial_value={'value': 42})
+
+        # Bind parameter with init_from='widget'
+        sync.bind_parameter(
+            value_param,
+            property_map={
+                'value': {
+                    'signal': value_param.sigValueChanged,
+                    'getter': value_param.value,
+                    'setter': value_param.setValue,
+                }
+            },
+            init_from='widget'
+        )
+
+        # Sync should be initialized with parameter's value
+        assert sync.value['value'] == 99
+
+    def test_bind_parameter_init_from_sync(self, qtbot):
+        """Test bind_parameter() with init_from='sync' (default)"""
+        from pymodaq_gui.parameter import Parameter
+
+        # Create parameter with different value than sync
+        params = [
+            {'title': 'Value:', 'name': 'value', 'type': 'int', 'value': 99}
+        ]
+        settings = Parameter.create(name='settings', type='group', children=params)
+        value_param = settings.child('value')
+
+        # Create sync with different value
+        sync = WidgetSync(initial_value={'value': 42})
+
+        # Bind parameter with init_from='sync' (default)
+        sync.bind_parameter(
+            value_param,
+            property_map={
+                'value': {
+                    'signal': value_param.sigValueChanged,
+                    'getter': value_param.value,
+                    'setter': value_param.setValue,
+                }
+            },
+            init_from='sync'
+        )
+
+        # Parameter should be initialized with sync's value
+        assert value_param.value() == 42
+
+    def test_bind_parameter_unbind(self, qtbot):
+        """Test unbinding a parameter"""
+        from pymodaq_gui.parameter import Parameter
+
+        # Create parameter
+        params = [
+            {'title': 'Value:', 'name': 'value', 'type': 'int', 'value': 10}
+        ]
+        settings = Parameter.create(name='settings', type='group', children=params)
+        value_param = settings.child('value')
+
+        # Create sync
+        sync = WidgetSync(initial_value={'value': 10})
+
+        # Bind parameter
+        sync.bind_parameter(
+            value_param,
+            property_map={
+                'value': {'param': value_param}
+            }
+        )
+
+        # Check it works
+        value_param.setValue(50)
+        assert sync.value['value'] == 50
+
+        # Unbind
+        sync.unbind(value_param)
+
+        # Changes should not propagate
+        value_param.setValue(99)
+        assert sync.value['value'] == 50  # Unchanged


### PR DESCRIPTION
The WidgetSync has been extended with a `bind_parameter` method to easily connect a ParameterTree object (that is almost everywhere in PyMoDAQ) and different widgets.

The docs and examples have been expanded to highlight some showcases.

