### PR TITLE
adding fixes to correctly send signal when updating lists

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync/2_dict_sync_example.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync/2_dict_sync_example.py
@@ -13,7 +13,7 @@ Run: python -m pymodaq_gui.examples.2_dict_sync_example
 import sys
 import json
 from qtpy.QtWidgets import (QApplication, QWidget, QVBoxLayout, QHBoxLayout,
-                             QComboBox, QPushButton, QLabel, QGroupBox,
+                             QComboBox, QPushButton, QLabel, QGroupBox,QLineEdit,
                              QTabWidget, QSpinBox, QSlider, QTextEdit)
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QPalette, QColor
@@ -340,8 +340,183 @@ class ConfigurationFormExample(QWidget):
         )
 
 
+class HelperMethodsExample(QWidget):
+    """Example 4: Using DictSync helper methods for list manipulation"""
+
+    def __init__(self):
+        super().__init__()
+        layout = QVBoxLayout(self)
+
+        layout.addWidget(QLabel(
+            "Use Case: Dynamic list management with helper methods\n"
+            "✓ append_to_list() - Add items safely\n"
+            "✓ remove_from_list() - Remove items safely\n"
+            "✓ pop_from_list() - Remove by index\n"
+            "✓ update_key() - Update individual keys\n"
+            "✓ All methods handle deep copying internally!"
+        ))
+
+        # Display area
+        display_group = QGroupBox("Current State")
+        display_layout = QVBoxLayout()
+
+        self.items_display = QLabel()
+        self.items_display.setStyleSheet(
+            "padding: 10px; "
+            "font-family: monospace; border-radius: 5px;"
+        )
+        display_layout.addWidget(self.items_display)
+
+        display_group.setLayout(display_layout)
+        layout.addWidget(display_group)
+
+        # Initialize sync with a list of items
+        self.list_sync = WidgetSync(initial_value={
+            'items': ['Apple', 'Banana', 'Cherry'],
+            'current': 'Apple',
+            'count': 3
+        })
+
+        # Update display when value changes
+        self.list_sync.value_changed.connect(lambda _: self.update_display())
+        self.update_display()
+
+        # Controls
+        controls_group = QGroupBox("List Operations")
+        controls_layout = QVBoxLayout()
+
+        # Add item controls
+        add_layout = QHBoxLayout()
+        add_layout.addWidget(QLabel("Add item:"))
+        self.add_input = QLineEdit()
+        self.add_input.setPlaceholderText("Enter item name...")
+        add_layout.addWidget(self.add_input)
+
+        add_btn = QPushButton("Append")
+        add_btn.clicked.connect(self.append_item)
+        add_layout.addWidget(add_btn)
+        controls_layout.addLayout(add_layout)
+
+        # Remove item controls
+        remove_layout = QHBoxLayout()
+        remove_layout.addWidget(QLabel("Remove item:"))
+        self.remove_input = QLineEdit()
+        self.remove_input.setPlaceholderText("Enter item name...")
+        remove_layout.addWidget(self.remove_input)
+
+        remove_btn = QPushButton("Remove")
+        remove_btn.clicked.connect(self.remove_item)
+        remove_layout.addWidget(remove_btn)
+        controls_layout.addLayout(remove_layout)
+
+        # Pop item controls
+        pop_layout = QHBoxLayout()
+        pop_layout.addWidget(QLabel("Pop by index:"))
+        self.pop_spin = QSpinBox()
+        self.pop_spin.setRange(-10, 10)
+        self.pop_spin.setValue(0)
+        pop_layout.addWidget(self.pop_spin)
+
+        pop_btn = QPushButton("Pop")
+        pop_btn.clicked.connect(self.pop_item)
+        pop_layout.addWidget(pop_btn)
+
+        pop_last_btn = QPushButton("Pop Last")
+        pop_last_btn.clicked.connect(lambda: self.pop_item(-1))
+        pop_layout.addWidget(pop_last_btn)
+        controls_layout.addLayout(pop_layout)
+
+        # Update current
+        current_layout = QHBoxLayout()
+        current_layout.addWidget(QLabel("Set current:"))
+        self.current_combo = QComboBox()
+        current_layout.addWidget(self.current_combo)
+
+        set_current_btn = QPushButton("Update")
+        set_current_btn.clicked.connect(self.update_current)
+        current_layout.addWidget(set_current_btn)
+        controls_layout.addLayout(current_layout)
+
+        # Bind combo to items list (display only)
+        self.list_sync.bind_properties(
+            self.current_combo,
+            property_map={
+                'items': {
+                    'getter': lambda: [self.current_combo.itemText(i)
+                                     for i in range(self.current_combo.count())],
+                    'setter': lambda items: (self.current_combo.clear(),
+                                           self.current_combo.addItems(items)),
+                    'mode': SyncMode.FROM_SYNC
+                }
+            }
+        )
+
+        controls_group.setLayout(controls_layout)
+        layout.addWidget(controls_group)
+
+        # Info box
+        info = QLabel(
+            "💡 All operations use helper methods that handle deep copying internally.\n"
+            "This prevents the shallow copy bug and ensures proper change detection!"
+        )
+        info.setStyleSheet("color: #0288d1; padding: 10px; font-style: italic;")
+        info.setWordWrap(True)
+        layout.addWidget(info)
+
+        layout.addStretch()
+
+    def append_item(self):
+        item = self.add_input.text().strip()
+        if item:
+            try:
+                # Use helper method - handles copying internally
+                self.list_sync.append_to_list('items', item)
+                self.list_sync.update_key('count', len(self.list_sync.value['items']))
+                self.add_input.clear()
+            except (KeyError, TypeError) as e:
+                print(f"Error: {e}")
+
+    def remove_item(self):
+        item = self.remove_input.text().strip()
+        if item:
+            try:
+                # Use helper method - handles copying internally
+                self.list_sync.remove_from_list('items', item)
+                self.list_sync.update_key('count', len(self.list_sync.value['items']))
+                self.remove_input.clear()
+            except (KeyError, TypeError, ValueError) as e:
+                print(f"Error: {e}")
+
+    def pop_item(self, index=None):
+        if index is None:
+            index = self.pop_spin.value()
+        try:
+            # Use helper method - handles copying internally
+            popped = self.list_sync.pop_from_list('items', index)
+            self.list_sync.update_key('count', len(self.list_sync.value['items']))
+            print(f"Popped: {popped}")
+        except (KeyError, TypeError, IndexError) as e:
+            print(f"Error: {e}")
+
+    def update_current(self):
+        current = self.current_combo.currentText()
+        if current:
+            # Use helper method - handles copying internally
+            self.list_sync.update_key('current', current)
+
+    def update_display(self):
+        v = self.list_sync.value
+        items_str = ', '.join(f"'{item}'" for item in v.get('items', []))
+        self.items_display.setText(
+            f"Items: [{items_str}]\n"
+            f"Current: '{v.get('current', 'N/A')}'\n"
+            f"Count: {v.get('count', 0)}\n\n"
+            f"Internal dict:\n{v}"
+        )
+
+
 class MixedBindingExample(QWidget):
