### PR TITLE
Hotfix/declared scripts fix

### DIFF
--- a/packages/pymodaq/pyproject.toml
+++ b/packages/pymodaq/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
 [project.scripts]
 daq_logger = "pymodaq.extensions.daq_logger:main"
 daq_move = "pymodaq.control_modules.daq_move:main"
-daq_scan = "pymodaq.extensions.scangit a.daq_scan:main"
+daq_scan = "pymodaq.extensions.scan.daq_scan:main"
 daq_viewer = "pymodaq.control_modules.daq_viewer:main"
 dashboard = "pymodaq.dashboard:main"
 

--- a/packages/pymodaq/pyproject.toml
+++ b/packages/pymodaq/pyproject.toml
@@ -60,7 +60,6 @@ dev = [
 ]
 
 [project.scripts]
-pymodaq_updater = "pymodaq.updater:main"
 daq_logger = "pymodaq.extensions.daq_logger:main"
 daq_move = "pymodaq.control_modules.daq_move:main"
 daq_scan = "pymodaq.extensions.daq_scan:main"

--- a/packages/pymodaq/pyproject.toml
+++ b/packages/pymodaq/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
 [project.scripts]
 daq_logger = "pymodaq.extensions.daq_logger:main"
 daq_move = "pymodaq.control_modules.daq_move:main"
-daq_scan = "pymodaq.extensions.daq_scan:main"
+daq_scan = "pymodaq.extensions.scangit a.daq_scan:main"
 daq_viewer = "pymodaq.control_modules.daq_viewer:main"
 dashboard = "pymodaq.dashboard:main"
 


### PR DESCRIPTION
Fix issues where pymodaq_updater and daq_scan could not be launched:

1. pymodaq_updater is removed as it no longer exists
2. daq_scan path for script is fixed