### PR TITLE
use a common function for the remote connection settings in params for daq_move / daq_viewer

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/move_utility_classes.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/move_utility_classes.py
@@ -31,7 +31,7 @@ from pymodaq.utils.data import DataActuator
 from pymodaq.control_modules.thread_commands import ThreadStatus, ThreadStatusMove
 from pymodaq.utils.config import Config as ControlModulesConfig
 from pymodaq.control_modules.daq_move_ui.factory import ActuatorUIFactory
-from pymodaq.control_modules.utils import create_controller_param, ControllerStatus
+from pymodaq.control_modules.utils import create_controller_param, create_remote_connection_params, ControllerStatus
 from pymodaq_gui.parameter.ioxml import VALID_FOR_CONFIGURATION
 
 
@@ -184,28 +184,7 @@ params = [
 
         {'title': 'Refresh value (ms):', 'name': 'refresh_timeout', 'type': 'int',
          'value': config('actuator', 'refresh_timeout_ms')},
-        {'title': 'TCP/IP options:', 'name': 'tcpip', 'type': 'group', 'visible': True, 'expanded': False,
-         'children': [
-             {'title': 'Connect to server:', 'name': 'connect_server', 'type': 'bool_push', 'label': 'Connect',
-              'value': False},
-             {'title': 'Connected?:', 'name': 'tcp_connected', 'type': 'led', 'value': False,
-              VALID_FOR_CONFIGURATION: False},
-             {'title': 'IP address:', 'name': 'ip_address', 'type': 'str',
-              'value': config_utils('network', 'tcp-server', 'ip')},
-             {'title': 'Port:', 'name': 'port', 'type': 'int', 'value': config_utils('network', 'tcp-server', 'port')},
-         ]},
-        {'title': 'LECO options:', 'name': 'leco', 'type': 'group', 'visible': True, 'expanded': False,
-         'children': [
-             {'title': 'Connect:', 'name': 'connect_leco_server', 'type': 'bool_push', 'label': 'Connect',
-              'value': False},
-             {'title': 'Connected?:', 'name': 'leco_connected', 'type': 'led', 'value': False,
-              VALID_FOR_CONFIGURATION: False},
-             {'title': 'Name', 'name': 'leco_name', 'type': 'str', 'value': "", 'default': ""},
-             {'title': 'Host:', 'name': 'host', 'type': 'str', 'value': config_utils('network', "leco-server", "host"),
-              "default": "localhost"},
-             {'title': 'Port:', 'name': 'port', 'type': 'int', 'value': config_utils('network', 'leco-server', 'port')},
-         ]},
-    ]},
+    ] + create_remote_connection_params()},
     {'title': 'Actuator Settings:', 'name': 'move_settings', 'type': 'group'}
 ]
 

