### PR TITLE
Feature/flipping icons horizontally/vertically

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
@@ -30,16 +30,20 @@ class QAction(QtQAction):
                  name='',
                  icon_checked: Union[str, QtGui.QIcon] = None,
                  icon_color: Union[QtGui.QColor, bytes, str]=None,
-                 icon_checked_color: Union[QtGui.QColor, bytes, str]=None):
+                 icon_checked_color: Union[QtGui.QColor, bytes, str]=None,
+                 flip_h: bool = False,
+                 flip_v: bool = False):
 
         if icon_unchecked is not None:
-            self.icon_unchecked = create_icon(icon_unchecked, icon_color, icon_checked_color)
+            self.icon_unchecked = create_icon(icon_unchecked, icon_color, icon_checked_color,
+                                              flip_h=flip_h, flip_v=flip_v)
             super().__init__(self.icon_unchecked, name)
         else:
             super().__init__(name)
 
         if icon_unchecked is not None and icon_checked is not None and not isinstance(icon_checked, QtGui.QIcon):
-            icon_checked = create_icon(icon_checked, icon_checked_color, icon_checked_color)
+            icon_checked = create_icon(icon_checked, icon_checked_color, icon_checked_color,
+                                       flip_h=flip_h, flip_v=flip_v)
             if isinstance(icon_unchecked, MaterialIcon):
                 self.icon_unchecked.set_icon(icon_checked, state=QtGui.QIcon.State.On)
             else:
@@ -114,7 +118,9 @@ def addaction(name: str = '', icon_name: Union[str, Path, QtGui.QIcon]= '', tip=
               menu: QtWidgets.QMenu = None, visible=True, shortcut: Union[str, QtCore.Qt.Key, QtGui.QKeySequence]=None,
               enabled=True, icon_checked: Union[str, Path, QtGui.QIcon] = None,
               icon_color: Union[QtGui.QColor, str] = None,
-              icon_checked_color: Union[QtGui.QColor, str] = None
+              icon_checked_color: Union[QtGui.QColor, str] = None,
+              flip_h: bool = False,
+              flip_v: bool = False,
               ):
     """Create a new action and add it eventually to a toolbar and a menu
 
@@ -153,13 +159,18 @@ def addaction(name: str = '', icon_name: Union[str, Path, QtGui.QIcon]= '', tip=
         color to be applied (if possible) to the unchecked icon
     icon_checked_color: QtGui.QColor / str
         color to be applied to the checked icon (if any)
+    flip_h: bool
+        mirror the icon horizontally (left ↔ right)
+    flip_v: bool
+        mirror the icon vertically (top ↔ bottom)
     """
 
     if icon_name is None or icon_name == '':
         action = QAction(None, name)
     else:
         action = QAction(icon_name, name, icon_checked=icon_checked,
-                         icon_color=icon_color, icon_checked_color=icon_checked_color)
+                         icon_color=icon_color, icon_checked_color=icon_checked_color,
+                         flip_h=flip_h, flip_v=flip_v)
 
     if slot is not None:
         action.connect_to(slot)
@@ -308,7 +319,9 @@ class ActionManager:
                    auto_toolbar=True, auto_menu=True,
                    enabled=True, icon_checked: Union[str, Path, QtGui.QIcon] = None,
                    icon_color: Union[QtGui.QColor, bytes, str]=None,
