### PR TITLE
Rationalize the origin/names of the data produced in the viewer/actuator and display in modules manager

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
@@ -722,15 +722,9 @@ class DAQ_Viewer(ParameterControlModule):
             if len(data) != 0:
                 viewer_title = data.name
                 for dat in data:
-                    if len(self.viewers) > 1:
-                        dat.origin = (f'{self.title} - {viewer_title} - {dat.origin}'
-                                      if dat.origin is not None
-                                      else f'{self.title} - {viewer_title}')
-                    else:
-                        dat.origin = (f'{self.title} - {dat.origin}'
-                                      if dat.origin is not None
-                                      else f'{self.title}')
-                    dat.add_extra_attribute(parent_channel=viewer_title)
+                    dat.name = '/'.join([viewer_title, dat.origin, dat.name])
+                    dat.origin = self.title
+
                 self._data_to_save_export.append(data)
 
             if self._received_data == len(self.viewers):

--- a/packages/pymodaq/src/pymodaq/extensions/optimizers_base/models.py
+++ b/packages/pymodaq/src/pymodaq/extensions/optimizers_base/models.py
@@ -13,7 +13,7 @@ from pymodaq.extensions.optimizers_base.utils import logger, individual_as_dta
 from pymodaq.extensions.optimizers_base.algorithm import GenericAlgorithm
 from pymodaq.utils.data import DataToActuators
 from pymodaq.utils.managers.modules.modules_manager import ModulesManager
-from pymodaq_data import DataToExport
+from pymodaq_data import DataToExport, DataDim
 from pymodaq_gui.plotting.data_viewers import ViewersEnum
 from pymodaq_utils.utils import get_entrypoints, find_dict_in_list_from_key_val
 
@@ -193,7 +193,7 @@ class OptimizerModelDefault(OptimizerModelGeneric):
 
     def optimize_from(self):
         self.modules_manager.get_det_data_list()
-        data0D_names = self.modules_manager.get_probed_data_channels('Data0D')
+        data0D_names = self.modules_manager.get_probed_data_full_names(DataDim.Data0D)
         self.settings.child('optimizing_signal', 'optimize_0d').setValue(
             dict(all_items=data0D_names, selected=data0D_names))
 

--- a/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan.py
+++ b/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan.py
@@ -25,7 +25,7 @@ from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.config import GlobalConfig as Config
 from pymodaq_utils import utils
 
-from pymodaq_data import data as data_mod, DataDistribution
+from pymodaq_data import data as data_mod, DataDistribution, DataDim
 from pymodaq_data.h5modules import data_saving
 
 from pymodaq_gui.parameter import ioxml, Parameter
@@ -193,13 +193,12 @@ class DAQScan(CustomExt):
 
     def plot_from(self):
         self.modules_manager.get_det_data_list()
-        data0D_names = self.modules_manager.get_probed_data_channels('Data0D')
-        data1D_names = self.modules_manager.get_probed_data_channels('Data1D')
+        data0D_names = self.modules_manager.get_probed_data_full_names(DataDim.Data0D)
+        data1D_names = self.modules_manager.get_probed_data_full_names(DataDim.Data1D)
         self.settings.child('plot_options', 'plot_0d').setValue(
             dict(all_items=data0D_names, selected=data0D_names))
         self.settings.child('plot_options', 'plot_1d').setValue(
             dict(all_items=data1D_names, selected=data1D_names))
-
 
 
     def setup_docks(self):
@@ -1359,6 +1358,7 @@ class DAQScanAcquisition(QObject):
                                     dict(indexes=indexes, distribution=self.scanner.distribution)))
 
             self.det_done_flag = True
+
 
             full_names: list = self.scan_settings['plot_options', 'plot_0d']['selected'][:]
             full_names.extend(self.scan_settings['plot_options', 'plot_1d']['selected'][:])

--- a/packages/pymodaq/src/pymodaq/utils/managers/modules/modules_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/modules/modules_manager.py
@@ -6,11 +6,12 @@ from qtpy.QtCore import QThread
 import time
 
 from pymodaq.utils.managers.modules.utils import ModuleType
+from pymodaq_utils.enums import enum_checker
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils import utils
 from pymodaq_utils.config import GlobalConfig as Config
 
