### PR TITLE
Fix doc compilation issue with pyqtgraph monkey-patch

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -157,7 +157,6 @@ autodoc_mock_imports = [
     "h5py",
     "matplotlib",
     "qtpy",
-    "pyqtgraph",
     "qtpy.QtCore",
     "qtpy.QtGui",
     "qtpy.QtWidgets"


### PR DESCRIPTION
fixes #838 by removing pyqtgraph of mock import list, as we monkey-patched its API