### PR TITLE
Refactor QApplication exec

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/control_module_selector.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/control_module_selector.py
@@ -1,6 +1,5 @@
 from qtpy import QtWidgets, QtCore
 
-import pymodaq_gui.qt_utils
 from pymodaq.control_modules.instruments import DET_TYPES
 
 REMOTE_ITEMS  = {'LECODirector', 'TCPServer'}
@@ -131,6 +130,7 @@ def add_category_layers(dimension_dict, remote_items=None, mock_items=None):
 
 
 if __name__ == '__main__':
+    import sys
     from pymodaq_gui.qt_utils import mkQApp
 
     app = mkQApp('Selector')
@@ -147,6 +147,6 @@ if __name__ == '__main__':
     selector = ModuleSelector('Add', add_menu_entries)
     selector.add_widget.show()
 
-    pymodaq_gui.qt_utils.exec()
+    sys.exit(app.exec())
 
 

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
@@ -20,7 +20,6 @@ from qtpy import QtWidgets
 
 from easydict import EasyDict as edict
 
-import pymodaq_gui.qt_utils
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.utils import find_keys_from_val
 from pymodaq_utils import utils
@@ -1179,7 +1178,7 @@ def main(init_qt=True):
     app = mkQApp("PyMoDAQ Move")
     shared_ui, daq_move = create_load_daq_move('simple')
     shared_ui.show()
-    pymodaq_gui.qt_utils.exec()
+    sys.exit(app.exec())
 
 
 if __name__ == "__main__":

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_move_ui/uis/binary.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_move_ui/uis/binary.py
@@ -101,7 +101,7 @@ def main(init_qt=True):
 
     win.show()
     if init_qt:
-        sys.exit(app.exec_())
+        sys.exit(app.exec())
     return prog, widget
 
 

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_move_ui/uis/relative.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_move_ui/uis/relative.py
@@ -89,7 +89,7 @@ def main(init_qt=True):
 
     win.show()
     if init_qt:
-        sys.exit(app.exec_())
+        sys.exit(app.exec())
     return prog, widget
 
 

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_move_ui/uis/simple.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_move_ui/uis/simple.py
@@ -90,7 +90,7 @@ def main(init_qt=True):
 
     win.show()
     if init_qt:
-        sys.exit(app.exec_())
+        sys.exit(app.exec())
     return prog, widget
 
 

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
@@ -1419,7 +1419,7 @@ def main(init_qt=True, init_det=False):
         daq_viewer.init_hardware_ui(init_det)
 
     if init_qt:
-        sys.exit(app.exec_())
+        sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer_ui/ui_base.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer_ui/ui_base.py
@@ -363,7 +363,7 @@ def main(init_qt=True):
 
 
     if init_qt:
-        sys.exit(app.exec_())
+        sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq/src/pymodaq/control_modules/move_utility_classes.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/move_utility_classes.py
@@ -213,7 +213,7 @@ def main(plugin_file, init=True, title='test'):
     if init:
         prog.init_hardware_ui()
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 ##########################

--- a/packages/pymodaq/src/pymodaq/control_modules/viewer_utility_classes.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/viewer_utility_classes.py
@@ -115,7 +115,7 @@ def main(plugin_file=None, init=True, title='Testing'):
     if init:
         prog.init_hardware_ui()
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 class DAQ_Viewer_base(QObject):

--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -22,7 +22,6 @@ from qtpy.QtWidgets import (
 )
 import numpy as np
 
-import pymodaq_gui.qt_utils
 from pymodaq.control_modules.daq_viewer_ui.viewer_selector import SelectedModule
 
 from pymodaq_utils.logger import set_logger, get_module_name
@@ -1645,7 +1644,7 @@ def main():
         win.show()
 
     # Run application
-    pymodaq_gui.qt_utils.exec()
+    sys.exit(app.exec())
 
 
 if __name__ == "__main__":

--- a/packages/pymodaq/src/pymodaq/examples/function_plotter.py
+++ b/packages/pymodaq/src/pymodaq/examples/function_plotter.py
@@ -153,7 +153,7 @@ def main():
     prog = FunctionPlotter(dockarea)
 
     mainwindow.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq/src/pymodaq/examples/nonlinearscanner.py
