### PR TITLE
Hotfix/manager base with no entry

### DIFF
--- a/packages/pymodaq/src/pymodaq/utils/managers/configurator/configurator.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/configurator/configurator.py
@@ -301,7 +301,7 @@ class Configurator(ManagerBase):
         self.preset_manager.get_action(ManagerActions.LIST_EXTERNAL
                                        ).widget.currentTextChanged.connect(self.set_preset_filename)
 
-    def _update_entry(self, entry: Union[str, Path] = None, **kwargs):
+    def _update_entry(self, entry: Path):
         self.config_model.load(self.entry_filepath)
 
     def update_settings(self, settings: Union[Parameter, Path, str] = None):

--- a/packages/pymodaq/src/pymodaq/utils/managers/overshoot/overshooter.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/overshoot/overshooter.py
@@ -263,13 +263,7 @@ class Overshooter(ManagerBase):
         self.settings.child('overshoots').setOpts(
             addList=self.modules_manager.available_data)
 
-    def _update_entry(self, entry: Union[str, Path] = None, **kwargs):
-        if entry is None:
-            entry = self.entry_filepath
-        elif isinstance(entry, str):
-            self.entry = entry
-            entry = self.entry_filepath
-
+    def _update_entry(self, entry: Path):
         if entry.exists():
             self.settings = entry
         else:
@@ -295,7 +289,7 @@ class Overshooter(ManagerBase):
         self.modules_manager.selected_detectors_name = self.modules_manager.detectors_name
 
         self.entries_sync.update_key('items', self.entries)
-        self._update_entry()
+        self.update_entry()
         self.update_available_data()
         self.update_configurations()
 

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -337,7 +337,7 @@ class ManagerBase(CustomExt):
             combo,
             property_map={
                 'items': {
-                    'signal': combo.items_changed,  
+                    'signal': combo.items_changed,
                     'getter': combo.get_items,
                     'setter': combo.set_items,
                     'mode': SyncMode.BIDIRECTIONAL
@@ -366,12 +366,11 @@ class ManagerBase(CustomExt):
                 f'Enter a NEW {self.entry_type.capitalize()} name',
                 f'{self.entry_type.capitalize()} name:', QtWidgets.QLineEdit.Normal)
         self.do_things_for_new_creation()
-        if ok and entry != '':
-            if self.save_check(entry, bypass_dialog=bypass_dialog):
-                self.entries_sync.append_to_list('items', entry)
-                self.entries_sync.update_key('current', entry)
-                self.update_action_list()
-                self.new_entry.emit(entry)
+        if ok and entry != '' and self.save_check(entry, bypass_dialog=bypass_dialog):
+            self.entries_sync.append_to_list('items', entry)
+            self.entries_sync.update_key('current', entry)
+            self.update_action_list()
+            self.new_entry.emit(entry)
 
     def do_things_for_new_creation(self):
         """ To be reimplemented if needed """
@@ -382,8 +381,7 @@ class ManagerBase(CustomExt):
             entry_path = self.get_entry_folder().joinpath(entry+self.entry_extension)
         else:
             entry_path = self.entry_filepath
-        if entry_path.exists():
-            if not bypass_dialog:
+        if entry_path.exists() and not bypass_dialog:
                 user_agreed = dialog(
                     title='Overwrite confirmation',
                     message='File exist do you want to overwrite it ?',

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -198,9 +198,7 @@ class ManagerBase(CustomExt):
     @property
     def entry_filepath(self) -> Path:
         """ Get the full path of the current entry file """
-        kwargs_to_entry_folder = {}  # reimplement if needed
-        return self.get_entry_folder(**kwargs_to_entry_folder).joinpath(
-            self.entry + self.entry_extension)
+        return self.entry_path_from_name(self.entry)
 
     def entry_path_from_name(self, entry_name: str) -> Path:
         kwargs_to_entry_folder = {}  # reimplement if needed
@@ -500,13 +498,13 @@ class ManagerBase(CustomExt):
         return False
 
     def update_entry(self, entry: Union[str, Path] = None, **kwargs):
-        """ Update the table given the entry argument"""
+        """ Load and display the given entry """
         if entry is None:
+            if self.entry is None:
+                return
             entry = self.entry_filepath
-
-        if isinstance(entry, str):
-            self.entry = entry  # make sure the current entry field reflects this method argument
-            entry = self.get_entry_folder(**kwargs).joinpath(f'{entry}{self.entry_extension}')
+        elif isinstance(entry, str):
+            entry = self.entry_path_from_name(entry)
 
         self.entry = entry.stem  # make sure the combo is updated (if triggered not from the combo, in particular the action slots)
 


### PR DESCRIPTION
- Hotfix to avoid error message on startup in managerbase.py when value["current"] is None.
self.entries_sync.value_changed.connect(lambda value: self.update_entry(value['current']))
- Simplify update_entry and use it in overshoot.py