### PR TITLE
Feature/xarray conversion

### DIFF
--- a/packages/pymodaq_data/pyproject.toml
+++ b/packages/pymodaq_data/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+xarray = ["xarray>=2024.10"]
 dev = [
     "hatch", 
     "flake8",

--- a/packages/pymodaq_data/src/pymodaq_data/data.py
+++ b/packages/pymodaq_data/src/pymodaq_data/data.py
@@ -2851,6 +2851,218 @@ class DataWithAxes(DataBase, SerializableBase):
         """ Get the underlying data selected from the list at index, returned as a DataWithAxes"""
         return self.deepcopy_with_new_data([self[index]])
 
+    def to_xarray(self):
+        """Convert this DataWithAxes to an xarray.Dataset.
+
+        Each array in self.data becomes a data variable (keyed by its label).
+        Each Axis becomes a coordinate on the corresponding dimension.
+        Error arrays (if present) are stored as ``<label>_error`` data variables.
+
+        Returns
+        -------
+        xr.Dataset
+
+        Raises
+        ------
+        ImportError
+            If xarray is not installed.
+        """
+        try:
+            import xarray as xr
+        except ImportError:
+            raise ImportError(
+                "xarray is required for to_xarray(). "
+                "Install it with: pip install 'pymodaq_data[xarray]'"
+            )
+
+        ndim = len(self.shape)
+
+        # --- build dim names (one per shape dimension) ---
+        dim_names = []
+        seen_dim_names = {}
+        for i in range(ndim):
+            axes_at_i = self.get_axis_from_index(i)
+            if axes_at_i and axes_at_i[0] is not None and axes_at_i[0].label:
+                base = axes_at_i[0].label
+            else:
+                base = f'dim_{i}'
+            # deduplicate
+            if base in seen_dim_names:
+                seen_dim_names[base] += 1
+                name = f'{base}_{seen_dim_names[base]}'
+            else:
+                seen_dim_names[base] = 0
+                name = base
+            dim_names.append(name)
+
+        # --- build coordinates ---
+        coords = {}
+        spread_dim_names = []
+        for axis in self.axes:
+            dim_name = dim_names[axis.index]
+            axis_data = axis.get_data()
+            if axis_data is None:
+                continue
+            if axis.spread_order > 0:
+                coord_name = f'{axis.label}_{axis.spread_order}' if axis.label else f'{dim_name}_{axis.spread_order}'
+                coord_attrs = {
+                    'units': axis.units,
+                    'pymodaq_label': axis.label,
+                    'spread_order': axis.spread_order,
+                }
+                if dim_name not in spread_dim_names:
+                    spread_dim_names.append(dim_name)
+            else:
+                coord_name = axis.label if axis.label else dim_name
+                coord_attrs = {
+                    'units': axis.units,
+                    'pymodaq_label': axis.label,
+                }
+            coords[coord_name] = xr.Variable(dim_name, axis_data, attrs=coord_attrs)
+
+        # --- build data variables ---
+        data_vars = {}
+        label_list = list(self.labels)
+        error_var_names = []
+        for i, (array, label) in enumerate(zip(self.data, label_list)):
+            var_name = label if label else f'data_{i}'
+            data_vars[var_name] = xr.Variable(dim_names, array)
+            if self.errors is not None:
+                err_name = f'{var_name}_error'
+                data_vars[err_name] = xr.Variable(dim_names, self.errors[i])
+                error_var_names.append(err_name)
+
+        # --- dataset attrs ---
+        attrs = {
+            'pymodaq_name': self.name,
+            'pymodaq_origin': self.origin,
+            'pymodaq_source': self.source.name,
+            'pymodaq_distribution': self.distribution.name,
+            'pymodaq_units': self.units,
+            'pymodaq_nav_indexes': list(self.nav_indexes),
+            'pymodaq_labels': label_list,
+        }
+        if error_var_names:
+            attrs['pymodaq_error_vars'] = error_var_names
+        if spread_dim_names:
+            attrs['pymodaq_spread_dim_names'] = spread_dim_names
+
+        return xr.Dataset(data_vars, coords=coords, attrs=attrs)
+
+    @classmethod
+    def from_xarray(cls, ds) -> 'DataWithAxes':
+        """Construct a DataWithAxes from an xarray Dataset (or DataArray).
+
+        Parameters
+        ----------
+        ds : xr.Dataset or xr.DataArray
+
+        Returns
+        -------
+        DataWithAxes
+
+        Raises
+        ------
+        ImportError
+            If xarray is not installed.
+        """
+        try:
+            import xarray as xr
+        except ImportError:
+            raise ImportError(
+                "xarray is required for from_xarray(). "
+                "Install it with: pip install 'pymodaq_data[xarray]'"
+            )
+
+        if isinstance(ds, xr.DataArray):
+            var_name = ds.name if ds.name else 'data'
+            ds = ds.to_dataset(name=var_name)
+
+        attrs = ds.attrs
+        name = attrs.get('pymodaq_name', 'from_xarray')
+        origin = attrs.get('pymodaq_origin', '')
+        source_str = attrs.get('pymodaq_source', 'raw')
+        distribution_str = attrs.get('pymodaq_distribution', 'uniform')
+        units = attrs.get('pymodaq_units', '')
+        nav_indexes = tuple(attrs.get('pymodaq_nav_indexes', []))
+        stored_labels = list(attrs.get('pymodaq_labels', []))
+        error_var_names = list(attrs.get('pymodaq_error_vars', []))
+
+        # separate error vars from regular data vars
+        regular_vars = {k: v for k, v in ds.data_vars.items() if k not in error_var_names}
+        error_vars = {k: v for k, v in ds.data_vars.items() if k in error_var_names}
+
+        # reconstruct data arrays and labels
+        data_arrays = []
+        labels = []
+        for i, (var_name, var) in enumerate(regular_vars.items()):
+            data_arrays.append(var.values)
+            label = stored_labels[i] if i < len(stored_labels) else var_name
+            labels.append(label)
+
+        # reconstruct error arrays (matched by position in error_var_names)
+        errors = None
+        if error_vars:
+            errors = [error_vars[err_name].values for err_name in error_var_names]
+
+        # reconstruct Axis objects from dims and coords
+        dim_names = list(ds.dims)
+        axes = []
+        for i, dim_name in enumerate(dim_names):
+            # find coords that live on this dimension
+            dim_coords = [
+                (cname, cvar) for cname, cvar in ds.coords.items()
+                if list(cvar.dims) == [dim_name]
+            ]
+            if dim_coords:
+                # primary coord: spread_order == 0 (or missing) comes first
+                primary = None
+                secondary = []
+                for cname, cvar in dim_coords:
+                    spread_order = int(cvar.attrs.get('spread_order', 0))
+                    axis_label = cvar.attrs.get('pymodaq_label', cname)
+                    axis_units = cvar.attrs.get('units', '')
+                    axis = Axis(
+                        label=axis_label,
+                        units=axis_units,
+                        data=cvar.values,
+                        index=i,
+                        spread_order=spread_order,
+                    )
+                    if spread_order == 0:
+                        primary = axis
+                    else:
+                        secondary.append(axis)
+                if primary is not None:
+                    axes.append(primary)
+                axes.extend(secondary)
+            else:
+                # no coord: create size-only axis
+                dim_size = ds.sizes[dim_name]
+                axes.append(Axis(label=dim_name, index=i, size=dim_size))
+
+        try:
+            source = DataSource[source_str]
+        except KeyError:
+            source = DataSource.raw
+        try:
+            distribution = DataDistribution[distribution_str]
+        except KeyError:
+            distribution = DataDistribution.uniform
+
+        return cls(
+            name=name,
+            source=source,
+            distribution=distribution,
+            data=data_arrays,
+            labels=labels,
+            units=units,
+            axes=axes,
+            nav_indexes=nav_indexes,
+            origin=origin,
+            errors=errors,
+        )
+
 
 @ser_factory.register_decorator()
 class DataRaw(DataWithAxes):
@@ -3529,6 +3741,75 @@ class DataToExport(DataLowLevel, SerializableBase):
     def append(self, dte: DataToExport):
         if isinstance(dte, DataToExport):
             self.append(dte.data)
+
+    def to_xarray(self):
+        """Convert this DataToExport to an xarray.DataTree.
+
+        The root node carries ``pymodaq_name`` in its attrs. Each DataWithAxes
+        becomes a child node whose dataset is produced by
+        ``DataWithAxes.to_xarray()``.
+
+        Returns
+        -------
+        xr.DataTree
+
+        Raises
+        ------
+        ImportError
+            If xarray is not installed.
+        """
+        try:
+            import xarray as xr
+        except ImportError:
+            raise ImportError(
+                "xarray is required for to_xarray(). "
+                "Install it with: pip install 'pymodaq_data[xarray]'"
+            )
+
+        children = {dwa.name: xr.DataTree(dataset=dwa.to_xarray()) for dwa in self}
+        root_ds = xr.Dataset(attrs={'pymodaq_name': self.name})
+        return xr.DataTree(dataset=root_ds, children=children)
+
+    @classmethod
+    def from_xarray(cls, dt, name: str = None) -> 'DataToExport':
+        """Construct a DataToExport from an xarray.DataTree or a dict of Datasets.
+
+        Parameters
+        ----------
+        dt : xr.DataTree or dict[str, xr.Dataset]
+        name : str, optional
+            Override the name; if None, read from ``dt.attrs['pymodaq_name']``.
+
+        Returns
+        -------
+        DataToExport
+
+        Raises
+        ------
+        ImportError
+            If xarray is not installed.
+        """
+        try:
+            import xarray as xr
+        except ImportError:
+            raise ImportError(
+                "xarray is required for from_xarray(). "
+                "Install it with: pip install 'pymodaq_data[xarray]'"
+            )
+
+        if isinstance(dt, xr.DataTree):
+            root_attrs = dt.dataset.attrs if dt.dataset is not None else {}
+            dte_name = name or root_attrs.get('pymodaq_name', 'from_xarray')
+            data_list = [
+                DataWithAxes.from_xarray(child.dataset)
+                for child in dt.children.values()
+            ]
+        else:
+            # dict[str, xr.Dataset] fallback
+            dte_name = name or 'from_xarray'
+            data_list = [DataWithAxes.from_xarray(ds) for ds in dt.values()]
+
+        return cls(name=dte_name, data=data_list)
 
 
 if __name__ == '__main__':

--- a/packages/pymodaq_data/tests/data_test.py
+++ b/packages/pymodaq_data/tests/data_test.py
@@ -1822,3 +1822,110 @@ class TestPintUnitReduction:
     def test_division(self, q1, q2, expected):
         res = dimensionless_aware_reduce_units(q1 / q2)
         assert res.m == expected.m and res.u == expected.u
+
+
+xr = pytest.importorskip('xarray')
+
+
+class TestXarrayConversion:
+    """Tests for DataWithAxes.to_xarray / from_xarray and DataToExport.to_xarray / from_xarray."""
+
+    def test_to_xarray_dims_coords(self):
+        axis = data_mod.Axis('time', units='s', data=np.linspace(0, 9, 10), index=0)
+        dwa = data_mod.DataRaw('mydata', data=[np.arange(10, dtype=float)], axes=[axis])
+        ds = dwa.to_xarray()
+        assert 'time' in ds.dims
+        assert 'time' in ds.coords
+        assert np.allclose(ds.coords['time'].values, axis.get_data())
+        assert ds.coords['time'].attrs['units'] == 's'
+
+    def test_to_xarray_data_vars(self):
+        arr1 = np.arange(5, dtype=float)
+        arr2 = np.arange(5, 10, dtype=float)
+        dwa = data_mod.DataRaw('mydata', data=[arr1, arr2], labels=['ch0', 'ch1'])
+        ds = dwa.to_xarray()
+        assert 'ch0' in ds.data_vars
+        assert 'ch1' in ds.data_vars
+        assert np.allclose(ds['ch0'].values, arr1)
+        assert np.allclose(ds['ch1'].values, arr2)
+
+    def test_to_xarray_attrs(self):
+        dwa = data_mod.DataRaw(
+            'test', units='mm', data=[np.zeros((3, 4))],
+            nav_indexes=(0,), origin='detector'
+        )
+        ds = dwa.to_xarray()
+        assert ds.attrs['pymodaq_name'] == 'test'
+        assert ds.attrs['pymodaq_units'] == 'mm'
+        assert ds.attrs['pymodaq_source'] == 'raw'
+        assert list(ds.attrs['pymodaq_nav_indexes']) == [0]
+
+    def test_round_trip_1d(self):
+        arr = np.linspace(1, 10, 20)
+        axis = data_mod.Axis('x', units='nm', data=np.linspace(0, 19, 20), index=0)
+        dwa = data_mod.DataRaw('signal', data=[arr], labels=['ch0'], axes=[axis])
+        dwa2 = data_mod.DataWithAxes.from_xarray(dwa.to_xarray())
+        assert dwa2.name == 'signal'
+        assert np.allclose(dwa2[0], arr)
+        axes = dwa2.get_axis_from_index(0)
+        assert axes and axes[0].label == 'x'
+        assert axes[0].units == 'nm'
+        assert np.allclose(axes[0].get_data(), axis.get_data())
+
+    def test_round_trip_2d_nav(self):
+        arr = np.arange(12, dtype=float).reshape(3, 4)
+        nav_axis = data_mod.Axis('nav', units='m', data=np.array([0., 1., 2.]), index=0)
+        sig_axis = data_mod.Axis('sig', units='Hz', data=np.array([10., 20., 30., 40.]), index=1)
+        dwa = data_mod.DataRaw(
+            'nd', data=[arr], nav_indexes=(0,), axes=[nav_axis, sig_axis]
+        )
+        dwa2 = data_mod.DataWithAxes.from_xarray(dwa.to_xarray())
+        assert tuple(dwa2.nav_indexes) == (0,)
+        assert np.allclose(dwa2[0], arr)
+
+    def test_round_trip_errors(self):
+        arr = np.arange(5, dtype=float)
+        err = arr * 0.1
+        dwa = data_mod.DataRaw('errs', data=[arr], labels=['ch0'], errors=[err])
+        ds = dwa.to_xarray()
+        assert 'ch0_error' in ds.data_vars
+        assert 'ch0' in ds.data_vars
+        dwa2 = data_mod.DataWithAxes.from_xarray(ds)
+        assert dwa2.errors is not None
+        assert np.allclose(dwa2.errors[0], err)
+        assert 'ch0_error' not in dwa2.labels
+
+    def test_from_dataarray(self):
+        da = xr.DataArray(
+            np.arange(6, dtype=float),
+            dims=['x'],
+            coords={'x': np.arange(6, dtype=float)},
+            name='myvar',
+        )
+        dwa = data_mod.DataWithAxes.from_xarray(da)
+        assert dwa.name == 'from_xarray'
+        assert np.allclose(dwa[0], da.values)
+
+    def test_dte_to_datatree(self):
+        dwa1 = data_mod.DataRaw('a', data=[np.zeros(5)])
+        dwa2 = data_mod.DataRaw('b', data=[np.ones((3, 4))])
+        dte = data_mod.DataToExport('myexp', data=[dwa1, dwa2])
+        dt = dte.to_xarray()
+        assert isinstance(dt, xr.DataTree)
+        assert len(dt.children) == 2
+        assert 'a' in dt.children
+        assert 'b' in dt.children
+
+    def test_dte_round_trip(self):
+        dwa1 = data_mod.DataRaw('ch1', data=[np.arange(8, dtype=float)])
+        dwa2 = data_mod.DataRaw('ch2', data=[np.arange(6, dtype=float).reshape(2, 3)])
+        dte = data_mod.DataToExport('myexp', data=[dwa1, dwa2])
+        dte2 = data_mod.DataToExport.from_xarray(dte.to_xarray())
+        assert dte2.name == 'myexp'
+        names = [dwa.name for dwa in dte2]
+        assert 'ch1' in names
+        assert 'ch2' in names
+        ch1 = dte2.get_data_from_name('ch1')
+        assert ch1.shape == (8,)
+        ch2 = dte2.get_data_from_name('ch2')
+        assert ch2.shape == (2, 3)


### PR DESCRIPTION
xarray is a python library that specialises in operations on labelled multi-dimensional arrays. Overall, one can see it as the extension of panda to ND arrays and as such it shares a lot of common attributes in its methods. 

For a quick overview, one can look at their readme which presents basic manipulation of their objects: DataArray (a variable with some attributes and some coordinates) and DataSets (a dictionnary of DataArrays that may share similar coordinates => makes operation between them relatively easy). One can read more about it in:
https://docs.xarray.dev/en/stable/getting-started-guide/quick-overview.html

The current status of DataWithAxes and DataToExport definitely share some similar features/ideas and in this PR, I propose to add a few utility functions to easily convert back and forth from one representation to the other.

Here are a few examples taken from the test to show some use case.

- DataArray to DataWithAxes
```
  da = xr.DataArray(
      np.arange(6, dtype=float),
      dims=['x'],
      coords={'x': np.arange(6, dtype=float)},
      name='myvar',
  )
  dwa = data_mod.DataWithAxes.from_xarray(da)
```

- DataWithAxes to DataArray 

```
arr = np.arange(12, dtype=float).reshape(3, 4)
nav_axis = data_mod.Axis('nav', units='m', data=np.array([0., 1., 2.]), index=0)
sig_axis = data_mod.Axis('sig', units='Hz', data=np.array([10., 20., 30., 40.]), index=1)
dwa = data_mod.DataRaw(
    'nd', data=[arr], nav_indexes=(0,), axes=[nav_axis, sig_axis]
)
da = dwa.to_xarray()
```

- DataToExport to DataTree

```

dwa1 = data_mod.DataRaw('a', data=[np.zeros(5)])
dwa2 = data_mod.DataRaw('b', data=[np.ones((3, 4))])
dte = data_mod.DataToExport('myexp', data=[dwa1, dwa2])
dt = dte.to_xarray()
```