+++ b/packages/pymodaq/src/pymodaq/examples/nonlinearscanner.py
@@ -119,7 +119,7 @@ def main():
     prog.positions_signal.connect(dash.scan_module.scanner.update_tabular_positions)
 
     mainwindow.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq/src/pymodaq/extensions/adaptive/adaptive_optimization.py
+++ b/packages/pymodaq/src/pymodaq/extensions/adaptive/adaptive_optimization.py
@@ -1,4 +1,3 @@
-import pymodaq_gui.qt_utils
 from pymodaq_gui.messenger import messagebox
 from pymodaq_utils import utils
 from pymodaq_utils import config as config_mod
@@ -163,6 +162,7 @@ class AdaptiveOptimisation(GenericOptimization):
 
 
 def main():
+    import sys
     from pymodaq_gui.qt_utils import mkQApp
     from pymodaq.utils.gui_utils.loader_utils import load_dashboard_with_preset
 
@@ -171,9 +171,7 @@ def main():
 
     dashboard, extension, win = load_dashboard_with_preset(preset_file_name, 'AdaptiveScan')
 
-    pymodaq_gui.qt_utils.exec()
-
-    return dashboard, extension, win
+    sys.exit(app.exec())
 
 if __name__ == '__main__':
     main()

--- a/packages/pymodaq/src/pymodaq/extensions/bayesian/bayesian_optimization.py
+++ b/packages/pymodaq/src/pymodaq/extensions/bayesian/bayesian_optimization.py
@@ -1,4 +1,3 @@
-import pymodaq_gui.qt_utils
 from pymodaq_utils import config as config_mod, utils
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.utils import ThreadCommand
@@ -125,6 +124,7 @@ class BayesianOptimization(GenericOptimization):
 
 
 def main():
+    import sys
     from pymodaq_gui.qt_utils import mkQApp
     from pymodaq.utils.gui_utils.loader_utils import load_dashboard_with_preset
 
@@ -133,9 +133,7 @@ def main():
 
     dashboard, extension, win = load_dashboard_with_preset('beam_steering', 'Bayesian')
 
-    pymodaq_gui.qt_utils.exec()
-
-    return dashboard, extension, win
+    sys.exit(app.exec())
 
 if __name__ == '__main__':
     main()

--- a/packages/pymodaq/src/pymodaq/extensions/console.py
+++ b/packages/pymodaq/src/pymodaq/extensions/console.py
@@ -8,7 +8,6 @@ Created the 25/10/2022
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
 from qtconsole.inprocess import QtInProcessKernelManager
 
-import pymodaq_gui.qt_utils
 from pymodaq_utils import config as configmod
 from pymodaq_utils.utils import get_version
 
@@ -57,6 +56,7 @@ class QtConsole(RichJupyterWidget):
 
 
 def main():
+    import sys
     from pymodaq_gui.qt_utils import mkQApp
 
     app = mkQApp('Console')
@@ -66,8 +66,7 @@ def main():
                      custom_banner=BANNER,
                      )
     prog.show()
-    pymodaq_gui.qt_utils.exec()
-    return prog
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq/src/pymodaq/extensions/daq_logger/daq_logger.py
+++ b/packages/pymodaq/src/pymodaq/extensions/daq_logger/daq_logger.py
@@ -11,7 +11,6 @@ from collections import OrderedDict
 import datetime
 from typing import TYPE_CHECKING, Union
 
-import pymodaq_gui.qt_utils
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_gui.utils.dock import Dock, DockArea
 from pymodaq_utils.config import Config
@@ -511,10 +510,7 @@ def main():
 
     dashboard, extension, win = load_dashboard_with_preset(preset_file_name, 'DAQLogger')
 
-    pymodaq_gui.qt_utils.exec()
-
-    return dashboard, extension, win
-
+    sys.exit(app.exec())
 
 if __name__ == '__main__':
     main()

