### PR TITLE
Feature/research in contrl module settings

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
@@ -118,7 +118,7 @@ class DAQ_Move(ParameterControlModule):
         self.logger = set_logger(f"{logger.name}.{title}")
         self.logger.info(f"Initializing DAQ_Move: {title}")
 
-        super().__init__(action_list=("save", "update"), **kwargs)
+        super().__init__(**kwargs)
 
         if not (
             ui_identifier is not None and ui_identifier in ActuatorUIFactory.keys()

--- a/packages/pymodaq/src/pymodaq/control_modules/utils.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/utils.py
@@ -384,7 +384,7 @@ class ParameterControlModule(ParameterManager, ControlModule):
     listener_class: Type[ActorListener] = ActorListener
 
     def __init__(self, **kwargs):
-        ParameterManager.__init__(self, action_list=('save', 'update'))
+        ParameterManager.__init__(self, action_list=("search", "save", "update"))
         ControlModule.__init__(self)
 
     def apply_controller_parameters(self, controller_param: Parameter):

--- a/packages/pymodaq/src/pymodaq/control_modules/utils.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/utils.py
@@ -384,7 +384,8 @@ class ParameterControlModule(ParameterManager, ControlModule):
     listener_class: Type[ActorListener] = ActorListener
 
     def __init__(self, **kwargs):
-        ParameterManager.__init__(self, action_list=("search", "save", "update"))
+        action_list = kwargs.get("action_list", ("search", "save", "update"))
+        ParameterManager.__init__(self, action_list=action_list)
         ControlModule.__init__(self)
 
     def apply_controller_parameters(self, controller_param: Parameter):


### PR DESCRIPTION
Context: The research functionality in parameter tree was not activated by default for the control modules.

In this PR: The default behavior for control module is now to include the search mechanism.