### PR TITLE
make sure the entry property reflects the argument of the update method

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -469,10 +469,12 @@ class ManagerBase(CustomExt):
         return False
 
     def update_entry_base(self, entry: Union[str, Path] = None, **kwargs):
+        """ Update the table given the entry argument"""
         if entry is None:
             entry = self.entry_filename
 
         if isinstance(entry, str):
+            self.entry = entry  # make sure the current entry field reflects this method argument
             entry = self.get_entry_folder(**kwargs).joinpath(f'{entry}{self.entry_extension}')
 
         self.update_entry(entry)


### PR DESCRIPTION
when using the configuration combobox from the dashboard toolbar, the combobox from the configurator is updated but the table may not reflect the current choice. This is because, update is called just before the combobox  changed event is processed.

This make sure the entry is updated