--- a/packages/pymodaq/src/pymodaq/extensions/daq_scan.py
+++ b/packages/pymodaq/src/pymodaq/extensions/daq_scan.py
@@ -19,7 +19,6 @@ from qtpy import QtWidgets, QtCore, QtGui
 from qtpy.QtWidgets import QDialogButtonBox
 from qtpy.QtCore import QObject, Slot, QThread, Signal, QDateTime, QDate, QTime
 
-import pymodaq_gui.qt_utils
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.config import Config
 from pymodaq_utils import utils
@@ -1208,9 +1207,7 @@ def main():
 
     dashboard, extension, win = load_dashboard_with_preset(preset_file_name, 'DAQScan')
 
-    pymodaq_gui.qt_utils.exec()
-
-    return dashboard, extension, win
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq/src/pymodaq/extensions/daq_scan_ui.py
+++ b/packages/pymodaq/src/pymodaq/extensions/daq_scan_ui.py
@@ -234,7 +234,7 @@ def main():
     prog.command_sig.connect(print_command_sig)
     prog.update_viewers([ViewersEnum['Viewer0D'], ViewersEnum['Viewer1D'], ViewersEnum['Viewer2D']])
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq/src/pymodaq/extensions/data_mixer/data_mixer.py
+++ b/packages/pymodaq/src/pymodaq/extensions/data_mixer/data_mixer.py
@@ -1,10 +1,11 @@
+import sys
+
 from qtpy import QtWidgets, QtCore
 import numpy as np
 from pathlib import Path
 
 from typing import Optional
 
-import pymodaq_gui.qt_utils
 from pymodaq_gui import utils as gutils
 from pymodaq_utils.config import Config, ConfigError
 from pymodaq_utils.logger import set_logger, get_module_name
@@ -254,9 +255,8 @@ def main():
 
     preset_file_name = config_pymodaq('presets', 'default_preset_for_datamixer')
     dashboard, extension, win = load_dashboard_with_preset(preset_file_name, EXTENSION_NAME)
-    pymodaq_gui.qt_utils.exec()
 
-    return dashboard, extension, win
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq/src/pymodaq/extensions/pid/pid_controller.py
+++ b/packages/pymodaq/src/pymodaq/extensions/pid/pid_controller.py
@@ -9,7 +9,6 @@ from qtpy.QtCore import QObject, Slot, QThread, Signal
 
 from simple_pid import PID
 
-import pymodaq_gui.qt_utils
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.utils import ThreadCommand, find_dict_in_list_from_key_val
 from pymodaq.utils.exceptions import DetectorError, ActuatorError, PIDError
@@ -1006,6 +1005,7 @@ class PIDRunner(QObject):
 
 
 if __name__ == "__main__":
+    import sys
     from pymodaq_gui.qt_utils import mkQApp
     from pymodaq.utils.gui_utils.loader_utils import load_dashboard_with_preset
 
@@ -1014,4 +1014,4 @@ if __name__ == "__main__":
 
     dashboard, extension, win = load_dashboard_with_preset(preset_file_name, "DAQ_PID")
 
-    pymodaq_gui.qt_utils.exec()
+    sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/extensions/pid/utils.py
+++ b/packages/pymodaq/src/pymodaq/extensions/pid/utils.py
@@ -142,7 +142,7 @@ def main(xmlfile):
     import sys
     app = mkQApp('BeamSteering')
     dashboard, extension, win = load_dashboard_with_preset(xmlfile, 'DAQ_PID')
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def get_models(model_name=None):

--- a/packages/pymodaq/src/pymodaq/post_treatment/load_and_plot.py
+++ b/packages/pymodaq/src/pymodaq/post_treatment/load_and_plot.py
@@ -344,7 +344,7 @@ def main(init_qt=True):
     loader.show_data()
 
     if init_qt:
-        sys.exit(app.exec_())
+        sys.exit(app.exec())
     return loader, win
 
 

--- a/packages/pymodaq/src/pymodaq/utils/calibration_camera.py
+++ b/packages/pymodaq/src/pymodaq/utils/calibration_camera.py
@@ -177,4 +177,4 @@ if __name__ == '__main__':
     win = QtWidgets.QWidget()
     prog = CalibrationCamera(win)
     win.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/utils/chrono_timer.py
