### PR TITLE
fix bad synchronization between widgets

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -193,9 +193,7 @@ class ManagerBase(CustomExt):
 
     @entry.setter
     def entry(self, entry_name: str):
-        value = self.entries_sync.value
-        value['current'] = entry_name
-        self.entries_sync.set_value(value)
+        self.entries_sync.set_value({**self.entries_sync.value, 'current': entry_name})
 
     @property
     def entry_filepath(self) -> Path:

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -196,7 +196,6 @@ class ManagerBase(CustomExt):
         value = self.entries_sync.value
         value['current'] = entry_name
         self.entries_sync.set_value(value)
-        #self.get_action_list().setCurrentText(entry_name)
 
     @property
     def entry_filepath(self) -> Path:

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -189,11 +189,14 @@ class ManagerBase(CustomExt):
     @property
     def entry(self) -> str:
         """ Get/Set the name of the current entry """
-        return self.get_action_list().currentText()
+        return self.entries_sync.value['current']
 
     @entry.setter
     def entry(self, entry_name: str):
-        self.get_action_list().setCurrentText(entry_name)
+        value = self.entries_sync.value
+        value['current'] = entry_name
+        self.entries_sync.set_value(value)
+        #self.get_action_list().setCurrentText(entry_name)
 
     @property
     def entry_filepath(self) -> Path:


### PR DESCRIPTION
#973 

Update the widget sync value instead of relying on the combo box currentText. Previously, one widget (in the Configurator window) was updated and the others were synced from it. This fix resolves the issue for the launcher, but does not address the root cause in the widget synchronization logic.