-                   icon_checked_color: Union[QtGui.QColor, bytes, str]=None
+                   icon_checked_color: Union[QtGui.QColor, bytes, str]=None,
+                   flip_h: bool = False,
+                   flip_v: bool = False,
                    ):
         """Create a new action and add it to toolbar and menu
 
@@ -359,6 +372,10 @@ class ActionManager:
             color to be applied (if possible) to the unchecked icon
         icon_checked_color: QtGui.QColor / str
             color to be applied to the checked icon (if any)
+        flip_h: bool
+            mirror the icon horizontally (left ↔ right)
+        flip_v: bool
+            mirror the icon vertically (top ↔ bottom)
 
         See Also
         --------
@@ -385,7 +402,9 @@ class ActionManager:
                                               visible=visible, shortcut=shortcut, enabled=enabled,
                                               icon_checked=icon_checked,
                                               icon_color=icon_color,
-                                              icon_checked_color=icon_checked_color)
+                                              icon_checked_color=icon_checked_color,
+                                              flip_h=flip_h,
+                                              flip_v=flip_v)
         return self._actions[short_name]
 
     def add_widget(self, short_name, klass: Union[str, QtWidgets.QWidget, object], *args, tip='',

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
@@ -835,6 +835,8 @@ class ActionManager:
         """Set the CheckedState of a given action or a list of actions"""
         if action_name in self._actions:
             self._actions[action_name].setChecked(checked)
+            if hasattr(self._actions[action_name], 'icon_checked'):
+                self._actions[action_name].set_icon()
         else:
             raise KeyError(f'The action with name: {action_name} is not referenced'
                            f' in the actions list: {self._actions}')

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/styling.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/styling.py
@@ -35,6 +35,77 @@ def create_color(icon_color: Union[QtGui.QColor, str]) -> Union[QtGui.QColor, No
                     icon_color = None
     return icon_color
 
+def transform_icon(icon: QtGui.QIcon, transform: QtGui.QTransform) -> QtGui.QIcon:
+    """Return a new QIcon with all pixmaps transformed by transform.
+    
+    Parameters
+    ----------
+    icon: QtGui.QIcon
+        The icon to transform.
+        
+    transform: QtGui.QTransform
+        The transform to apply to the icon.
+    """
+    new_icon = QtGui.QIcon()
+    sizes = icon.availableSizes() or [QtCore.QSize(s, s) for s in (20, 40)]
+    for size in sizes:
+        for state in (QtGui.QIcon.State.Off, QtGui.QIcon.State.On):
+            px = icon.pixmap(size, QtGui.QIcon.Mode.Normal, state)
+            if not px.isNull():
+                new_icon.addPixmap(
+                    QtGui.QPixmap.fromImage(px.transformed(transform)),
+                    QtGui.QIcon.Mode.Normal,
+                    state,
+                )
+    return new_icon
+
+def _translate_icon(icon: QtGui.QIcon, x: int = 0, y: int = 0) -> QtGui.QIcon:
+    """Return a new QIcon with all pixmaps translated by x and y pixels.
+    
+    Parameters
+    ----------
+    icon: QtGui.QIcon
+        The icon to translate.
+        
+    x: int
+        The number of pixels to translate the icon in the x direction.
+        
+    y: int
+        The number of pixels to translate the icon in the y direction.
+    """
+    transform = QtGui.QTransform().translate(x, y)
+    return transform_icon(icon, transform)
+
+def _scale_icon(icon: QtGui.QIcon, scale_x: float = 1.0, scale_y: float = None) -> QtGui.QIcon:
+    """Return a new QIcon with all pixmaps scaled by scale.
+    
+    Parameters
+    ----------
+    icon: QtGui.QIcon
+        The icon to scale.
+        
+    scale: float
+        The scale factor to apply to the icon.
+    """
+    if scale_y is None:
+        scale_y = scale_x
+    transform = QtGui.QTransform().scale(scale_x, scale_y)
+    return transform_icon(icon, transform)
+
+def _rotate_icon(icon: QtGui.QIcon, angle: int = 0) -> QtGui.QIcon:
+    """Return a new QIcon with all pixmaps rotated by angle degrees.
+    
+    Parameters
+    ----------
+    icon: QtGui.QIcon
+        The icon to rotate.
+        
+    angle: int
+        The angle in degrees to rotate the icon.
+    """
+    transform = QtGui.QTransform().rotate(angle)
+    return transform_icon(icon, transform)    
+
 
 def _flip_icon(icon: QtGui.QIcon, flip_h: bool, flip_v: bool) -> QtGui.QIcon:
     """Return a new QIcon with all Normal-mode pixmaps mirrored.
@@ -51,20 +122,7 @@ def _flip_icon(icon: QtGui.QIcon, flip_h: bool, flip_v: bool) -> QtGui.QIcon:
         return icon
     sx = -1.0 if flip_h else 1.0
     sy = -1.0 if flip_v else 1.0