+++ b/packages/pymodaq/src/pymodaq/utils/chrono_timer.py
@@ -200,4 +200,4 @@ if __name__ == '__main__':
     # prog = ChronoTimer(area, dict(hours=1, minutes=0, seconds=0))
     prog = ChronoTimer(area)
     win.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/utils/managers/batchscan_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/batchscan_manager.py
@@ -329,7 +329,7 @@ def main_batch_scanner():
     main.setupUI()
     main.create_menu()
     win.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def main_batch_manager():
@@ -338,7 +338,7 @@ def main_batch_manager():
     actuators = [MockDAQMove(title='Xaxis'), MockDAQMove(title='Yaxis')]
     detectors = [MockDAQViewer(title='Det0D'), MockDAQViewer(title='Det1D')]
     prog = BatchManager(msgbox=True, actuators=actuators, detectors=detectors)
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq/src/pymodaq/utils/managers/configurator/configurator.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/configurator/configurator.py
@@ -395,4 +395,4 @@ if __name__ == "__main__":
     prog.mainwindow.show()
 
     external_ui.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/utils/managers/configurator/subentries.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/configurator/subentries.py
@@ -5,7 +5,6 @@ from typing import Callable, TYPE_CHECKING, Union, Tuple
 
 from qtpy import QtWidgets, QtCore
 
-import pymodaq_gui.qt_utils
 from pymodaq_data import DataToExport
 from pymodaq_gui.utils.widgets import SpinBox
 from pymodaq_gui.parameter.utils import Parameter, ParameterWithPath
@@ -353,6 +352,9 @@ class WaitSubEntryHandler(SubEntryHandler):
 
 
 if __name__ == '__main__':
+    import sys
+    from pymodaq_gui.qt_utils import mkQApp
+
     class MockModel:
         def add_data(self, index, data: ConfiguratorSubEntry):
             print(data)
@@ -362,14 +364,12 @@ if __name__ == '__main__':
 
     factory = SubEntryHandlerFactory()
 
-    from pymodaq_gui.qt_utils import mkQApp
-
     app = mkQApp('SpecialEntry')
 
     special_entry = factory.get_subentry_handler('wait_time')(MockModel(), None)
     special_entry.show_dialog()
 
     # Run application
-    pymodaq_gui.qt_utils.exec()
+    sys.exit(app.exec())
 
 

--- a/packages/pymodaq/src/pymodaq/utils/managers/modules_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/modules_manager.py
@@ -658,4 +658,4 @@ if __name__ == '__main__':
     manager = ModulesManager(actuators=[act1, act2], detectors=[prog, prog2, prog3], selected_detectors=[prog2])
     manager.settings_tree.show()
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/utils/managers/overshoot_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/overshoot_manager.py
@@ -239,4 +239,4 @@ if __name__ == '__main__':
     app = QtWidgets.QApplication(sys.argv)
     prog = OvershootManager(True, ['det camera', 'det current'], ['Move X', 'Move Y'])
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/utils/managers/preset/preset_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/preset/preset_manager.py
@@ -549,4 +549,4 @@ if __name__ == '__main__':
     prog.update_entry_base()
     prog.mainwindow.show()
     external_ui.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/utils/managers/remote_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/remote_manager.py
@@ -481,4 +481,4 @@ if __name__ == '__main__':
     #prog = RemoteManager(actuators=actuators, detectors=detectors, msgbox=True)
     msgBox = JoystickButtonsSelection()
     ret = msgBox.exec()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/utils/scanner/scan_selector.py
+++ b/packages/pymodaq/src/pymodaq/utils/scanner/scan_selector.py
@@ -469,7 +469,7 @@ def main_navigator():
     scan_selector = ScanSelector(viewer_items=items)
     scan_selector.settings_tree.show()
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq/src/pymodaq/utils/scanner/scanner.py
+++ b/packages/pymodaq/src/pymodaq/utils/scanner/scanner.py
@@ -315,7 +315,7 @@ def main():
     settings.child('set_scan').sigActivated.connect(scanner.set_scan)
     scanner.scanner_updated_signal.connect(print_info)
     widget_main.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq/src/pymodaq/utils/shared_ui.py