-from pymodaq_data.data import DataToExport, DataSource
+from pymodaq_data.data import DataToExport, DataSource, DataDim
 
 from pymodaq_gui.managers.parameter_manager import ParameterManager
 from pymodaq_gui.parameter import Parameter
@@ -262,116 +263,39 @@ class ModulesManager(QObject, ParameterManager):
         elif param.name() == 'actuators':
             self.actuators_changed.emit(param.value()['selected'])
 
-    def get_det_data_list(self) -> DataToExport:
+    def get_det_data_list(self, add_to_this_param: Parameter = None) -> DataToExport:
         """Do a snap of selected detectors, to populate the data channels tree and return the data"""
 
         if len(self.detectors) == 0:
             return DataToExport(name=__class__.__name__, control_module='DAQ_Viewer')
 
+        if add_to_this_param is None:
+            add_to_this_param = self.settings.child('probe_data')
+
         self.connect_detectors()
         try:
             datas: DataToExport = self.grab_data(Naverage=1)
+            logger.debug(f'Acquired: {datas.get_full_names()}')
 
-            data_channels = self.settings.child('probe_data')
-            data_channels.clearChildren()
+            add_to_this_param.clearChildren()
 
-            for det in self.detectors:
-                det_title = det.title
-                det_data = [dwa for dwa in datas.data
-                            if dwa.origin == det_title or dwa.origin.startswith(f'{det_title} - ')]
+            data_children = []
 
-                # In single-viewer mode raw data has origin == det_title.
-                # In multi-viewer mode (one viewer per channel) the viewer prepends its title:
-                #   raw origin  → '{det_title} - {viewer_title}'
-                #   ROI origin  → '{det_title} - {viewer_title} - {roi_name}'
-                # daq_viewer sets parent_channel = viewer_title on every datum, so we can use
-                # that to reconstruct the set of "direct" origins (no ROI suffix).
-                unique_parent_channels = {getattr(dwa, 'parent_channel', '') for dwa in det_data}
-                direct_origins = ({det_title}
-                                  | {f'{det_title} - {pc}' for pc in unique_parent_channels if pc})
-
-                direct_raw = [dwa for dwa in det_data
-                              if dwa.source == DataSource.raw and dwa.origin in direct_origins]
-                direct_calc = [dwa for dwa in det_data
-                               if dwa.source == DataSource.calculated and dwa.origin in direct_origins]
-
-                # ROI data: everything whose origin has an extra depth beyond the direct origins.
-                roi_data = [dwa for dwa in det_data if dwa.origin not in direct_origins]
-                roi_origins = sorted({dwa.origin for dwa in roi_data})
-
-                roi_groups_by_raw: dict[str, list] = {raw.name: [] for raw in direct_raw}
-
-                for roi_origin in roi_origins:
-                    roi_dwas = [dwa for dwa in roi_data if dwa.origin == roi_origin]
-                    if not roi_dwas:
-                        continue
-
-                    # Strip '{det_title} - ' (and the channel prefix in multi-viewer) to get
-                    # a short display name like 'ROI_00' rather than 'Mock2D_0 - ROI_00'.
-                    roi_pc = getattr(roi_dwas[0], 'parent_channel', None)
-                    roi_display_full = roi_origin.replace(f'{det_title} - ', '', 1)
-                    if roi_pc and roi_display_full.startswith(f'{roi_pc} - '):
-                        roi_short = roi_display_full[len(f'{roi_pc} - '):]
-                    elif roi_pc and roi_display_full.startswith(roi_pc):
-                        roi_short = roi_display_full[len(roi_pc):].lstrip(' -')
-                    else:
-                        roi_short = roi_display_full  # single-viewer: already 'ROI_00'
-
-                    # Strip '_ROI_00' suffixes from child names for a cleaner display
-                    roi_children = [
-                        {'title': dwa.name.replace(f'_{roi_short}', ''),
-                         'name': dwa.name.replace(f'_{roi_short}', '').replace(' ', '_'),
-                         'type': 'bool', 'value': True, 'dim': dwa.dim.name,
-                         'full_name': f'{dwa.origin}/{dwa.name}'}
-                        for dwa in roi_dwas
-                    ]
-                    roi_group = {
-                        'title': roi_short,
-                        'name': roi_short.replace(' ', '_'),
-                        'type': 'group',
-                        'children': roi_children,
-                    }
-
-                    # parent_channel matches raw.name (viewer title == data name set in
-                    # set_data_to_viewers), so use it directly as the grouping key.
-                    if roi_pc in roi_groups_by_raw:
-                        roi_groups_by_raw[roi_pc].append(roi_group)
-                    elif len(direct_raw) == 1:
-                        roi_groups_by_raw[direct_raw[0].name].append(roi_group)
-                    # else: ambiguous → skip to avoid duplication across channels
-
-                det_children = []
-                for raw in direct_raw:
-                    calc_children = [
-                        {'title': dwa.name,
-                         'name': dwa.name.replace(' ', '_'),
-                         'type': 'bool', 'value': True, 'dim': dwa.dim.name,
-                         'full_name': f'{dwa.origin}/{dwa.name}'}
-                        for dwa in direct_calc
-                        if getattr(dwa, 'parent_channel', None) == raw.name
-                    ]
-                    all_children = calc_children + roi_groups_by_raw.get(raw.name, [])
-                    det_children.append({
-                        'title': raw.name,
-                        'name': raw.name.replace(' ', '_'),
-                        'type': 'bool', 'value': True, 'dim': raw.dim.name,
-                        'full_name': f'{raw.origin}/{raw.name}',
-                        **({'children': all_children} if all_children else {}),
-                    })
-
-                if det_children:
-                    data_channels.addChild({
-                        'title': det_title,
-                        'name': det_title.replace(' ', '_'),
-                        'type': 'group',
-                        'children': det_children,
-                    })
+            for data_dim in DataDim.names():
+                data_from_dim = datas.get_data_from_dim(data_dim)
+                if len(data_dim) != 0:
+                    data_children.append(
+                        {'title': data_dim, 'name': data_dim, 'type': 'group', 'children':[
+                            {'title': dwa.origin, 'name': dwa.get_full_name(), 'type': 'str',
+                             'value': dwa.name, 'readonly': True} for dwa in data_from_dim
+                        ]})
+            add_to_this_param.addChildren(data_children)
         finally:
             self.connect_detectors(False)
         return datas
 
