### PR TITLE
patching the signal signature for pyside6

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/tree_layout.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/tree_layout.py
@@ -31,8 +31,8 @@ class TreeLayout(QObject):
         self.close_tree_pb.clicked.connect(self.collapse_all)
         self.open_tree_selected_pb.clicked.connect(self.open_tree_selection)
         
-        self.tree.itemClicked.connect(self.item_clicked_sig.emit)
-        self.tree.itemDoubleClicked.connect(self.item_double_clicked_sig.emit)
+        self.tree.itemClicked.connect(lambda item, index: self.item_clicked_sig.emit(item))
+        self.tree.itemDoubleClicked.connect(lambda item, index: self.item_double_clicked_sig.emit(item))
 
     def _current_text(self, col_index: int = 2):
         return self.tree.currentItem().text(col_index)

--- a/packages/pymodaq_gui/tests/utils/widgets/tree_layout_test.py
+++ b/packages/pymodaq_gui/tests/utils/widgets/tree_layout_test.py
@@ -11,29 +11,26 @@ DATA = [dict(name='papa', contents=[
         dict(name='maman', contents=[dict(name='fistone', contents=[dict(name='subfistone', contents='baby')])])]
 
 @fixture
-def tree_yield(qtbot):
+def tree(qtbot):
     widget = QtWidgets.QWidget()
     tree = TreeLayout(widget, col_counts=2, labels=["Material", "File"])
     qtbot.addWidget(widget)
     widget.show()
 
-    yield tree, qtbot
+    yield tree
     widget.close()
 
 
 
-def test_populate_tree(tree_yield):
-    tree, qtbot = tree_yield
+def test_populate_tree(tree):
     tree.populate_tree(DATA)
 
 
-def test_add_action(tree_yield):
-    tree, qtbot = tree_yield
+def test_add_action(tree):
     detector_action = QtWidgets.QAction("Grab from camera", None)
     tree.tree.addAction(detector_action)
 
-def test_clicked(tree_yield):
-    tree, qtbot = tree_yield
+def test_clicked(tree):
     tree.populate_tree(DATA)
 
     def print_item(item: QtWidgets.QTreeWidgetItem):

--- a/packages/pymodaq_gui/tests/utils/widgets/tree_layout_test.py
+++ b/packages/pymodaq_gui/tests/utils/widgets/tree_layout_test.py
@@ -1,0 +1,54 @@
+from pytest import fixture
+from pytestqt import qtbot
+from qtpy import QtWidgets, QtCore
+
+from pymodaq_gui.utils.widgets.tree_layout import TreeLayout
+
+DATA = [dict(name='papa', contents=[
+    dict(name='fiston', contents=[dict(name='subfiston', contents='baby', filename='Cest pas sorcier')]),
+    dict(name='fiston1', contents=[dict(name='subfiston', contents='baby', filename='Cest pas malin')]),
+    dict(name='fiston2', contents=[dict(name='subfiston', contents='baby', filename='Cest pas normal')])]),
+        dict(name='maman', contents=[dict(name='fistone', contents=[dict(name='subfistone', contents='baby')])])]
+
+@fixture
+def tree_yield(qtbot):
+    widget = QtWidgets.QWidget()
+    tree = TreeLayout(widget, col_counts=2, labels=["Material", "File"])
+    qtbot.addWidget(widget)
+    widget.show()
+
+    yield tree, qtbot
+    widget.close()
+
+
+
+def test_populate_tree(tree_yield):
+    tree, qtbot = tree_yield
+    tree.populate_tree(DATA)
+
+
+def test_add_action(tree_yield):
+    tree, qtbot = tree_yield
+    detector_action = QtWidgets.QAction("Grab from camera", None)
+    tree.tree.addAction(detector_action)
+
+def test_clicked(tree_yield):
+    tree, qtbot = tree_yield
+    tree.populate_tree(DATA)
+
+    def print_item(item: QtWidgets.QTreeWidgetItem):
+        print(item.text(0))
+
+    tree.item_clicked_sig.connect(print_item)
+    tree.item_double_clicked_sig.connect(print_item)
+
+    ROW = 1
+    COL = 1
+
+    tree.tree.itemClicked.emit(tree.tree.itemFromIndex(tree.tree.model().index(ROW,COL)), COL)
+    tree.tree.itemDoubleClicked.emit(tree.tree.itemFromIndex(tree.tree.model().index(ROW, COL)), COL)
+
+
+
+
+


### PR DESCRIPTION
When using the tree_layout widget (pymodaq_gui) used for instance in the h5browser, then simple click or double click is raising an error in pyside6 due to signal signature mismatch (which is not the case for pyqt6...)

This PR patch this together with a test suite ! 