+++ b/packages/pymodaq/src/pymodaq/utils/shared_ui.py
@@ -21,7 +21,6 @@ import numpy as np
 from pymodaq_plugin_manager.manager import PluginManager
 from pymodaq_plugin_manager.validate import get_pypi_pymodaq
 
-import pymodaq_gui.qt_utils
 from pymodaq_gui.managers.action_manager import QAction
 from pymodaq_gui.utils import DockArea
 from pymodaq_utils.enums import StrEnum
@@ -365,7 +364,7 @@ def main():
     window = SharedUI(win)
 
     # Run application
-    pymodaq_gui.qt_utils.exec()
+    sys.exit(app.exec())
 
 
 if __name__ == "__main__":

--- a/packages/pymodaq/src/pymodaq/utils/svg/svg_renderer.py
+++ b/packages/pymodaq/src/pymodaq/utils/svg/svg_renderer.py
@@ -17,4 +17,4 @@ if __name__ == '__main__':
     widget.show()
     widget.load(r'C:\Users\weber\Labo\Projet-Dossier candidature\Technical project\GDSII\wafer.svg')
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/utils/svg/svg_view.py
+++ b/packages/pymodaq/src/pymodaq/utils/svg/svg_view.py
@@ -32,4 +32,4 @@ if __name__ == '__main__':
     prog = SVGView(widget)
     widget.show()
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/utils/svg/svg_viewer2D.py
+++ b/packages/pymodaq/src/pymodaq/utils/svg/svg_viewer2D.py
@@ -43,7 +43,7 @@ def main():
     prog.view.move_scale_roi_target((50, 40), (20, 20))
 
     QtWidgets.QApplication.processEvents()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/packages/pymodaq/src/pymodaq/utils/tcp_ip/tcp_server_client.py
+++ b/packages/pymodaq/src/pymodaq/utils/tcp_ip/tcp_server_client.py
@@ -769,4 +769,4 @@ if __name__ == '__main__':  # pragma: no cover
     grabber = Grabber(mockdata_grabber.grab)
     grabber.connect_tcp_ip()
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/action_checked_icons.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/action_checked_icons.py
@@ -1,4 +1,3 @@
-import pymodaq_gui.qt_utils
 from pymodaq_gui.managers.action_manager import ActionManager
 from pymodaq_utils.config import Config
 
@@ -38,7 +37,7 @@ def main():
     widget = QtWidgets.QWidget()
     mywidget = MyWidget(widget)
 
-    sys.exit(pymodaq_gui.qt_utils.exec())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/curves.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/curves.py
@@ -137,7 +137,7 @@ def main(data_distribution='uniform'):
 
 
     QtWidgets.QApplication.processEvents()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def generate_uniform_data() -> DataRaw:

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/custom_viewer.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/custom_viewer.py
@@ -109,4 +109,4 @@ if __name__ == '__main__':
     viewer.setYaxis(Axis(data=y, label='This is y axis', units='au'))
     win.show()
     app.processEvents()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/data_picker.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/data_picker.py
@@ -1,9 +1,10 @@
+import sys
+
 from qtpy.QtCore import Qt
 from qtpy import QtWidgets
 
 from typing import Optional
 
-import pymodaq_gui.qt_utils
 from pymodaq_data.data import DataRaw, Axis
 
 from pymodaq_gui.utils.widgets.table import SpinBoxDelegate
@@ -118,7 +119,7 @@ def main():
 
     data_picker.show_data(data_to_plot)
     win.show()
-    pymodaq_gui.qt_utils.exec()
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/icons.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/icons.py
@@ -4,8 +4,6 @@ from PyQt6.QtWidgets import (QApplication, QGridLayout, QPushButton, QStyle,
                              QWidget, QVBoxLayout)
 from PyQt6.QtGui import QIcon
 
-import pymodaq_gui.qt_utils
-
 
 class Icons():
     def __init__(self, widget: QWidget):
@@ -40,12 +38,13 @@ class Icons():
         self.widget.layout().addLayout(layout_theme)
 
 def main():
