### PR TITLE
implement data  dynamic casting on the viewer level

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
@@ -837,14 +837,13 @@ class DAQ_Viewer(ParameterControlModule):
         if self.ui is not None:
             self.set_data_to_viewers(data, temp=True)
 
-    @Slot(DataToExport)
     def show_data(self, dte: DataToExport):
-        """Send data to their dedicated viewers
+        """ Receive data from plugins and send them to their dedicated viewers
 
         Slot receiving data from plugins emitted with the `data_grabed_signal`
         Process the data as specified in the settings, display them into the dedicated data viewers depending on the
         settings:
-            * create a container (OrderedDict `_data_to_save_export`) with info from this DAQ_Viewer (title), a timestamp...
+            * create a container (DataToExport `_data_to_save_export`) with info from this DAQ_Viewer (title), a timestamp...
             * call `_process_data`
             * do background subtraction if any
             * check refresh time (if set in the settings) to send or not data to data viewers
@@ -880,6 +879,11 @@ class DAQ_Viewer(ParameterControlModule):
             else:
                 for dwa in dte:
                     dwa.origin = self._title
+                    if self.settings['main_settings', 'dynamic'] != 'as_is':
+                        arrays = []
+                        for data_array in dwa:
+                            arrays.append(data_array.astype(self.settings['main_settings', 'dynamic'], copy=False))
+                        dwa.data = arrays
                 self._data_to_save_export = DataToExport(self._title, control_module='DAQ_Viewer', data=dte.data)
 
             if self._take_bkg:
@@ -1009,10 +1013,12 @@ class DAQ_Viewer(ParameterControlModule):
                                                      [param.value()]))
 
         elif param.name() in putils.iter_children(self.settings.child('saver_settings'), []):
-            if param.name() == 'do_save':
-                self.setup_continuous_saving(param.value())
-            self._h5saver_continuous.settings.child(*path[1:]).setValue(param.value())
-
+            try:
+                if param.name() == 'do_save':
+                    self.setup_continuous_saving(param.value())
+                self._h5saver_continuous.settings.child(*path[1:]).setValue(param.value())
+            except KeyError:
+                pass
         self._update_settings(param=param)
 
     def child_added(self, param, data):

--- a/packages/pymodaq/src/pymodaq/control_modules/viewer_utility_classes.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/viewer_utility_classes.py
@@ -47,7 +47,9 @@ params = [
         {'title': 'Detector type:', 'name': 'detector_type', 'type': 'str', 'value': '', 'readonly': True},
         {'title': 'Detector Name:', 'name': 'module_name', 'type': 'str', 'value': '', 'readonly': True},
         {'title': 'Plugin Config:', 'name': 'plugin_config', 'type': 'bool_push', 'label': 'Show Config', },
-
+        {'title': 'Dynamic:', 'name': 'dynamic', 'type': 'list',
+         'limits': config('data_saving', 'data_type', 'dynamics'),
+         'value': config('data_saving', 'data_type', 'dynamic')},
         {'title': 'Show data and process:', 'name': 'show_data', 'type': 'bool', 'value': True, },
         {'title': 'Refresh time (ms):', 'name': 'refresh_time', 'type': 'float', 'value': 50., 'min': 0.},
         {'title': 'Naverage', 'name': 'Naverage', 'type': 'int', 'default': 1, 'value': 1, 'min': 1},

--- a/packages/pymodaq_gui/src/pymodaq_gui/h5modules/saving.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/h5modules/saving.py
@@ -128,9 +128,6 @@ class H5SaverBase(H5SaverLowLevel, ParameterManager):
         {'title': 'h5file:', 'name': 'current_h5_file', 'type': 'text', 'value': '',
          'readonly': True},
         {'title': 'New file', 'name': 'new_file', 'type': 'action'},
-        {'title': 'Saving dynamic', 'name': 'dynamic', 'type': 'list',
-         'limits': config('data_saving', 'data_type', 'dynamics'),
-         'value': config('data_saving', 'data_type', 'dynamic')},
         {'title': 'Compression options:', 'name': 'compression_options', 'type': 'group',
          'children': [
             {'title': 'Compression library:', 'name': 'h5comp_library', 'type': 'list',

--- a/packages/pymodaq_utils/src/pymodaq_utils/resources/config_template.toml
+++ b/packages/pymodaq_utils/src/pymodaq_utils/resources/config_template.toml
@@ -22,8 +22,8 @@ backend = "pyqt6"
     pwd = "pymodaq"
 
     [data_saving.data_type]
-    dynamic = 'float64' # choose from below. This will force the datatype to be saved to
-    dynamics =  ['uint8', 'int8', 'uint16', 'int16', 'uint32', 'int32', 'uint64', 'int64', 'float64']
+    dynamic = 'as_is' # choose from below. This will force the datatype to be saved to
+    dynamics =  ['as_is', 'uint8', 'int8', 'uint16', 'int16', 'uint32', 'int32', 'uint64', 'int64', 'float64']
 
 
 [general]


### PR DESCRIPTION
So far, an option to save data as a given type in the daq_scan was possible (if not working in fact in latest versions)

However, it does not make sense as various data from various detectors could be saved together each with their own dynamic. This PR remove this dynmic feature from the h5saver general options and adds it in the daq_viewer main_settings. By default, the dtype is preserved from what is set in the plugin (most of the time as float64) with the option: 'as_is'. If the user select one of the possible dtypes like 'uint8', 'float32'... then the data is cast into that type with all the possible issues this could raise if one is not carefull about data handling, bit rounding etc...

The inprint on the disc could however be drastically improved if the correct dtype is set! 


@rgeneaux this could be of interest to Lou...