-    transform = QtGui.QTransform().scale(sx, sy)
-
-    new_icon = QtGui.QIcon()
-    sizes = icon.availableSizes() or [QtCore.QSize(s, s) for s in (20, 40)]
-    for size in sizes:
-        for state in (QtGui.QIcon.State.Off, QtGui.QIcon.State.On):
-            px = icon.pixmap(size, QtGui.QIcon.Mode.Normal, state)
-            if not px.isNull():
-                new_icon.addPixmap(
-                    px.transformed(transform),
-                    QtGui.QIcon.Mode.Normal,
-                    state,
-                )
-    return new_icon
+    return _scale_icon(icon, scale_x=sx, scale_y=sy)
 
 
 def create_icon(icon_name: Union[QtGui.QIcon, str, Path],

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/styling.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/styling.py
@@ -36,9 +36,42 @@ def create_color(icon_color: Union[QtGui.QColor, str]) -> Union[QtGui.QColor, No
     return icon_color
 
 
+def _flip_icon(icon: QtGui.QIcon, flip_h: bool, flip_v: bool) -> QtGui.QIcon:
+    """Return a new QIcon with all Normal-mode pixmaps mirrored.
+
+    Only the Normal mode is transformed; Qt derives Disabled/Active/Selected
+    variants automatically.  Both Off and On states are handled so that
+    checkable actions with two visual states work correctly.
+
+    For SVG/vector icons (e.g. MaterialIcon) ``availableSizes()`` returns an
+    empty list; the function falls back to the two standard Material sizes
+    (20 × 20 and 40 × 40) so the icon is still rendered at a usable resolution.
+    """
+    if not flip_h and not flip_v:
+        return icon
+    sx = -1.0 if flip_h else 1.0
+    sy = -1.0 if flip_v else 1.0
+    transform = QtGui.QTransform().scale(sx, sy)
+
+    new_icon = QtGui.QIcon()
+    sizes = icon.availableSizes() or [QtCore.QSize(s, s) for s in (20, 40)]
+    for size in sizes:
+        for state in (QtGui.QIcon.State.Off, QtGui.QIcon.State.On):
+            px = icon.pixmap(size, QtGui.QIcon.Mode.Normal, state)
+            if not px.isNull():
+                new_icon.addPixmap(
+                    px.transformed(transform),
+                    QtGui.QIcon.Mode.Normal,
+                    state,
+                )
+    return new_icon
+
+
 def create_icon(icon_name: Union[QtGui.QIcon, str, Path],
                 icon_color: Union[QtGui.QColor, bytes, str] = None,
-                icon_checked_color: Union[QtGui.QColor, bytes, str] = None):
+                icon_checked_color: Union[QtGui.QColor, bytes, str] = None,
+                flip_h: bool = False,
+                flip_v: bool = False):
     """ Create an icon from various sources by order of preference:
 
     1) icon_name is an icon
@@ -47,10 +80,23 @@ def create_icon(icon_name: Union[QtGui.QIcon, str, Path],
     4) icon_name is a registered png in icon_library
     5) icon_name is a registered ThemeIcon
     6) icon_name is a registered StandardPixmap
+
+    Parameters
+    ----------
+    icon_name:
+        Icon source — see priority list above.
+    icon_color:
+        Colour applied to the unchecked/off-state icon (MaterialIcon only).
+    icon_checked_color:
+        Colour applied to the checked/on-state icon (MaterialIcon only).
+    flip_h:
+        Mirror the icon horizontally (left ↔ right).
+    flip_v:
+        Mirror the icon vertically (top ↔ bottom).
     """
 
     if isinstance(icon_name, QtGui.QIcon):
-        return icon_name
+        return _flip_icon(icon_name, flip_h, flip_v)
     elif resource_path_exists(
             MaterialIcon.resource_path(
                 icon_name,
@@ -78,9 +124,7 @@ def create_icon(icon_name: Union[QtGui.QIcon, str, Path],
         icon = QtWidgets.QWidget().style().standardIcon(pixmapi)
     else:
         icon = QtGui.QIcon()
-    return icon
-
-
+    return _flip_icon(icon, flip_h, flip_v)
 
 
 def resource_path_exists(path: str) -> bool:

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/styling.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/styling.py
@@ -52,8 +52,13 @@ def transform_icon(icon: QtGui.QIcon, transform: QtGui.QTransform) -> QtGui.QIco
         for state in (QtGui.QIcon.State.Off, QtGui.QIcon.State.On):
             px = icon.pixmap(size, QtGui.QIcon.Mode.Normal, state)
             if not px.isNull():
+                if type(px) is not QtGui.QPixmap:
+                    px = QtGui.QPixmap.fromImage(px)                
+                px_transformed = px.transformed(transform)
+                if type(px) is not QtGui.QPixmap:
+                    px_transformed = QtGui.QPixmap.fromImage(px.transformed(transform))
                 new_icon.addPixmap(
-                    QtGui.QPixmap.fromImage(px.transformed(transform)),
+                    px_transformed,
                     QtGui.QIcon.Mode.Normal,
                     state,
                 )


### PR DESCRIPTION
Among all the icons, we are sometimes missing a particular orientation. 
This PR adds the keyword flip_v/flip_h during the creation of icons to have the mirror image used instead.

It also adds the fix of #915 to the set_action_checked method
