### PR TITLE
Bugfix/preset

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -280,12 +280,12 @@ class ManagerBase(CustomExt):
                         f'Reload {self.entry_type.capitalize()}', 'refresh',
                         tip=f'Reload the current {self.entry_type} file ("Ctrl+R")',
                         icon_color=self.get_theme().orange,
-                        shortcut=QKeySequence(Qt.Modifier.CTRL | Qt.Key.Key_R))
+                        shortcut=QKeySequence(Qt.Modifier.CTRL | Qt.Modifier.SHIFT | Qt.Key.Key_R))
         self.add_action(ManagerActions.EXECUTE,
                         f'Execute {self.entry_type.capitalize()}', 'start',
                         icon_color=self.get_theme().magenta,
-                        tip=f'Execute the current {self.entry_type} file ("Ctrl+E")',
-                        shortcut=QKeySequence(Qt.Modifier.CTRL | Qt.Key.Key_E))
+                        tip=f'Execute the current {self.entry_type} file ("Ctrl+Shift+E")',
+                        shortcut=QKeySequence(Qt.Modifier.CTRL | Qt.Modifier.SHIFT | Qt.Key.Key_E))
         self.add_action(ManagerActions.OPEN, f"{self.entry_type.capitalize()} Manager",
                         "build_circle",
                         icon_color=self.get_theme().blue,
@@ -513,7 +513,7 @@ class ManagerBase(CustomExt):
 
     def update_execute_action_tooltip(self, entry: str):
         self.get_action(ManagerActions.EXECUTE).setToolTip(
-            f'Execute the selected {self.entry_type} entry: {entry} ("Ctrl+A")')
+            f'Execute the selected {self.entry_type} entry: {entry} ("Ctrl+Shift+E")')
 
     def create_slot_from_file(self, filename: Path):
         return lambda: self.execute_entry_base(filename)

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -278,7 +278,7 @@ class ManagerBase(CustomExt):
                         shortcut=QKeySequence(Qt.Modifier.CTRL | Qt.Key.Key_S))
         self.add_action(ManagerActions.RELOAD,
                         f'Reload {self.entry_type.capitalize()}', 'refresh',
-                        tip=f'Reload the current {self.entry_type} file ("Ctrl+R")',
+                        tip=f'Reload the current {self.entry_type} file ("Ctrl+Shift+R")',
                         icon_color=self.get_theme().orange,
                         shortcut=QKeySequence(Qt.Modifier.CTRL | Qt.Modifier.SHIFT | Qt.Key.Key_R))
         self.add_action(ManagerActions.EXECUTE,

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -359,8 +359,8 @@ class ManagerBase(CustomExt):
                 None,
                 f'Enter a NEW {self.entry_type.capitalize()} name',
                 f'{self.entry_type.capitalize()} name:', QtWidgets.QLineEdit.Normal)
-        self.do_things_for_new_creation()
         if ok and entry != '':
+            self.do_things_for_new_creation()
             if self.save_check(entry, bypass_dialog=bypass_dialog):
                 self.entries_sync.append_to_list('items', entry)
                 self.entries_sync.update_key('current', entry)


### PR DESCRIPTION
- There are some conflicts currently with shortcut CTRL+E between the daq_move and the preset making the QAction ambiguous. I propose to use the shortcut CTRL + SHIFT + E / CTRL + SHIFT + R to apply either the preset or the configurator. Future conflicts should be avoided and applying config keeps a consistent syntax
- When adding a new entry, the manager always go for self.do_things_for_new_creation() even if the user pressed cancel. This leaves it with a blank preset but with the name of the previous one. Now we only get a new preset if a valid name has been given by the user.