### PR TITLE
hotfix/viewer_selector

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer_ui/viewer_selector.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer_ui/viewer_selector.py
@@ -36,7 +36,7 @@ class ViewerSelector(ModuleSelector):
         self.add_widget.setText(str(value))
         self.module_changed.emit(value)
 
-    def _add_menu_item_selected(self, path_tuple):
+    def _add_menu_item_selected(self, name, path_tuple):
         """Called when a menu item is selected from the nested add menu
 
         To be subclassed for particular signal emission


### PR DESCRIPTION
The viewer selector did not have the same signature as the control_module_selector resulting in missing arguments when switching detectors from daq_viewer. 