### PR TITLE
global pyproject

### DIFF
--- a/packages/pymodaq/pyproject.toml
+++ b/packages/pymodaq/pyproject.toml
@@ -85,11 +85,3 @@ include = [
     "/src",
 ]
 
-[tool.coverage.run]
-omit = [
-    "*/examples/*",
-    "*/resources/*"
-]
-
-[tool.ruff]
-line-length = 120

--- a/packages/pymodaq_gui/pyproject.toml
+++ b/packages/pymodaq_gui/pyproject.toml
@@ -79,7 +79,3 @@ include = [
     "/src",
 ]
 
-[tool.coverage.run]
-omit = [
-    "*/examples/*",
-]

--- a/packages/pymodaq_utils/pyproject.toml
+++ b/packages/pymodaq_utils/pyproject.toml
@@ -74,7 +74,3 @@ include = [
     "/src",
 ]
 
-[tool.coverage.run]
-omit = [
-    "*/resources/*"
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+# Root configuration for development tooling
+# Package-specific build configs remain in packages/*/pyproject.toml
+
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
+testpaths = ["packages"]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+    "ignore::PendingDeprecationWarning",
+]
+
+[tool.coverage.run]
+source = ["packages"]
+omit = [
+    "*/tests/*",
+    "*/examples/*",
+    "*/resources/*",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]
+
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+
+[tool.ruff.lint]
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # pyflakes
+    "I",      # isort
+    "UP",     # pyupgrade
+    "B",      # flake8-bugbear
+    "SIM",    # flake8-simplify
+]
+ignore = [
+    "E501",   # line too long (handled by formatter)
+    "B008",   # function call in default argument (common in Qt)
+    "SIM108", # ternary operator (can reduce readability)
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["pymodaq", "pymodaq_utils", "pymodaq_data", "pymodaq_gui"]
+
+[tool.ruff.lint.per-file-ignores]
+"**/tests/*" = ["B", "SIM"]  # relaxed rules for tests


### PR DESCRIPTION
Hey everyone,

so I have been struggling a lot using pytest and vscode.  The main reason comes from the pytest discovery which had a lot of errors and I was stuck passing by the terminal to test each package separately.
The errors mostly originated from tests sharing the same name between the different packages in pymodaq.

Trying to fix this, I discovered two things:
-- The "--import-mode=importlib" argument allows pytest to make the difference between files with same name.
-- We can give a global config to the different subpackages with this keyword attached to it

I propose to take this occasion to make a pyproject.toml that gathers the formatting/coverage/settings that we would like to be applied in the suite.

Here is a proposition of such file