### PR TITLE
LECODirector timers are stopped when directors are stopped

### DIFF
--- a/packages/pymodaq/src/pymodaq/utils/leco/daq_move_LECODirector.py
+++ b/packages/pymodaq/src/pymodaq/utils/leco/daq_move_LECODirector.py
@@ -210,7 +210,9 @@ class DAQ_Move_LECODirector(LECODirector, DAQ_Move_base):
 
     def close(self) -> None:
         """ Clear the content of the settings_clients setting"""
+        self.timer.stop()
         super().close()
+
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq/src/pymodaq/utils/leco/daq_xDviewer_LECODirector.py
+++ b/packages/pymodaq/src/pymodaq/utils/leco/daq_xDviewer_LECODirector.py
@@ -158,6 +158,9 @@ class DAQ_xDViewer_LECODirector(LECODirector, DAQ_Viewer_base):
             raise ValueError("Can't set_data when data is None")
         self.dte_signal.emit(dte)
 
+    def close(self) -> None:
+        self.timer.stop()
+        super().close()
 
 if __name__ == '__main__':
     main(__file__, init=False)


### PR DESCRIPTION
LECODirector are using timers and were relying on qt main thread itself to stop and release them when they lived and were active in a different thread, causing this obscure error/warning message:

```
QObject::killTimer: Timers cannot be stopped from another thread
QObject::~QObject: Timers cannot be stopped from another thread
```