-    app = QApplication(sys.argv)
+    from pymodaq_gui.qt_utils import mkQApp
+    app = mkQApp("Icon list")
 
     w = Icons(QWidget())
     w.widget.show()
 
-    pymodaq_gui.qt_utils.exec()
+    sys.exit(app.exec())
 
 if __name__ == "__main__":
     main()

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/listwidget.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/listwidget.py
@@ -25,7 +25,7 @@ def main():
     itemsel.set_value(dict(all_items=[f'item{ind}' for ind in range(23)],
                            selected=[f'item{ind}' for ind in range(23)]))
     itemsel.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/material_icon_ex.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/material_icon_ex.py
@@ -74,7 +74,7 @@ class WidgetWithMaterialIcons(CustomApp):
 
 
 if __name__ == '__main__':
-
+    import sys
     from pymodaq_gui.qt_utils import mkQApp
 
     # Create application and main window
@@ -83,5 +83,5 @@ if __name__ == '__main__':
     myapp = WidgetWithMaterialIcons(parent)
 
     parent.show()
-    app.exec_()
+    sys.exit(app.exec())
 

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/parameter_ex.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/parameter_ex.py
@@ -6,7 +6,6 @@ import sys
 from qtpy import QtWidgets, QtCore
 from collections import OrderedDict
 
-import pymodaq_gui.qt_utils
 import pymodaq_gui.utils.widgets.table as table
 from pymodaq_gui.utils.utils import create_nested_menu
 from pymodaq_gui.parameter.pymodaq_ptypes import GroupParameter, registerParameterType
@@ -195,7 +194,7 @@ def main():
     ptree.settings.child('itemss', 'itemsbis').setValue(dict(all_items=['item1', 'item2', 'item3'],
                                                              selected=['item1', 'item3']))
 
-    pymodaq_gui.qt_utils.exec()
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync/6_parameter_binding_example.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/widget_sync/6_parameter_binding_example.py
@@ -484,7 +484,7 @@ def main():
     window = ParameterBindingExample()
     window.show()
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq_gui/src/pymodaq_gui/h5modules/h5browser.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/h5modules/h5browser.py
@@ -4,7 +4,6 @@ import sys
 import os
 from qtpy import QtWidgets
 
-import pymodaq_gui.qt_utils
 
 os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 from pymodaq_gui.h5modules.browsing import H5Browser
@@ -36,7 +35,7 @@ def main(h5file_path: Path = None):
     win.show()
     QtWidgets.QApplication.processEvents()
 
-    pymodaq_gui.qt_utils.exec()
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -6,7 +6,6 @@ from qtpy.QtCore import Qt, QModelIndex
 from qtpy import QtWidgets, QtCore, QtGui
 from qtpy.QtGui import QKeySequence
 
-import pymodaq_gui.qt_utils
 from pymodaq_gui.utils.styling import create_icon
 
 from pymodaq_utils.logger import set_logger, get_module_name
@@ -563,4 +562,4 @@ if __name__ == '__main__':
 
     widget.show_splash()
     execute_entries(entries)
-    pymodaq_gui.qt_utils.exec()
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/roi_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/roi_manager.py
@@ -660,4 +660,4 @@ if __name__ == '__main__':
     prog.add_roi_programmatically(ROI2D_TYPES[0])
     prog.add_roi_programmatically(ROI2D_TYPES[1])
     prog.add_roi_programmatically(ROI2D_TYPES[2])
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/pixmap.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/pixmap.py
@@ -142,7 +142,7 @@ def main_widget():
 
     prog.checkbox.toggled.connect(print_toggled)
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def main_parameter():
@@ -168,7 +168,7 @@ def main_parameter():
     prog = PixmapParameter()
     prog.settings_tree.show()
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/text_pattern.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/text_pattern.py
@@ -481,4 +481,4 @@ if __name__ == "__main__":
 
     p.sigTreeStateChanged.connect(value_changed)
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer.py
@@ -273,4 +273,4 @@ if __name__ == '__main__':
 
     prog.show_data(dte)
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer0D.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer0D.py
@@ -271,7 +271,7 @@ def main_view():
     widget = QtWidgets.QWidget()
     prog = View0D(widget)
     widget.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def main():