--- a/packages/pymodaq/src/pymodaq/control_modules/utils.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/utils.py
@@ -56,6 +56,44 @@ def create_controller_param(axis_name: str = None, axis_names: Optional[list[str
     return controller_param
 
 
+def create_remote_connection_params() -> list[dict]:
+    """Create common remote connection parameter definitions (TCP/IP and LECO)
+
+    These parameters are shared between DAQ_Move and DAQ_Viewer control modules
+    and provide the settings for connecting to remote TCP/IP servers or LECO instances.
+
+    Returns
+    -------
+    list of dict
+        Parameter definitions for TCP/IP and LECO remote connections
+    """
+    return [
+        {'title': 'TCP/IP options:', 'name': 'tcpip', 'type': 'group', 'visible': True,
+         'expanded': False, 'children': [
+            {'title': 'Connect to server:', 'name': 'connect_server', 'type': 'bool_push',
+             'label': 'Connect', 'value': False},
+            {'title': 'Connected?:', 'name': 'tcp_connected', 'type': 'led', 'value': False,
+             VALID_FOR_CONFIGURATION: False, 'readonly': True},
+            {'title': 'IP address:', 'name': 'ip_address', 'type': 'str',
+             'value': config_utils('network', 'tcp-server', 'ip')},
+            {'title': 'Port:', 'name': 'port', 'type': 'int',
+             'value': config_utils('network', 'tcp-server', 'port')},
+        ]},
+        {'title': 'LECO options:', 'name': 'leco', 'type': 'group', 'visible': True,
+         'expanded': False, 'children': [
+            {'title': 'Connect:', 'name': 'connect_leco_server', 'type': 'bool_push',
+             'label': 'Connect', 'value': False},
+            {'title': 'Connected?:', 'name': 'leco_connected', 'type': 'led', 'value': False,
+             VALID_FOR_CONFIGURATION: False, 'readonly': True},
+            {'title': 'Name', 'name': 'leco_name', 'type': 'str', 'value': "", 'default': ""},
+            {'title': 'Host:', 'name': 'host', 'type': 'str',
+             'value': config_utils('network', "leco-server", "host"), "default": "localhost"},
+            {'title': 'Port:', 'name': 'port', 'type': 'int',
+             'value': config_utils('network', 'leco-server', 'port')},
+        ]},
+    ]
+
+
 config_utils = Config()
 config = ControlModulesConfig()
 logger = set_logger(get_module_name(__file__))

--- a/packages/pymodaq/src/pymodaq/control_modules/viewer_utility_classes.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/viewer_utility_classes.py
@@ -19,7 +19,7 @@ from pymodaq_utils.serialize.mysocket import Socket
 from pymodaq_utils.serialize.serializer_legacy import DeSerializer, Serializer
 from pymodaq_gui.plotting.utils.plot_utils import RoiInfo
 from pymodaq.control_modules.thread_commands import ThreadStatus, ThreadStatusViewer
-from pymodaq.control_modules.utils import create_controller_param, ControllerStatus
+from pymodaq.control_modules.utils import create_controller_param, create_remote_connection_params, ControllerStatus
 from pymodaq_gui.utils.utils import mkQApp
 from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.parameter.ioxml import VALID_FOR_CONFIGURATION
@@ -57,25 +57,7 @@ params = [
         {'title': 'Wait time (ms):', 'name': 'wait_time', 'type': 'int', 'default': 0, 'value': 00, 'min': 0},
         {'title': 'Continuous saving:', 'name': 'continuous_saving_opt', 'type': 'bool', 'default': False,
          'value': False},
-        {'title': 'TCP/IP options:', 'name': 'tcpip', 'type': 'group', 'visible': True, 'expanded': False, 'children': [
-            {'title': 'Connect to server:', 'name': 'connect_server', 'type': 'bool_push', 'label': 'Connect',
-             'value': False},
-            {'title': 'Connected?:', 'name': 'tcp_connected', 'type': 'led', 'value': False,
-             VALID_FOR_CONFIGURATION: False},
-            {'title': 'IP address:', 'name': 'ip_address', 'type': 'str',
-             'value': config('network', 'tcp-server', 'ip')},
-            {'title': 'Port:', 'name': 'port', 'type': 'int', 'value': config('network', 'tcp-server', 'port')},
-        ]},
-        {'title': 'LECO options:', 'name': 'leco', 'type': 'group', 'visible': True, 'expanded': False,
-         'children': [
-             {'title': 'Connect:', 'name': 'connect_leco_server', 'type': 'bool_push', 'label': 'Connect',
-              'value': False},
-             {'title': 'Connected?:', 'name': 'leco_connected', 'type': 'led', 'value': False,
-              VALID_FOR_CONFIGURATION: False},
-             {'title': 'Name', 'name': 'leco_name', 'type': 'str', 'value': "", 'default': ""},
-             {'title': 'Host:', 'name': 'host', 'type': 'str', 'value': config('network', "leco-server", "host"), "default": "localhost"},
-             {'title': 'Port:', 'name': 'port', 'type': 'int', 'value': config('network', 'leco-server', 'port')},
-         ]},
+    ] + create_remote_connection_params() + [
         {'title': 'Overshoot options:', 'name': 'overshoot', 'type': 'group', 'visible': True, 'expanded': False,
          'children': [
              {'title': 'Overshoot:', 'name': 'stop_overshoot', 'type': 'bool', 'value': False},


### PR DESCRIPTION
- Using common function create_remote_connection_params for both viewer/move_utility_classes 
- change leco_connected/tcp_connected settings to read_only to avoid changing its status by clicking on it