### PR TITLE
adding a condition to set the correct icon if checked is true

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
@@ -168,6 +168,8 @@ def addaction(name: str = '', icon_name: Union[str, Path, QtGui.QIcon]= '', tip=
     action.setCheckable(checkable)
     if checkable:
         action.setChecked(checked)
+        if checked and hasattr(action, 'icon_checked'):
+            action.set_icon()
     action.setToolTip(tip)
     if toolbar is not None:
         toolbar.addAction(action)


### PR DESCRIPTION
When adding an action with the ActionManager as:
```
        self.add_action('sync_x_axis', 
                        'Sync X axis',
                        'sync_disabled',
                        'If checked, adding a new channel resets all histories so curves share the same x-axis origin', 
                        checkable=True, 
                        checked=True, 
                        icon_checked='sync_lock',
                        icon_color='#F9A825', 
                        icon_checked_color='#607D8B')
```

The initial action is checked but with the unchecked icon.
This PR adds a set_icon in init to use the checked version.