-    """Example 4: Mix bind(), bind_dict(), and custom logic"""
+    """Example 5: Mix bind(), bind_dict(), and custom logic"""
 
     def __init__(self):
         super().__init__()
@@ -459,7 +634,8 @@ class DictSyncDemo(QWidget):
         tabs.addTab(ComboBoxPropertiesExample(), "1. bind_properties()")
         tabs.addTab(RGBSlidersExample(), "2. bind_dict()")
         tabs.addTab(ConfigurationFormExample(), "3. Config Forms")
-        tabs.addTab(MixedBindingExample(), "4. Mixed Binding")
+        tabs.addTab(HelperMethodsExample(), "4. Helper Methods")
+        tabs.addTab(MixedBindingExample(), "5. Mixed Binding")
 
         layout.addWidget(tabs)
 

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
@@ -5,6 +5,7 @@ Implementation for syncing widget properties across multiple widgets.
 
 """
 from __future__ import annotations
+import copy
 
 from qtpy.QtCore import QObject, Signal
 from qtpy.QtWidgets import QWidget
@@ -1078,12 +1079,22 @@ class ValueSync(BaseWidgetSync):
 
         # Validate and wrap the initial value
         validated_value = self._validate_value(initial_value)
-        self._value = {"__value__": validated_value}
-        self._previous_value = self._value.copy()
+        # Deep copy to ensure independence of mutable values
+        self._value = {"__value__": copy.deepcopy(validated_value) if validated_value is not None else None}
+        self._previous_value = copy.deepcopy(self._value)
 
     @property
     def value(self) -> Any:
-        """Get current synced value."""
+        """Get current synced value.
+
+        Warning: For mutable values (lists, dicts, custom objects), returns
+        a direct reference to the internal value. Modifying the returned
+        value in-place will affect the sync's internal state and may cause
+        change detection to fail.
+
+        For a fully independent copy of mutable values, use:
+        copy.copy(sync.value) or copy.deepcopy(sync.value)
+        """
         return self._value.get("__value__")
 
     @value.setter
@@ -1122,8 +1133,8 @@ class ValueSync(BaseWidgetSync):
 
         if self._value != new_dict_value:
             # Store previous value for property change detection
-            self._previous_value = self._value.copy()
-            self._value = new_dict_value
+            self._previous_value = copy.deepcopy(self._value)
+            self._value = copy.deepcopy(new_dict_value)
             if emit:
                 # Emit unwrapped value for user-facing signal handlers
                 self.value_changed.emit(validated_value)
@@ -1378,13 +1389,20 @@ class DictSync(BaseWidgetSync):
 
         self._validator = validator
         self._data_type = dict
-        self._value = initial_value.copy() if initial_value else {}
-        self._previous_value = self._value.copy()
+        self._value = copy.deepcopy(initial_value) if initial_value else {}
+        self._previous_value = copy.deepcopy(self._value)
 
     @property
     def value(self) -> dict:
-        """Get current synced dict value."""
-        return self._value
+        """Get current synced dict value.
+
+        Returns a shallow copy of the internal dict. Modifying dict keys
+        will not affect the sync, but modifying nested mutable objects
+        (lists, dicts) will affect internal state and should be avoided.
+
+        For a fully independent copy, use copy.deepcopy(sync.value).
+        """
+        return copy.copy(self._value)
 
     @value.setter
     def value(self, new_value: dict) -> None:
@@ -1417,8 +1435,8 @@ class DictSync(BaseWidgetSync):
 
         if self._value != validated_value:
             # Store previous value for property change detection
-            self._previous_value = self._value.copy()
-            self._value = validated_value.copy()
+            self._previous_value = copy.deepcopy(self._value)
+            self._value = copy.deepcopy(validated_value)
             if emit:
                 self.value_changed.emit(self._value)
 
@@ -1849,3 +1867,164 @@ class DictSync(BaseWidgetSync):
             widget = widget_ref()
             if widget is not None:
                 self._setup_widget_destruction_callback(widget, connection_keys)
+
+    def _validate_list_key(self, key: str) -> None:
+        """
+        Validate that a key exists and points to a list.
+
+        Parameters
+        ----------
+        key : str
+            The dict key to validate
+
+        Raises
+        ------
+        KeyError
+            If key doesn't exist in dict
+        TypeError
+            If value at key is not a list
+        """
+        if key not in self._value:
+            raise KeyError(f"Key '{key}' not found in dict value")
+        if not isinstance(self._value[key], list):
+            raise TypeError(f"Value at key '{key}' is not a list")
+
+    def _modify_and_set(self, modify_fn: callable, emit: bool = True) -> Any:
+        """
+        Common pattern: deep copy dict, modify it, set it back.
+
+        Parameters
+        ----------
+        modify_fn : callable
+            Function that takes the copied dict and modifies it.
+            Should return the value to return from the calling method (or None).
+        emit : bool, optional
+            Whether to emit value_changed signal (default: True)
+
+        Returns
+        -------
+        Any
+            Whatever modify_fn returns
+        """
+        new_dict = copy.deepcopy(self._value)
+        result = modify_fn(new_dict)
+        self.set_value(new_dict, emit=emit)
+        return result
+
+    def update_key(self, key: str, value: Any, emit: bool = True) -> None:
+        """
+        Update a single key in the dict value.
+
+        Convenience method that handles copying internally.
+
+        Parameters
+        ----------
+        key : str
+            The dict key to update
+        value : Any
+            The new value for the key
+        emit : bool, optional
+            Whether to emit value_changed signal (default: True)
+
+        Example
+        -------
+        >>> sync = DictSync({'items': ['a', 'b'], 'current': 'a'})
+        >>> sync.update_key('current', 'b')
+        """
+        self._modify_and_set(lambda d: d.__setitem__(key, value), emit=emit)
+
+    def append_to_list(self, key: str, item: Any, emit: bool = True) -> None:
+        """
+        Append an item to a list value in the dict.
+
+        Parameters
+        ----------
+        key : str
+            The dict key containing the list
+        item : Any
+            The item to append
+        emit : bool, optional
+            Whether to emit value_changed signal (default: True)
+
+        Raises
+        ------
+        KeyError
+            If key doesn't exist in dict
+        TypeError
+            If value at key is not a list
+
+        Example
+        -------
+        >>> sync = DictSync({'items': ['a', 'b'], 'current': 'a'})
+        >>> sync.append_to_list('items', 'c')
+        >>> sync.value['items']  # Returns ['a', 'b', 'c']
+        """
+        self._validate_list_key(key)
+        self._modify_and_set(lambda d: d[key].append(item), emit=emit)
+
+    def remove_from_list(self, key: str, item: Any, emit: bool = True) -> None:
+        """
+        Remove an item from a list value in the dict.
+
+        Parameters
+        ----------
+        key : str
+            The dict key containing the list
+        item : Any
+            The item to remove
+        emit : bool, optional
+            Whether to emit value_changed signal (default: True)
+
+        Raises
+        ------
+        KeyError
+            If key doesn't exist in dict
+        TypeError
+            If value at key is not a list
+        ValueError
+            If item not in list
+
+        Example
+        -------
+        >>> sync = DictSync({'items': ['a', 'b', 'c'], 'current': 'a'})
+        >>> sync.remove_from_list('items', 'b')
+        >>> sync.value['items']  # Returns ['a', 'c']
+        """
+        self._validate_list_key(key)
+        self._modify_and_set(lambda d: d[key].remove(item), emit=emit)
+
+    def pop_from_list(self, key: str, index: int = -1, emit: bool = True) -> Any:
+        """
+        Pop an item from a list value in the dict.
+
+        Parameters
+        ----------
+        key : str
+            The dict key containing the list
+        index : int, optional
+            Index to pop (default: -1, last item)
+        emit : bool, optional
+            Whether to emit value_changed signal (default: True)
+
+        Returns
+        -------
+        Any
+            The popped item
+
+        Raises
+        ------
+        KeyError
+            If key doesn't exist in dict
+        TypeError
+            If value at key is not a list
+        IndexError
+            If index out of range
+
+        Example
+        -------
+        >>> sync = DictSync({'items': ['a', 'b', 'c'], 'current': 'a'})
+        >>> removed = sync.pop_from_list('items', 1)  # Returns 'b'
+        >>> sync.value['items']  # Returns ['a', 'c']
+        """
+        self._validate_list_key(key)
+        return self._modify_and_set(lambda d: d[key].pop(index), emit=emit)

--- a/packages/pymodaq_gui/tests/utils/widget_sync_test.py
+++ b/packages/pymodaq_gui/tests/utils/widget_sync_test.py
@@ -1636,3 +1636,350 @@ class TestBindParameter:
         # Changes should not propagate
         value_param.setValue(99)
         assert sync.value['value'] == 50  # Unchanged
+
+
+class TestHelperMethods:
+    """Test DictSync helper methods for list manipulation"""
+
+    def test_update_key(self, qtbot_app):
+        """Test update_key() method"""
+        sync = DictSync(initial_value={'a': 1, 'b': 2, 'c': 3})
+
+        # Track value changes
+        changes = []
+        sync.value_changed.connect(lambda v: changes.append(v.copy()))
+
+        # Update single key
+        sync.update_key('b', 99)
+
+        assert sync.value['a'] == 1
+        assert sync.value['b'] == 99
+        assert sync.value['c'] == 3
+        assert len(changes) == 1
+        assert changes[0]['b'] == 99
+
+    def test_update_key_with_widgets(self, qtbot_app):
+        """Test that update_key() triggers widget updates"""
+        sync = DictSync(initial_value={'value': 10})
+
+        spinbox = QSpinBox()
+        sync.bind_dict({'value': {'widget': spinbox, 'property': 'value'}})
+
+        assert spinbox.value() == 10
+
+        # Update key
+        sync.update_key('value', 50)
+
+        # Widget should be updated
+        assert spinbox.value() == 50
+
+    def test_append_to_list_basic(self, qtbot_app):
+        """Test append_to_list() basic functionality"""
+        sync = DictSync(initial_value={'items': ['a', 'b', 'c']})
+
+        sync.append_to_list('items', 'd')
+
+        assert sync.value['items'] == ['a', 'b', 'c', 'd']
+
+    def test_append_to_list_triggers_signal(self, qtbot_app):
+        """Test that append_to_list() emits value_changed signal"""
+        sync = DictSync(initial_value={'items': ['a']})
+
+        changes = []
+        sync.value_changed.connect(lambda v: changes.append(v.copy()))
+
+        sync.append_to_list('items', 'b')
+
+        assert len(changes) == 1
+        assert changes[0]['items'] == ['a', 'b']
+
+    def test_append_to_list_nonexistent_key_raises(self, qtbot_app):
+        """Test that append_to_list() raises KeyError for nonexistent key"""
+        sync = DictSync(initial_value={'items': []})
+
+        with pytest.raises(KeyError, match="Key 'missing' not found"):
+            sync.append_to_list('missing', 'x')
+
+    def test_append_to_list_non_list_raises(self, qtbot_app):
+        """Test that append_to_list() raises TypeError for non-list value"""
+        sync = DictSync(initial_value={'value': 42})
+
+        with pytest.raises(TypeError, match="not a list"):
+            sync.append_to_list('value', 10)
+
+    def test_remove_from_list_basic(self, qtbot_app):
+        """Test remove_from_list() basic functionality"""
+        sync = DictSync(initial_value={'items': ['a', 'b', 'c', 'b']})
+
+        sync.remove_from_list('items', 'b')
+
+        # Only first occurrence removed
+        assert sync.value['items'] == ['a', 'c', 'b']
+
+    def test_remove_from_list_not_found_raises(self, qtbot_app):
+        """Test that remove_from_list() raises ValueError when item not found"""
+        sync = DictSync(initial_value={'items': ['a', 'b', 'c']})
+
+        with pytest.raises(ValueError):
+            sync.remove_from_list('items', 'x')
+
+    def test_remove_from_list_nonexistent_key_raises(self, qtbot_app):
+        """Test that remove_from_list() raises KeyError for nonexistent key"""
+        sync = DictSync(initial_value={'items': []})
+
+        with pytest.raises(KeyError, match="Key 'missing' not found"):
+            sync.remove_from_list('missing', 'x')
+
+    def test_remove_from_list_non_list_raises(self, qtbot_app):
+        """Test that remove_from_list() raises TypeError for non-list value"""
+        sync = DictSync(initial_value={'value': 42})
+
+        with pytest.raises(TypeError, match="not a list"):
+            sync.remove_from_list('value', 10)
+
+    def test_pop_from_list_basic(self, qtbot_app):
+        """Test pop_from_list() basic functionality"""
+        sync = DictSync(initial_value={'items': ['a', 'b', 'c']})
+
+        popped = sync.pop_from_list('items', 1)
+
+        assert popped == 'b'
+        assert sync.value['items'] == ['a', 'c']
+
+    def test_pop_from_list_last_item(self, qtbot_app):
+        """Test pop_from_list() with default index (last item)"""
+        sync = DictSync(initial_value={'items': ['a', 'b', 'c']})
+
+        popped = sync.pop_from_list('items')  # Default index=-1
+
+        assert popped == 'c'
+        assert sync.value['items'] == ['a', 'b']
+
+    def test_pop_from_list_negative_index(self, qtbot_app):
+        """Test pop_from_list() with negative index"""
+        sync = DictSync(initial_value={'items': ['a', 'b', 'c']})
+
+        popped = sync.pop_from_list('items', -2)
+
+        assert popped == 'b'
+        assert sync.value['items'] == ['a', 'c']
+
+    def test_pop_from_list_out_of_range_raises(self, qtbot_app):
+        """Test that pop_from_list() raises IndexError for invalid index"""
+        sync = DictSync(initial_value={'items': ['a', 'b']})
+
+        with pytest.raises(IndexError):
+            sync.pop_from_list('items', 10)
+
+    def test_pop_from_list_nonexistent_key_raises(self, qtbot_app):
+        """Test that pop_from_list() raises KeyError for nonexistent key"""
+        sync = DictSync(initial_value={'items': []})
+
+        with pytest.raises(KeyError, match="Key 'missing' not found"):
+            sync.pop_from_list('missing', 0)
+
+    def test_pop_from_list_non_list_raises(self, qtbot_app):
+        """Test that pop_from_list() raises TypeError for non-list value"""
+        sync = DictSync(initial_value={'value': 42})
+
+        with pytest.raises(TypeError, match="not a list"):
+            sync.pop_from_list('value', 0)
+
+    def test_helper_methods_with_widgets(self, qtbot_app):
+        """Test that helper methods properly update bound widgets"""
+        sync = DictSync(initial_value={
+            'items': ['Red', 'Green', 'Blue'],
+            'current': 'Red'
+        })
+
+        # Create combo box bound to items
+        combo = QComboBox()
+        sync.bind_properties(
+            combo,
+            property_map={
+                'items': {
+                    'getter': lambda: [combo.itemText(i) for i in range(combo.count())],
+                    'setter': lambda items: (combo.clear(), combo.addItems(items)),
+                    'mode': SyncMode.FROM_SYNC
+                }
+            }
+        )
+
+        assert combo.count() == 3
+        assert combo.itemText(0) == 'Red'
+
+        # Append using helper method
+        sync.append_to_list('items', 'Yellow')
+        assert combo.count() == 4
+        assert combo.itemText(3) == 'Yellow'
+
+        # Remove using helper method
+        sync.remove_from_list('items', 'Green')
+        assert combo.count() == 3
+        assert combo.itemText(1) == 'Blue'
+
+        # Pop using helper method
+        popped = sync.pop_from_list('items', 0)
+        assert popped == 'Red'
+        assert combo.count() == 2
+        assert combo.itemText(0) == 'Blue'
+
+    def test_helper_methods_emit_control(self, qtbot_app):
+        """Test that helper methods respect emit parameter"""
+        sync = DictSync(initial_value={'items': ['a']})
+
+        changes = []
+        sync.value_changed.connect(lambda v: changes.append(v.copy()))
+
+        # With emit=True (default)
+        sync.append_to_list('items', 'b')
+        assert len(changes) == 1
+
+        # With emit=False
+        sync.append_to_list('items', 'c', emit=False)
+        assert len(changes) == 1  # No new emission
+
+        # Verify value was updated even without emission
+        assert sync.value['items'] == ['a', 'b', 'c']
+
+    def test_deep_copy_prevents_external_modification(self, qtbot_app):
+        """Test that helper methods use deep copy to prevent external modifications"""
+        # This test verifies the fix for the shallow copy bug
+        my_list = ['a', 'b', 'c']
+        sync = DictSync(initial_value={'items': my_list})
+
+        # Modify external list
+        my_list.append('d')
+
+        # Sync's internal list should NOT be affected (deep copy)
+        assert sync.value['items'] == ['a', 'b', 'c']
+
+        # Use helper method
+        sync.append_to_list('items', 'x')
+
+        # External list should not be affected
+        assert my_list == ['a', 'b', 'c', 'd']
+        assert sync.value['items'] == ['a', 'b', 'c', 'x']
+
+    def test_complex_list_operations_sequence(self, qtbot_app):
+        """Test a sequence of list operations"""
+        sync = DictSync(initial_value={
+            'items': ['Apple', 'Banana', 'Cherry'],
+            'count': 3
+        })
+
+        # Append
+        sync.append_to_list('items', 'Date')
+        sync.update_key('count', 4)
+        assert sync.value['items'] == ['Apple', 'Banana', 'Cherry', 'Date']
+        assert sync.value['count'] == 4
+
+        # Remove
+        sync.remove_from_list('items', 'Banana')
+        sync.update_key('count', 3)
+        assert sync.value['items'] == ['Apple', 'Cherry', 'Date']
+        assert sync.value['count'] == 3
+
+        # Pop
+        popped = sync.pop_from_list('items', 1)
+        sync.update_key('count', 2)
+        assert popped == 'Cherry'
+        assert sync.value['items'] == ['Apple', 'Date']
+        assert sync.value['count'] == 2
+
+        # Append again
+        sync.append_to_list('items', 'Elderberry')
+        sync.update_key('count', 3)
+        assert sync.value['items'] == ['Apple', 'Date', 'Elderberry']
+        assert sync.value['count'] == 3
+
+
+class TestDeepCopyBugFix:
+    """Test that the deep copy bug fix works correctly"""
+
+    def test_dictsync_deep_copy_on_set(self, qtbot_app):
+        """Test that DictSync deep copies values on set"""
+        my_list = [1, 2, 3]
+        sync = DictSync(initial_value={'items': my_list})
+
+        # Modify external list
+        my_list.append(4)
+
+        # Sync's value should be unaffected
+        assert sync.value['items'] == [1, 2, 3]
+
+    def test_dictsync_shallow_copy_on_get(self, qtbot_app):
+        """Test that DictSync returns shallow copy on get"""
+        sync = DictSync(initial_value={'a': 1, 'b': 2})
+
+        # Get value
+        value1 = sync.value
+        value2 = sync.value
+
+        # Should be different dict objects (shallow copy)
+        assert value1 is not value2
+        assert value1 == value2
+
+    def test_valuesync_deep_copy_on_set(self, qtbot_app):
+        """Test that ValueSync deep copies mutable values on set"""
+        my_list = [1, 2, 3]
+        sync = ValueSync(initial_value=my_list)
+
+        # Modify external list
+        my_list.append(4)
+
+        # Sync's value should be unaffected
+        assert sync.value == [1, 2, 3]
+
+    def test_valuesync_with_immutable_values(self, qtbot_app):
+        """Test that ValueSync works correctly with immutable values"""
+        sync = ValueSync(initial_value=42)
+
+        val = sync.value
+        assert val == 42
+
+        sync.value = 99
+        assert sync.value == 99
+
+    def test_widget_callback_deep_copy(self, qtbot_app):
+        """Test that widget callbacks properly handle deep copy"""
+        sync = DictSync(initial_value={'items': ['a', 'b'], 'current': 'a'})
+
+        combo = QComboBox()
+        # Add items to combo box first
+        combo.addItems(['a', 'b'])
+
+        sync.bind_properties(
+            combo,
+            property_map={
+                'current': {
+                    'signal': combo.currentTextChanged,
+                    'getter': combo.currentText,
+                    'setter': combo.setCurrentText,
+                    'mode': SyncMode.BIDIRECTIONAL
+                }
+            }
+        )
+
+        # Initial value should be set
+        assert combo.currentText() == 'a'
+
+        # Change via widget
+        combo.setCurrentText('b')
+
+        # This should have updated the sync without causing shallow copy issues
+        assert sync.value['current'] == 'b'
+        assert sync.value['items'] == ['a', 'b']  # Unchanged
+
+    def test_no_signal_emission_on_unchanged_value(self, qtbot_app):
+        """Test that setting same value doesn't emit signal"""
+        sync = DictSync(initial_value={'items': [1, 2, 3]})
+
+        changes = []
+        sync.value_changed.connect(lambda v: changes.append(v.copy()))
+
+        # Set to same value (different list object but same contents)
+        sync.value = {'items': [1, 2, 3]}
+
+        # Should not emit (comparison works correctly with deep copy)
+        assert len(changes) == 0


### PR DESCRIPTION
PR Related to Bugfix/configurator #833

Currently, adding/removing elements in the list did not fire properly.
The reason comes from the use of shallow copy which changes the value without properly firing the emitChangedSignal.
Overall, in the method `set_value`, the check`if self._value != validated_value:` always gives false and the signal is never emitted.

This PR fixes it by using copy/deepcopy to avoid these conflicts. 
Some tests and an example have been added.
