### PR TITLE
Feature/cleaning/config path

### DIFF
--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -52,7 +52,8 @@ from pymodaq.utils.exceptions import DetectorError, ActuatorError, MasterSlaveEr
 from pymodaq.utils.daq_utils import get_instrument_plugins
 
 from pymodaq.utils.config import (get_set_preset_path, get_set_overshoot_path,
-                                  get_set_roi_path, get_set_remote_path, get_set_layout_path)
+                                  get_set_remote_path)
+from pymodaq_gui.config import get_set_layout_path, get_set_roi_path
 from pymodaq.utils.gui_utils.widgets.window import make_window
 
 from pymodaq.control_modules.daq_move import DAQ_Move

--- a/packages/pymodaq/src/pymodaq/utils/config.py
+++ b/packages/pymodaq/src/pymodaq/utils/config.py
@@ -1,10 +1,7 @@
 
 from pathlib import Path
 
-try:
-    from pymodaq_gui.config_saver_loader import get_set_roi_path
-except ModuleNotFoundError:
-    from pymodaq_gui.config import get_set_roi_path
+from pymodaq_gui.config import get_set_roi_path, get_set_layout_path  # noqa
 
 from pymodaq_utils.config import (GlobalConfig, BaseConfig, ConfigError, get_set_config_dir,
                                   USER, CONFIG_BASE_PATH, get_set_local_dir)
@@ -36,12 +33,6 @@ def get_set_pid_path(user=False):
     return get_set_config_dir('pid_configs', user=user)
 
 
-def get_set_layout_path(user=False):
-    """ creates and return the config folder path for layout files
-    """
-    return get_set_config_dir('layout_configs', user=user)
-
-
 def get_set_remote_path(user=False):
     """ creates and return the config folder path for remote (shortcuts or joystick) files
     """
@@ -52,6 +43,7 @@ def get_set_overshoot_path(user=False):
     """ creates and return the config folder path for overshoot files
     """
     return get_set_config_dir('overshoot_configs', user=user)
+
 
 @GlobalConfig.register()
 class Config(BaseConfig):

--- a/packages/pymodaq/src/pymodaq/utils/managers/preset/preset_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/preset/preset_manager.py
@@ -4,7 +4,6 @@ import sys
 
 from qtpy import QtWidgets
 
-from pymodaq_gui.config_saver_loader import get_set_roi_path
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_gui.messenger import dialog, messagebox
 from pymodaq_gui.utils.dock import Dock
@@ -12,8 +11,8 @@ from pymodaq_gui.utils.dock import Dock
 from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.parameter import ioxml
 
-from pymodaq.utils.config import get_set_preset_path, get_set_overshoot_path, get_set_layout_path, \
-    get_set_configurator_path, get_set_remote_path
+from pymodaq.utils.config import get_set_preset_path, get_set_overshoot_path, get_set_configurator_path, get_set_remote_path
+from pymodaq_gui.config import get_set_layout_path, get_set_roi_path
 from pymodaq_gui.managers.manager_base import ManagerBase
 from pymodaq.utils.managers.modules.utils import ModuleType
 

--- a/packages/pymodaq/tests/utils/config_test.py
+++ b/packages/pymodaq/tests/utils/config_test.py
@@ -1,12 +1,9 @@
 from pathlib import Path
 
+import pymodaq_gui.config
 from pymodaq.utils import config as config_mod_pymodaq
 from pymodaq_utils import config as config_mod
 
-
-def test_import():
-    from pymodaq.utils.config import (BaseConfig, Config, ConfigError, get_set_config_dir, USER,
-                                      CONFIG_BASE_PATH, get_set_local_dir)
 
 
 class TestGetSet:
@@ -27,12 +24,6 @@ class TestGetSet:
         log_path = config_mod.get_set_log_path()
         assert Path(log_path) == Path(local_path).joinpath('log')
         assert Path(log_path).is_dir()
-
-    def test_get_set_layout_path(self):
-        local_path = config_mod.get_set_local_dir()
-        layout_path = config_mod_pymodaq.get_set_layout_path()
-        assert Path(layout_path) == Path(local_path).joinpath('layout_configs')
-        assert Path(layout_path).is_dir()
 
     def test_get_set_remote_path(self):
         local_path = config_mod.get_set_local_dir()

--- a/packages/pymodaq_gui/src/pymodaq_gui/config.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/config.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from pymodaq_utils.config import (GlobalConfig, BaseConfig)
+from pymodaq_utils.config import (GlobalConfig, BaseConfig, get_set_config_dir)
 
 
 @GlobalConfig.register()
@@ -9,3 +9,14 @@ class Config(BaseConfig):
     config_template_path = Path(__file__).parent.joinpath('resources/config_template.toml')
     config_name = f"gui"
 
+
+def get_set_layout_path(user=False):
+    """ creates and return the config folder path for layout files
+    """
+    return get_set_config_dir('layout_configs', user=user)
+
+
+def get_set_roi_path():
+    """ creates and return the config folder path for managers files
+    """
+    return get_set_config_dir('roi_configs')

--- a/packages/pymodaq_gui/src/pymodaq_gui/config_saver_loader.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/config_saver_loader.py
@@ -1,4 +1,3 @@
-from abc import abstractproperty
 from collections.abc import Iterable
 
 
@@ -6,18 +5,12 @@ from typing import List, TYPE_CHECKING, Optional
 from typing import Iterable as IterableType
 
 