@@ -290,7 +290,7 @@ def main():
                                         labels=['lab1', 'lab2'], units="V"))
         QtWidgets.QApplication.processEvents()
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer1D.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer1D.py
@@ -706,7 +706,7 @@ def main():
     QtWidgets.QApplication.processEvents()
     prog.show_data(data)
     QtWidgets.QApplication.processEvents()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def main_unsorted():
@@ -725,7 +725,7 @@ def main_unsorted():
     widget.show()
     prog.show_data(data)
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def main_random():
@@ -746,7 +746,7 @@ def main_random():
     widget.show()
     prog.show_data(data)
     QtWidgets.QApplication.processEvents()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def main_extra_scatter():
@@ -775,7 +775,7 @@ def main_extra_scatter():
     widget.show()
     prog.show_data(data, scatter_dwa=scatter_dwa)
     QtWidgets.QApplication.processEvents()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def main_errors():
@@ -798,7 +798,7 @@ def main_errors():
     widget.show()
     prog.show_data(data)
     QtWidgets.QApplication.processEvents()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def main_view1D():
@@ -806,7 +806,7 @@ def main_view1D():
     widget = QtWidgets.QWidget()
     prog = View1D(widget)
     widget.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def main_nans():
@@ -826,7 +826,7 @@ def main_nans():
     widget.show()
     prog.show_data(data)
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def main_xy():
@@ -843,7 +843,7 @@ def main_xy():
                    )
     data.plot('qt')
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer1Dbasic.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer1Dbasic.py
@@ -228,4 +228,4 @@ if __name__ == '__main__':  # pragma: no cover
     Form.show()
     prog.x_axis
     prog.update_labels(labels=['sig0', 'tralala', 'ouhaouh'])
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer2D.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer2D.py
@@ -1046,7 +1046,7 @@ def main_spread():
     prog.show_data(DataRaw(name='mydata', distribution='spread', data=[data_spread],
                            axes=[]))
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def main(data_distribution='uniform'):
@@ -1092,7 +1092,7 @@ def main(data_distribution='uniform'):
     button.clicked.connect(lambda: plot_data(prog, ndata.value()))
     widget_button.show()
     QtWidgets.QApplication.processEvents()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def generate_uniform_data() -> DataRaw:
@@ -1133,7 +1133,7 @@ def main_view():
     form = QtWidgets.QWidget()
     prog = View2D(form)
     form.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer2D_basic.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer2D_basic.py
@@ -143,4 +143,4 @@ if __name__ == '__main__':  # pragma: no cover
     # tr.scale(300/rect.width(), 300/rect.height())
     # svg_item.setTransform(tr)
     pass
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewerND.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewerND.py
@@ -802,7 +802,7 @@ def main():
     prog.show_settings()
 
     widget.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 def spread_main():
@@ -840,7 +840,7 @@ def spread_main():
 
     widget.show()
     prog.show_data(data_2D_1x2_spread)
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/gant_chart.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/gant_chart.py
@@ -120,4 +120,4 @@ if __name__ == '__main__':
         dict(name='This is task 1, the best of all the tasks!yeeah baby', idnumber=1, task_type=1, time_start=5,
              time_end=7))
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/image_viewer.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/image_viewer.py
@@ -94,4 +94,4 @@ if __name__ == '__main__':
     window = Window()
     window.setGeometry(500, 300, 800, 600)
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/utils/axes_viewer.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/utils/axes_viewer.py
@@ -84,5 +84,5 @@ if __name__ == '__main__':
 
     prog.navigation_changed.connect(print_positions)
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/utils/filter.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/utils/filter.py
@@ -576,4 +576,4 @@ if __name__ == '__main__':
         2 * np.pi * 0.008 * xdata - np.deg2rad(-10)) + 2 * np.random.rand(len(xdata))
 
     prog.show_data(dict(data=ydata_sin, xaxis=xdata))
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/qt_utils.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/qt_utils.py
@@ -82,6 +82,3 @@ def mkQApp(name: str):
     return app
 
 
-def exec():
-    app = mkQApp('a name')
-    return app.exec() if hasattr(app, 'exec') else app.exec()

