### PR TITLE
Allow to load dashboard with preset and config

### DIFF
--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -1631,9 +1631,14 @@ def main():
     app = mkQApp('Dashboard')
 
     # Command-line argument parsing
-    parser = argparse.ArgumentParser(prog="dashboard", description="PyMoDAQ dashboard")
-    parser.add_argument("-p", "--preset", metavar="PRESET_NAME", help="preset name to load")
-    parser.add_argument("-c", "--config", metavar="CONFIG_NAME", help="config name to execute")
+    parser = argparse.ArgumentParser(prog="dashboard",
+                                     description="PyMoDAQ dashboard. "
+                                                 "Command-line options only affect GUI initial state."
+                                     )
+    parser.add_argument("-p", "--preset", metavar="PRESET_NAME",
+                        help="preset name to load at startup")
+    parser.add_argument("-c", "--config", metavar="CONFIG_NAME",
+                        help="config name to execute (ignored if no preset provided)")
     args = parser.parse_args()
 
     # If preset name is supplied, load dashboard with this preset

--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -1633,11 +1633,12 @@ def main():
     # Command-line argument parsing
     parser = argparse.ArgumentParser(prog="dashboard", description="PyMoDAQ dashboard")
     parser.add_argument("-p", "--preset", metavar="PRESET_NAME", help="preset name to load")
+    parser.add_argument("-c", "--config", metavar="CONFIG_NAME", help="config name to execute")
     args = parser.parse_args()
 
     # If preset name is supplied, load dashboard with this preset
     if args.preset:
-        dashboard, extension, win = load_dashboard_with_preset(args.preset)
+        dashboard, extension, win = load_dashboard_with_preset(args.preset, configuration_name=args.config)
 
     # If no command-line arguments are supplied, start empty
     else:

--- a/packages/pymodaq/src/pymodaq/utils/gui_utils/loader_utils.py
+++ b/packages/pymodaq/src/pymodaq/utils/gui_utils/loader_utils.py
@@ -8,7 +8,7 @@ from qtpy.QtWidgets import QMessageBox, QMainWindow
 from pymodaq import dashboard
 from pymodaq.dashboard import DashBoard
 from pymodaq.utils.gui_utils import DockArea
-from pymodaq.utils.config import get_set_preset_path
+from pymodaq.utils.config import get_set_preset_path, get_set_configurator_path
 from pymodaq.extensions.utils import CustomExt
 
 from pymodaq.utils.shared_ui import SharedUI
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from pymodaq.control_modules.daq_viewer import DAQ_Viewer
 
 
-def load_dashboard_with_preset(preset_name: str, extension_name: str = None)  -> \
+def load_dashboard_with_preset(preset_name: str, extension_name: str = None, configuration_name: str = None)  -> \
         tuple[DashBoard, CustomExt, QMainWindow]:
 
     """ Load the Dashboard using a given preset then load an extension
@@ -45,13 +45,15 @@ def load_dashboard_with_preset(preset_name: str, extension_name: str = None)  ->
     """
     shared_ui, dashboard = create_load_dashboard()
 
-
-    preset_name = Path(preset_name).stem
+    preset_path = get_set_preset_path().joinpath(f'{preset_name}.xml')
+    preset_name = preset_path.stem
     extension = None
 
     if preset_name in dashboard.preset_manager.entries:
-        dashboard.preset_manager.entry = preset_name
-
+        dashboard.preset_manager.execute_entry_base(preset_path)
+        if configuration_name is not None:
+            configuration_path = get_set_configurator_path().joinpath(preset_name).joinpath(f'{configuration_name}.config')
+            dashboard.configurator.execute_entry(configuration_path)
         if extension_name is not None:
             if extension_name == 'DAQScan':
                 extension = dashboard.load_scan_module()

--- a/packages/pymodaq/src/pymodaq/utils/gui_utils/loader_utils.py
+++ b/packages/pymodaq/src/pymodaq/utils/gui_utils/loader_utils.py
@@ -53,7 +53,7 @@ def load_dashboard_with_preset(preset_name: str, extension_name: str = None, con
         dashboard.preset_manager.execute_entry_base(preset_path)
         if configuration_name is not None:
             configuration_path = get_set_configurator_path().joinpath(preset_name).joinpath(f'{configuration_name}.config')
-            dashboard.configurator.execute_entry(configuration_path)
+            dashboard.configurator.execute_entry_base(configuration_path)
         if extension_name is not None:
             if extension_name == 'DAQScan':
                 extension = dashboard.load_scan_module()


### PR DESCRIPTION
It is a fix and a feature:

1. Loading a preset from command line was broken, it just set the selected preset to the one provided but didn't load it. This is fixed.
2. We can also tell the program to load a specific configuration (after the default one that is always automatically loaded)