-    def get_probed_data_channels(self, dim: str = None) -> List[str]:
-        """Return full names (origin/channel) of probed data channels, optionally filtered by dim.
+    def get_probed_data_full_names(self, dim: DataDim | str = None) -> List[str]:
+        """Return full names (origin/name) of probed data, optionally filtered by dim.
 
         Parameters
         ----------
@@ -383,21 +307,11 @@ class ModulesManager(QObject, ParameterManager):
         list of str
         """
         names = []
+        if dim is not None:
+            dim = enum_checker(DataDim, dim)
         for det_param in self.settings.child('probe_data').children():
-            for ch_param in det_param.children():
-                # ch_param is a raw channel node
-                if dim is None or ch_param.opts.get('dim') == dim:
-                    names.append(ch_param.opts['full_name'])
-                for sub_param in ch_param.children():
-                    if 'full_name' in sub_param.opts:
-                        # calculated child of the raw channel
-                        if dim is None or sub_param.opts.get('dim') == dim:
-                            names.append(sub_param.opts['full_name'])
-                    else:
-                        # ROI group node — iterate its children
-                        for roi_child in sub_param.children():
-                            if dim is None or roi_child.opts.get('dim') == dim:
-                                names.append(roi_child.opts['full_name'])
+            if dim is None or det_param.name() == dim.name:
+                names.extend([child.name() for child in det_param.children()])
         return names
 
     def grab_data(self, check_do_override=True, Naverage: Optional[int] = None, **kwargs):
@@ -677,46 +591,21 @@ if __name__ == '__main__':
     import sys
 
     from pymodaq_gui.qt_utils import mkQApp
-    from pymodaq.utils.gui_utils import DockArea
-    from pymodaq.control_modules.daq_viewer import DAQ_Viewer
-    from pymodaq.control_modules.daq_move import DAQ_Move
-    from pymodaq.utils.shared_ui import SharedUI
+
+    from pymodaq.dashboard import create_load_dashboard
+
 
     app = mkQApp('ModulesManager')
-    area = DockArea()
 
-    prog = DAQ_Viewer(area, title="Testing2D", daq_type='DAQ2D')
-    prog2 = DAQ_Viewer(area, title="Testing1D", daq_type='DAQ1D')
-    prog3 = DAQ_Viewer(area, title="Testing0D", daq_type='DAQ0D')
+    win, dashboard = create_load_dashboard()
+    win.show()
 
-    act1_widget = QtWidgets.QWidget()
-    act2_widget = QtWidgets.QWidget()
-    act1 = DAQ_Move(act1_widget, title='X_axis')
-    act2 = DAQ_Move(act2_widget, title='Y_axis')
-    act1.actuator = 'Mock'
-    act2.actuator = 'Mock'
+    dashboard.preset_manager.execute_entry_base()
 
-    QThread.msleep(1000)
-    prog.init_hardware_ui()
-    prog2.init_hardware_ui()
-    prog3.init_hardware_ui()
+    dashboard.modules_manager.settings_tree.show()
 
-    dock1 = Dock('actuator 1')
-    dock1.addWidget(act1_widget)
-    area.addDock(dock1)
+    dashboard.modules_manager.get_det_data_list()
 
-    dock2 = Dock('actuator 2')
-    dock2.addWidget(act2_widget)
-    area.addDock(dock2)
-
-    act1.init_hardware_ui()
-    act2.init_hardware_ui()
-
-    QtWidgets.QApplication.processEvents()
-
-    win = SharedUI(area, title='ModulesManager')
-
-    manager = ModulesManager(actuators=[act1, act2], detectors=[prog, prog2, prog3], selected_detectors=[prog2])
-    manager.settings_tree.show()
+    print(dashboard.modules_manager.get_probed_data_full_names())
 
     sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/utils/managers/modules/modules_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/modules/modules_manager.py
@@ -283,7 +283,7 @@ class ModulesManager(QObject, ParameterManager):
 
             for data_dim in DataDim.names():
                 data_from_dim = datas.get_data_from_dim(data_dim)
-                if len(data_dim) != 0:
+                if len(data_from_dim) != 0:
                     data_children.append(
                         {'title': data_dim, 'name': data_dim, 'type': 'group', 'children':[
                             {'title': dwa.origin, 'name': dwa.get_full_name(), 'type': 'str',

--- a/packages/pymodaq/tests/utils/managers/modules_manager_test.py
+++ b/packages/pymodaq/tests/utils/managers/modules_manager_test.py
@@ -66,9 +66,9 @@ def manager(detectors, actuators):
 # Helpers to build controlled DataToExport for tree-building tests
 # ---------------------------------------------------------------------------
 
-def make_raw_dte(det_title: str, channel_name: str = 'CH0') -> DataToExport:
+def make_raw_dte(det_title: str, dwa_name: str = 'DWA_NANE') -> DataToExport:
     """DTE with a single raw 1D channel from a detector."""
-    raw = DataRaw(channel_name, data=[np.zeros(10)])
+    raw = DataRaw(dwa_name, data=[np.zeros(10)])
     raw.origin = det_title
     dte = DataToExport('test', control_module='DAQ_Viewer')
     dte.append(raw)
@@ -302,7 +302,7 @@ class TestGetDetDataList:
 
     def test_raw_channel_in_tree(self, manager):
         manager.selected_detectors_name = ['Det1']
-        dte = make_raw_dte('Det1', 'CH0')
+        dte = make_raw_dte()
         with patch.object(manager, 'grab_data', return_value=dte):
             manager.get_det_data_list()
 
@@ -311,12 +311,15 @@ class TestGetDetDataList:
 
     def test_tree_cleared_on_repopulate(self, manager):
         manager.selected_detectors_name = ['Det1']
-        dte = make_raw_dte('Det1', 'CH0')
+        dte = make_raw_dte()
         with patch.object(manager, 'grab_data', return_value=dte):
             manager.get_det_data_list()
             manager.get_det_data_list()  # second call must not duplicate
 
-        pass
+        for dim in DataDim.names():
+            for dwa in dte.get_data_from_dim(dim):
+                assert dwa.get_full_name() in [child.name() for child in
+                                           manager.settings.child('probe_data', dim).children()]
 
     def test_connect_detectors_released_on_exception(self, manager):
         """connect_detectors(False) must be called via finally even if grab_data raises."""

--- a/packages/pymodaq/tests/utils/managers/modules_manager_test.py
+++ b/packages/pymodaq/tests/utils/managers/modules_manager_test.py
@@ -302,7 +302,7 @@ class TestGetDetDataList:
 
     def test_raw_channel_in_tree(self, manager):
         manager.selected_detectors_name = ['Det1']
-        dte = make_raw_dte()
+        dte = make_raw_dte('dte')
         with patch.object(manager, 'grab_data', return_value=dte):
             manager.get_det_data_list()
 
@@ -311,7 +311,7 @@ class TestGetDetDataList:
 
     def test_tree_cleared_on_repopulate(self, manager):
         manager.selected_detectors_name = ['Det1']
-        dte = make_raw_dte()
+        dte = make_raw_dte('dte')
         with patch.object(manager, 'grab_data', return_value=dte):
             manager.get_det_data_list()
             manager.get_det_data_list()  # second call must not duplicate

--- a/packages/pymodaq/tests/utils/managers/modules_manager_test.py
+++ b/packages/pymodaq/tests/utils/managers/modules_manager_test.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from qtpy.QtCore import QObject, Signal
 
-from pymodaq_data.data import DataToExport, DataRaw, DataSource
+from pymodaq_data.data import DataToExport, DataRaw, DataSource, DataDim
 
 from pymodaq.utils.data import DataActuator
 from pymodaq.utils.managers.modules import ModulesManager, ModuleType
@@ -42,12 +42,12 @@ class MockActuator(QObject):
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-def detectors():
+def detectors(qtbot):
     return [MockDetector('Det1'), MockDetector('Det2'), MockDetector('Det3')]
 
 
 @pytest.fixture
-def actuators():
+def actuators(qtbot):
     return [MockActuator('X_axis', 0.0), MockActuator('Y_axis', 1.0)]
 
 
@@ -104,7 +104,7 @@ def make_dte_with_roi(det_title: str, channel_name: str = 'CH0',
 
 class TestInit:
 
-    def test_empty_init(self):
+    def test_empty_init(self, qtbot):
         mm = ModulesManager()
         assert mm.detectors_all == []
         assert mm.actuators_all == []
@@ -307,10 +307,7 @@ class TestGetDetDataList:
             manager.get_det_data_list()
 
         det_param = manager.settings.child('probe_data').children()[0]
-        assert det_param.name() == 'Det1'
-        ch_param = det_param.children()[0]
-        assert ch_param.name() == 'CH0'
-        assert ch_param.opts['full_name'] == 'Det1/CH0'
+        assert det_param.name() in DataDim.names()
 
     def test_tree_cleared_on_repopulate(self, manager):
         manager.selected_detectors_name = ['Det1']
@@ -319,34 +316,7 @@ class TestGetDetDataList:
             manager.get_det_data_list()
             manager.get_det_data_list()  # second call must not duplicate
 
-        assert len(manager.settings.child('probe_data').children()) == 1
-
-    def test_roi_nested_under_raw_channel(self, manager):
-        manager.selected_detectors_name = ['Det1']
-        dte = make_dte_with_roi('Det1', 'CH0', 'ROI_00')
-        with patch.object(manager, 'grab_data', return_value=dte):
-            manager.get_det_data_list()
-
-        ch_param = manager.settings.child('probe_data').children()[0].children()[0]
-        roi_groups = [p for p in ch_param.children() if p.type() == 'group']
-        assert len(roi_groups) == 1
-        assert roi_groups[0].name() == 'ROI_00'
-        roi_child_names = {p.name() for p in roi_groups[0].children()}
-        assert {'hor', 'int'}.issubset(roi_child_names)
-
-    def test_multiple_rois_nested_under_same_channel(self, manager):
-        manager.selected_detectors_name = ['Det1']
-        dte = make_dte_with_roi('Det1', 'CH0', 'ROI_00')
-        for dwa in make_dte_with_roi('Det1', 'CH0', 'ROI_01').data:
-            if dwa.origin != 'Det1':
-                dte.append(dwa)
-
-        with patch.object(manager, 'grab_data', return_value=dte):
-            manager.get_det_data_list()
-
-        ch_param = manager.settings.child('probe_data').children()[0].children()[0]
-        roi_groups = [p for p in ch_param.children() if p.type() == 'group']
-        assert {g.name() for g in roi_groups} == {'ROI_00', 'ROI_01'}
+        pass
 
     def test_connect_detectors_released_on_exception(self, manager):
         """connect_detectors(False) must be called via finally even if grab_data raises."""
@@ -356,33 +326,6 @@ class TestGetDetDataList:
                 with pytest.raises(RuntimeError):
                     manager.get_det_data_list()
         mock_connect.assert_any_call(False)
-
-
-class TestGetProbedDataChannels:
-
-    def _populate(self, manager):
-        manager.selected_detectors_name = ['Det1']
-        dte = make_dte_with_roi('Det1', 'CH0', 'ROI_00')
-        with patch.object(manager, 'grab_data', return_value=dte):
-            manager.get_det_data_list()
-
-    def test_returns_raw_channel(self, manager):
-        self._populate(manager)
-        assert 'Det1/CH0' in manager.get_probed_data_channels()
-
-    def test_returns_roi_outputs(self, manager):
-        self._populate(manager)
-        names = manager.get_probed_data_channels()
-        assert 'Det1 - ROI_00/hor' in names
-        assert 'Det1 - ROI_00/int' in names
-
-    def test_dim_filter(self, manager):
-        self._populate(manager)
-        # 'DataND' should match nothing in our simple 0D/1D test data
-        assert manager.get_probed_data_channels(dim='DataND') == []
-
-    def test_empty_before_probe(self, manager):
-        assert manager.get_probed_data_channels() == []
 
 
 class TestShowOnlyControlModules:

--- a/packages/pymodaq_data/src/pymodaq_data/data.py
+++ b/packages/pymodaq_data/src/pymodaq_data/data.py
@@ -3464,9 +3464,9 @@ class DataToExport(DataLowLevel, SerializableBase):
     def get_data_from_full_name(self, full_name: str, deepcopy=False) -> DataWithAxes:
         """Get the DataWithAxes with matching full name"""
         if deepcopy:
-            data = self.get_data_from_name_origin(full_name.split('/')[1], full_name.split('/')[0]).deepcopy()
+            data = self.get_data_from_name_origin('/'.join(full_name.split('/')[1:]), full_name.split('/')[0]).deepcopy()
         else:
-            data = self.get_data_from_name_origin(full_name.split('/')[1], full_name.split('/')[0])
+            data = self.get_data_from_name_origin('/'.join(full_name.split('/')[1:]), full_name.split('/')[0])
         return data
 
     def get_data_from_full_names(self, full_names: List[str], deepcopy=False) -> DataToExport:

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer1D.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer1D.py
@@ -586,9 +586,9 @@ class Viewer1D(ViewerBase):
                 roi_dte_bis = roi_dte.deepcopy()
                 for dwa in roi_dte_bis:
                     if dwa.name == 'HorData':
-                        dwa.name = f'Hlineout_{dwa.origin}'
+                        dwa.name = f'Hlineout'
                     elif dwa.name == 'IntData':
-                        dwa.name = f'Integrated_{dwa.origin}'
+                        dwa.name = f'Integrated'
                 self.data_to_export.append(roi_dte_bis.data)
                 self.data_to_export_signal.emit(self.data_to_export)
         except AttributeError:

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer2D.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer2D.py
@@ -1008,17 +1008,17 @@ class Viewer2D(ViewerBase):
                 roi_dte_bis = roi_dte.deepcopy()
                 for dwa in roi_dte_bis.data:
                     if dwa.name == 'hor':
-                        dwa.name = f'Hlineout_{dwa.origin}'
+                        dwa.name = f'Hlineout'
                     elif dwa.name == 'ver':
-                        dwa.name = f'Vlineout_{dwa.origin}'
+                        dwa.name = f'Vlineout'
                     elif dwa.name == 'int':
-                        dwa.name = f'Integrated_{dwa.origin}'
+                        dwa.name = f'Integrated'
                 self.data_to_export.append(roi_dte_bis)
 
                 self.measure_data_dict = dict([])
 
                 for roi_name in roi_dte_bis.get_origins():
-                    dwa = roi_dte_bis.get_data_from_name_origin(f'Integrated_{roi_name}', roi_name)
+                    dwa = roi_dte_bis.get_data_from_name_origin(f'Integrated', roi_name)
                     for ind, data_array in enumerate(dwa.data):
                             self.measure_data_dict[f'{dwa.labels[ind]}:'] = float(data_array[0])
 

--- a/packages/pymodaq_gui/tests/plotting_test/data_viewers_test/viewer2D_test.py
+++ b/packages/pymodaq_gui/tests/plotting_test/data_viewers_test/viewer2D_test.py
@@ -2,7 +2,7 @@ from typing import Tuple, Any, Generator
 from pytestqt.qtbot import QtBot
 from qtpy import QtWidgets, QtCore
 
-from pymodaq_data import data as data_mod
+from pymodaq_data import data as data_mod, DataDim
 from pymodaq_gui.plotting.data_viewers.viewer2D import Viewer2D
 from pymodaq_gui.plotting.data_viewers import viewer2D as v2d
 
@@ -441,18 +441,18 @@ class TestROI:
             roi.setPos((0, 0))
 
         data_to_export: data_mod.DataToExport = blocker.args[0]
-        assert len(data_to_export.get_data_from_dim('data1D')) != 0
-        assert len(data_to_export.get_data_from_dim('data0D')) != 0
+        assert len(data_to_export.get_data_from_dim(DataDim.Data1D)) != 0
+        assert len(data_to_export.get_data_from_dim(DataDim.Data0D)) != 0
 
-        assert f'Hlineout_{roi_format(index_roi)}' in data_to_export.get_names()
-        assert f'Vlineout_{roi_format(index_roi)}' in \
-               data_to_export.get_names('data1D')
-        assert f'Integrated_{roi_format(index_roi)}' in \
-               data_to_export.get_names('data0D')
+        assert f'Hlineout' in data_to_export.get_names()
+        assert f'Vlineout' in \
+               data_to_export.get_names(DataDim.Data1D)
+        assert f'Integrated' in \
+               data_to_export.get_names(DataDim.Data0D)
 
-        hlineout = data_to_export.get_data_from_name(f'Hlineout_{roi_format(index_roi)}')
-        vlineout = data_to_export.get_data_from_name(f'Vlineout_{roi_format(index_roi)}')
-        intlineout = data_to_export.get_data_from_name(f'Integrated_{roi_format(index_roi)}')
+        hlineout = data_to_export.get_data_from_name(f'Hlineout')
+        vlineout = data_to_export.get_data_from_name(f'Vlineout')
+        intlineout = data_to_export.get_data_from_name(f'Integrated')
 
         assert np.any(hlineout.data[0] == approx(np.mean(data[0], 0)))
         assert np.any(vlineout.data[0] == approx(np.mean(data[0], 1)))
@@ -475,9 +475,9 @@ class TestROI:
         assert len(data_to_export.get_data_from_dim('data1D')) != 0
         assert len(data_to_export.get_data_from_dim('data0D')) != 0
 
-        assert f'Hlineout_{roi_format(index_roi)}' in data_to_export.get_names('data1D')
-        assert f'Vlineout_{roi_format(index_roi)}' in data_to_export.get_names('data1D')
-        assert f'Integrated_{roi_format(index_roi)}' in data_to_export.get_names('data0D')
+        assert f'Hlineout' in data_to_export.get_names('data1D')
+        assert f'Vlineout' in data_to_export.get_names('data1D')
+        assert f'Integrated' in data_to_export.get_names('data0D')
 
 
     def test_show_roi(self, init_viewer2d):


### PR DESCRIPTION
I updated a recent PR that broke the way the data are to be used within the ModuleManager

the origin is kept as from the title of the control module

the name is built using slashes (like files) see below
<img width="322" height="641" alt="image" src="https://github.com/user-attachments/assets/b7d6af20-9796-4f15-90ee-d96bcb045472" />

using simple strings parameter (allowing double click and copy paste (important for the datamixer model equation)

the title of the setting is the origin, the value is the name and the name is the full_name