### PR TITLE
Feature/standard icon

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/parameter_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/parameter_manager.py
@@ -64,9 +64,11 @@ class ParameterTreeWidget(ActionManager):
 
         # self.tree.setMinimumWidth(150)
         # self.tree.setMinimumHeight(300)
-        toggle_top = QtWidgets.QPushButton("▼")
+
+        toggle_btn = QtWidgets.QPushButton("▼")
+        toggle_btn.setFixedHeight(16)
         self.collapsible_widget = CollapsibleWidget(
-            toggle_widget=toggle_top,
+            toggle_widget=toggle_btn,
             collapsible_widget=self.toolbar,
             direction="top",
             content_before_toggle=False,

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/styling.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/styling.py
@@ -1,16 +1,124 @@
 from pathlib import Path
 from typing import Union
 
+import pyqtgraph as pg
 import qt_themes
-from qtpy import QtGui, QtWidgets, QtCore
+from qtpy import QtCore, QtGui, QtWidgets
 
 from pymodaq_gui.resources.material_icons import MaterialIcon
 from pymodaq_utils.config import GlobalConfig as Config
 
-
 config = Config()
 theme = qt_themes.get_theme(config('gui', 'style', 'theme')[0])
 
+def make_shape_icon(
+    shape: str = "circle",
+    filled: bool = True,
+    size: int = 12,
+    width: int = None,
+    height: int = None,
+    pen: QtGui.QPen = None,
+    brush: QtGui.QBrush = None,
+    **kwargs,
+) -> QtGui.QIcon:
+    """Return a small solid or outlined shape as a QIcon, using pyqtgraph's mkPen/mkBrush.
+
+    Parameters
+    ----------
+    shape:
+        Shape of the icon: 'circle', 'triangle', 'square', 'rectangle', or 'diamond'.
+    filled:
+        If True, the shape is filled; if False, only the outline is drawn.
+    size:
+        Diameter of the circle, side length of the square/diamond, or default side for triangle/rectangle in pixels (default 12).
+    width:
+        Width of the rectangle (if shape is 'rectangle'). If None, defaults to `size`.
+    height:
+        Height of the rectangle (if shape is 'rectangle'). If None, defaults to `size`.
+    pen:
+        QPen for the outline (e.g., pg.mkPen('blue', width=2)).
+    brush:
+        QBrush for filling the shape (e.g., pg.mkBrush('red')).
+    **kwargs:
+        Optional arguments for creating pen/brush if not provided:
+        - color: str (default: 'black')
+        - pen_width: int (default: 1)
+        - pen_style: str (e.g., 'solid', 'dashed', 'dotted', 'dashdot', 'dashdotdot')
+        - brush_color: str (default: same as color)
+    """
+    if width is None:
+        width = size
+    if height is None:
+        height = size
+
+    # Map string pen styles to Qt.PenStyle enums
+    style_map = {
+        "solid": QtCore.Qt.PenStyle.SolidLine,
+        "dashed": QtCore.Qt.PenStyle.DashLine,
+        "dotted": QtCore.Qt.PenStyle.DotLine,
+        "dashdot": QtCore.Qt.PenStyle.DashDotLine,
+        "dashdotdot": QtCore.Qt.PenStyle.DashDotDotLine,
+        "none": QtCore.Qt.PenStyle.NoPen,
+    }
+
+    # Use the maximum of width/height to ensure the pixmap is large enough
+    pixmap_size = max(width, height)
+    pixmap = QtGui.QPixmap(pixmap_size, pixmap_size)
+    pixmap.fill(QtCore.Qt.GlobalColor.transparent)
+    painter = QtGui.QPainter(pixmap)
+    painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
+
+    # Create pen and brush if not provided
+    if pen is None:
+        color = kwargs.get("color", "black")
+        pen_width = kwargs.get("pen_width", 1)
+        pen_style = kwargs.get("pen_style", "solid")
+        style = style_map.get(pen_style.lower(), QtCore.Qt.PenStyle.SolidLine)
+        pen = pg.mkPen(color, width=pen_width)
+        pen.setStyle(style)
+    if brush is None and filled:
+        brush_color = kwargs.get("brush_color", kwargs.get("color", "black"))
+        brush = pg.mkBrush(brush_color)
+
+    # Set brush and pen
+    painter.setBrush(brush if filled else QtCore.Qt.BrushStyle.NoBrush)
+    painter.setPen(pen if not filled else QtCore.Qt.PenStyle.NoPen)
+
+    if shape == "circle":
+        painter.drawEllipse(1, 1, size - 2, size - 2)
+    elif shape == "triangle":
+        # Draw an equilateral triangle pointing upwards
+        half_size = size / 2
+        triangle_height = (size * (3 ** 0.5)) / 2
+        offset_y = (size - triangle_height) / 2
+        points = [
+            QtCore.QPointF(half_size, offset_y),
+            QtCore.QPointF(size - 1, size - offset_y - 1),
+            QtCore.QPointF(1, size - offset_y - 1),
+        ]
+        polygon = QtGui.QPolygonF(points)
+        painter.drawPolygon(polygon)
+    elif shape == "square":
+        painter.drawRect(1, 1, size - 2, size - 2)
+    elif shape == "rectangle":
+        painter.drawRect(1, 1, width - 2, height - 2)
+    elif shape == "diamond":
+        # Draw a diamond (rotated square)
+        half_width = width / 2
+        half_height = height / 2
+        points = [
+            QtCore.QPointF(half_width, 1),
+            QtCore.QPointF(width - 1, half_height),
+            QtCore.QPointF(half_width, height - 1),
+            QtCore.QPointF(1, half_height),
+        ]
+        polygon = QtGui.QPolygonF(points)
+        painter.drawPolygon(polygon)
+    else:
+        raise ValueError(f"Unsupported shape: {shape}")
+
+    painter.end()
+    return QtGui.QIcon(pixmap)
 
 def create_font(font_name=None, font_size=None, isbold=False, isitalic=False) -> QtGui.QFont:
     font = QtGui.QFont()
@@ -37,12 +145,12 @@ def create_color(icon_color: Union[QtGui.QColor, str]) -> Union[QtGui.QColor, No
 
 def transform_icon(icon: QtGui.QIcon, transform: QtGui.QTransform) -> QtGui.QIcon:
     """Return a new QIcon with all pixmaps transformed by transform.
-    
+
     Parameters
     ----------
     icon: QtGui.QIcon
         The icon to transform.
-        
+
     transform: QtGui.QTransform
         The transform to apply to the icon.
     """
@@ -53,7 +161,7 @@ def transform_icon(icon: QtGui.QIcon, transform: QtGui.QTransform) -> QtGui.QIco
             px = icon.pixmap(size, QtGui.QIcon.Mode.Normal, state)
             if not px.isNull():
                 if type(px) is not QtGui.QPixmap:
-                    px = QtGui.QPixmap.fromImage(px)                
+                    px = QtGui.QPixmap.fromImage(px)
                 px_transformed = px.transformed(transform)
                 if type(px) is not QtGui.QPixmap:
                     px_transformed = QtGui.QPixmap.fromImage(px.transformed(transform))
@@ -66,15 +174,15 @@ def transform_icon(icon: QtGui.QIcon, transform: QtGui.QTransform) -> QtGui.QIco
 
 def _translate_icon(icon: QtGui.QIcon, x: int = 0, y: int = 0) -> QtGui.QIcon:
     """Return a new QIcon with all pixmaps translated by x and y pixels.
-    
+
     Parameters
     ----------
     icon: QtGui.QIcon
         The icon to translate.
-        
+
     x: int
         The number of pixels to translate the icon in the x direction.
-        
+
     y: int
         The number of pixels to translate the icon in the y direction.
     """
@@ -83,12 +191,12 @@ def _translate_icon(icon: QtGui.QIcon, x: int = 0, y: int = 0) -> QtGui.QIcon:
 
 def _scale_icon(icon: QtGui.QIcon, scale_x: float = 1.0, scale_y: float = None) -> QtGui.QIcon:
     """Return a new QIcon with all pixmaps scaled by scale.
-    
+
     Parameters
     ----------
     icon: QtGui.QIcon
         The icon to scale.
-        
+
     scale: float
         The scale factor to apply to the icon.
     """
@@ -99,17 +207,17 @@ def _scale_icon(icon: QtGui.QIcon, scale_x: float = 1.0, scale_y: float = None) 
 
 def _rotate_icon(icon: QtGui.QIcon, angle: int = 0) -> QtGui.QIcon:
     """Return a new QIcon with all pixmaps rotated by angle degrees.
-    
+
     Parameters
     ----------
     icon: QtGui.QIcon
         The icon to rotate.
-        
+
     angle: int
         The angle in degrees to rotate the icon.
     """
     transform = QtGui.QTransform().rotate(angle)
-    return transform_icon(icon, transform)    
+    return transform_icon(icon, transform)
 
 
 def _flip_icon(icon: QtGui.QIcon, flip_h: bool, flip_v: bool) -> QtGui.QIcon:

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/collapsible_widget.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/collapsible_widget.py
@@ -146,16 +146,16 @@ class CollapsibleWidget(QWidget):
 
         # Start the animation
         self.animation.start()
-        
+
         self.toggled_signal.emit(self.is_expanded)
 
     def _update_toggle_symbol(self, expanded):
         """Update the toggle button symbol based on expanded state"""
         if not isinstance(self.toggle_widget, QPushButton) or not self.original_text:
             return
-        text = self.original_text if not expanded else symbol_map[self.original_text]        
+        text = self.original_text if not expanded else symbol_map[self.original_text]
         self.toggle_widget.setText(text)
-        
+
     def set_expanded(self, expanded):
         """Programmatically set the expanded state without animation"""
         if expanded and not self.is_expanded:


### PR DESCRIPTION
- Adding a standard method in styling to easily draw basic shape (circle/rectangle/square/...)
```
BINDING_ICONS = {
        'icon_1':   make_shape_icon(shape="diamond", filled=False, color="purple", pen_width=2, pen_style="dotted"),  
        'icon_2': make_shape_icon(shape="circle", filled=True, color="green", pen_width=2),
    }
```
- reducing height of toggle button in parameter manager to make it slightly more discrete