-from pymodaq_utils.config import (BaseConfig, recursive_iterable_flattening, ConfigError,
-                                  get_set_config_dir)
+from pymodaq_utils.config import (BaseConfig, recursive_iterable_flattening, ConfigError)
 from pymodaq_gui.parameter import Parameter
+
 
 if TYPE_CHECKING:
     from pymodaq_gui.parameter import Parameter
-
-
-def get_set_roi_path():
-    """ creates and return the config folder path for managers files
-    """
-    return get_set_config_dir('roi_configs')
 
 
 class ConfigSaverLoader:

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/roi_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/roi_manager.py
@@ -19,7 +19,7 @@ from pymodaq_gui.managers.action_manager import QAction
 from pymodaq_data.plotting.utils import PlotColors
 from pymodaq_utils.logger import get_module_name, set_logger
 from pymodaq_utils.config import GlobalConfig as Config
-from pymodaq_gui.config_saver_loader import get_set_roi_path
+from pymodaq_gui.config import get_set_roi_path
 from pymodaq_gui.utils import select_file
 from pymodaq_gui.plotting.items.roi import ROIFactory, ROI, LinearROI, RectROI, DataDim
 

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/items/roi.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/items/roi.py
@@ -18,7 +18,7 @@ from pyqtgraph import functions as fn
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import QSignalBlocker, Signal, Slot
 
-from pymodaq_gui.config_saver_loader import get_set_roi_path
+from pymodaq_gui.config import get_set_roi_path
 from pymodaq_gui.parameter import (Parameter, ParameterTree,
                                    )
 from pymodaq_gui.plotting.utils import plot_utils

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/layout.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/layout.py
@@ -1,15 +1,15 @@
 import pickle
 
-from pymodaq_utils import config as config_mod
+from pymodaq_gui.config import get_set_layout_path
 from pymodaq_gui.utils.file_io import select_file
 
 
-def load_layout_state(dockarea, file=None):
+def load_layout_state(dockarea, file=None, user=False):
     """
         Load and restore a dockarea layout state from the select_file obtained pathname file.
     """
     if file is None:
-        file = select_file(start_path=config_mod.get_set_layout_path(), save=False, ext='dock')
+        file = select_file(start_path=get_set_layout_path(user=user), save=False, ext='dock')
     if file is not None:
         with open(str(file), 'rb') as f:
             dockstate = pickle.load(f)
@@ -18,7 +18,7 @@ def load_layout_state(dockarea, file=None):
     return file
 
 
-def save_layout_state(dockarea, file=None):
+def save_layout_state(dockarea, file=None, user=False):
     """
         Save the current layout state in the select_file obtained pathname file.
         Once done dump the pickle.
@@ -28,7 +28,7 @@ def save_layout_state(dockarea, file=None):
     if 'float' in dockstate:
         dockstate['float'] = []
     if file is None:
-        file = select_file(start_path=config_mod.get_set_layout_path(), save=True, ext='dock')
+        file = select_file(start_path=get_set_layout_path(user=user), save=True, ext='dock')
     if file is not None:
         with open(str(file), 'wb') as f:
             pickle.dump(dockstate, f, pickle.HIGHEST_PROTOCOL)

--- a/packages/pymodaq_gui/tests/utils/config_test.py
+++ b/packages/pymodaq_gui/tests/utils/config_test.py
@@ -6,7 +6,8 @@ import toml
 
 from pymodaq_utils import config as config_mod
 from pymodaq_gui.parameter import Parameter
-from pymodaq_gui.config_saver_loader import ConfigSaverLoader, get_set_roi_path
+from pymodaq_gui.config_saver_loader import ConfigSaverLoader
+from pymodaq_gui.config import get_set_layout_path, get_set_config_dir, get_set_roi_path
 
 
 class CustomConfig(config_mod.BaseConfig):
@@ -21,6 +22,13 @@ class TestGetSet:
         roi_path = get_set_roi_path()
         assert Path(roi_path) == Path(local_path).joinpath('roi_configs')
         assert Path(roi_path).is_dir()
+
+
+    def test_get_set_layout_path(self):
+        local_path = config_mod.get_set_local_dir()
+        layout_path = get_set_layout_path()
+        assert Path(layout_path) == Path(local_path).joinpath('layout_configs')
+        assert Path(layout_path).is_dir()
 
 
 class TestConfigSaverLoader:

--- a/packages/pymodaq_utils/tests/config_test.py
+++ b/packages/pymodaq_utils/tests/config_test.py
@@ -58,6 +58,10 @@ def test_replace_extension():
     assert replace_file_extension(test_name, 'toml') == f'{test_name}.toml'
 
 
+def test_import():
+    from pymodaq_utils.config import (BaseConfig, Config, ConfigError, get_set_config_dir, USER,
+                                      CONFIG_BASE_PATH, get_set_local_dir)
+
 @pytest.mark.parametrize('user', [False, True])
 def test_get_set_config_dir(user):
     local_path = get_set_config_dir(user=user)


### PR DESCRIPTION
some config folder methods were not in the right package

@bernhardlang the module: packages/pymodaq_gui/src/pymodaq_gui/utils/layout.py
contains built in methods to save/load dockarea layout state. In your tests together with mainwindow geometry, you should incorporate these in the CustomApp class to allow user to easily load and save the app geometry/layout