### PR TITLE
Adding a None check before disconnect

### DIFF
--- a/packages/pymodaq/src/pymodaq/utils/leco/pymodaq_listener.py
+++ b/packages/pymodaq/src/pymodaq/utils/leco/pymodaq_listener.py
@@ -479,10 +479,11 @@ class LECOComponentMixin:
             self._leco_client.start_listen()
         else:
             self._leco_commands_signal.emit(ThreadCommand(LECOCommands.QUIT, ))
-            try:
-                self._leco_commands_signal.disconnect(self._leco_client.queue_command)
-            except TypeError:
-                pass  # already disconnected
+            if self._leco_client is not None:
+                try:
+                    self._leco_commands_signal.disconnect(self._leco_client.queue_command)
+                except TypeError:
+                    pass  # already disconnected
 
     def get_leco_name(self) -> str:
         """Return the LECO component name used to register on the network.

--- a/packages/pymodaq/src/pymodaq/utils/leco/pymodaq_listener.py
+++ b/packages/pymodaq/src/pymodaq/utils/leco/pymodaq_listener.py
@@ -461,8 +461,8 @@ class LECOComponentMixin:
         sent from the Qt thread.
 
         When *connect* is ``False``, a :attr:`~LECOCommands.QUIT` command is
-        emitted to stop the listener gracefully, and the signal/slot connection
-        to :meth:`~ActorListener.queue_command` is removed.
+        emitted to stop the listener gracefully, and both signal/slot connections
+        (to :meth:`~ActorListener.queue_command` and from ``cmd_signal``) are removed.
 
         :param connect: ``True`` to establish the connection, ``False`` to
             tear it down.
@@ -482,6 +482,10 @@ class LECOComponentMixin:
             if self._leco_client is not None:
                 try:
                     self._leco_commands_signal.disconnect(self._leco_client.queue_command)
+                except TypeError:
+                    pass  # already disconnected    
+                try:
+                    self._leco_client.cmd_signal.disconnect(self.process_leco_commands)
                 except TypeError:
                     pass  # already disconnected
 


### PR DESCRIPTION
Fix AttributeError bug when the _leco_client (ActorListener) is None

```
(pymodaq_3.13) D:\Work\PyMoDAQ>dashboard
Traceback (most recent call last):
  File "D:\Work\PyMoDAQ\packages\pymodaq\src\pymodaq\control_modules\daq_move.py", line 188, in process_ui_cmds
    self.init_hardware(cmd.attribute[0])
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "D:\Work\PyMoDAQ\packages\pymodaq\src\pymodaq\control_modules\daq_move.py", line 439, in init_hardware
    self.connect_leco(False)
    ~~~~~~~~~~~~~~~~~^^^^^^^
  File "D:\Work\PyMoDAQ\packages\pymodaq\src\pymodaq\control_modules\daq_move.py", line 844, in connect_leco
    super().connect_leco(connect)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "D:\Work\PyMoDAQ\packages\pymodaq\src\pymodaq\utils\leco\pymodaq_listener.py", line 483, in connect_leco
    self._leco_commands_signal.disconnect(self._leco_client.queue_command)
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'queue_command'
```