--- a/packages/pymodaq_gui/src/pymodaq_gui/qt_utils.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/qt_utils.py
@@ -84,4 +84,4 @@ def mkQApp(name: str):
 
 def exec():
     app = mkQApp('a name')
-    return app.exec() if hasattr(app, 'exec') else app.exec_()
+    return app.exec() if hasattr(app, 'exec') else app.exec()

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/file_io.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/file_io.py
@@ -92,4 +92,4 @@ if __name__ == '__main__':
     app = QtWidgets.QApplication(sys.argv)
     file = select_file(save=True, filter="Images (*.png *.xpm *.jpg);;Text files (*.txt);;XML files (*.xml)")
     print(file)
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/collapsible_widget.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/collapsible_widget.py
@@ -317,4 +317,4 @@ if __name__ == "__main__":
     main_layout.addStretch()
 
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/lcd.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/lcd.py
@@ -108,4 +108,4 @@ if __name__ == '__main__':
     for ind, data in enumerate(y1):
         prog.setvalues([np.array([data])])
         QtWidgets.QApplication.processEvents()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/push.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/push.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from qtpy import QtWidgets, QtCore, QtGui
 from qtpy.QtWidgets import QWidget
 
-import pymodaq_gui.qt_utils
 from pymodaq_gui.utils.styling import create_icon
 from pymodaq_gui.utils.widgets.spinbox import SpinBox
 
@@ -24,7 +23,7 @@ class PushButtonIcon(QtWidgets.QPushButton):
         
     def contextMenuEvent(self, event):
         if self._menu is not None:
-            pymodaq_gui.qt_utils.exec(event.globalPos())
+            self._menu.exec(event.globalPos())
 
 
 class EditPushInfo:
@@ -95,7 +94,7 @@ class ActionMenu(QtWidgets.QAction):
 
     def contextMenuEvent(self, event):
         if self._menu is not None:
-            pymodaq_gui.qt_utils.exec(event.globalPos())
+            self._menu.exec(event.globalPos())
 
 
 def main(init_qt=True):
@@ -139,7 +138,7 @@ def main(init_qt=True):
 
     widget.show()
     if init_qt:
-        sys.exit(app.exec_())
+        sys.exit(app.exec())
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/spinbox.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/spinbox.py
@@ -1,7 +1,6 @@
 from qtpy import QtWidgets, QtGui, QtCore
 from pyqtgraph.widgets.SpinBox import SpinBox
 
-import pymodaq_gui.qt_utils
 
 
 class SpinBox(SpinBox):
@@ -49,7 +48,7 @@ class QSpinBox_ro(SpinBox):
 
 
 if __name__ == '__main__':
-
+    import sys
     from pymodaq_gui.qt_utils import mkQApp
 
     app = mkQApp('Test Spinbox')
@@ -63,4 +62,4 @@ if __name__ == '__main__':
     spinbox.shortcut['Ctrl+Enter'].activatedAmbiguously.connect(lambda: print_spinbox(f'Ctrl+Enter: {spinbox.value()}'))
     spinbox.show()
 
-    pymodaq_gui.qt_utils.exec()
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/table.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/table.py
@@ -285,4 +285,4 @@ if __name__ == '__main__':
     # c = TreeFromToml()
     # c.show_dialog()
 
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/tree_layout.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/tree_layout.py
@@ -185,4 +185,4 @@ if __name__ == '__main__':
     # base_node = h5_file.root
     # base_tree_item, pixmap_items = h5tree_to_QTree(h5_file, base_node)
     # prog.ui.Tree.addTopLevelItem(base_tree_item)
-    sys.exit(app.exec_())
+    sys.exit(app.exec())


### PR DESCRIPTION
Fixes #875 

* Replace all calls to exec_ with exec as exec_ is deprecated
* Wrap all of them with sys.exit to return the correct exit code to the OS
* Removed qt_utils.exec function as not needed anymore
* Fixes a problematic usage of `qt_utils.exec` in `pymodaq_gui.utils.widgets.push` where `PushButtonIcon` and `ActionMenu` implementation of `contextMenuEvent` where calling exec on the app instead of the menu