### PR TITLE
Fix sync bug in + renamed manager standalone + restore '-p' for preset/exPeriment loading in cli

### DIFF
--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -1435,7 +1435,7 @@ def main():
                                      description="PyMoDAQ dashboard. "
                                                  "Command-line options only affect GUI initial state."
                                      )
-    parser.add_argument("-p", "--experiment", metavar="EXPERIMENT_NAME",
+    parser.add_argument("-x", "--experiment", metavar="EXPERIMENT_NAME",
                         help="experiment name to load at startup")
     parser.add_argument("-c", "--config", metavar="CONFIG_NAME",
                         help="config name to execute (ignored if no experiment provided)")

--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -1395,7 +1395,7 @@ def load_dashboard_with_experiment(experiment_name: str,
     -------
 
     """
-    from pymodaq.utils.config import get_set_configurator_path, get_set_experiment_path
+    from pymodaq.utils.config import get_set_experiment_path
     shared_ui, dashboard = create_load_dashboard()
 
     experiment_path = get_set_experiment_path().joinpath(f'{experiment_name}.xml')
@@ -1404,10 +1404,7 @@ def load_dashboard_with_experiment(experiment_name: str,
 
     if experiment_name in dashboard.experiment_manager.entries:
         dashboard.experiment_manager.entry = experiment_name
-        QtWidgets.QApplication().processEvents()
         if configuration_name is not None:
-            configuration_path = get_set_configurator_path().joinpath(experiment_name).joinpath(
-                f'{configuration_name}.config')
             dashboard.configurator.entry = configuration_name
         dashboard.experiment_manager.execute_entry(experiment_path)
 
@@ -1438,7 +1435,7 @@ def main():
                                      description="PyMoDAQ dashboard. "
                                                  "Command-line options only affect GUI initial state."
                                      )
-    parser.add_argument("-exp", "--experiment", metavar="EXPERIMENT_NAME",
+    parser.add_argument("-p", "--experiment", metavar="EXPERIMENT_NAME",
                         help="experiment name to load at startup")
     parser.add_argument("-c", "--config", metavar="CONFIG_NAME",
                         help="config name to execute (ignored if no experiment provided)")

--- a/packages/pymodaq/src/pymodaq/utils/managers/configurator/configurator.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/configurator/configurator.py
@@ -105,8 +105,7 @@ class Configurator(ManagerBase):
     def experiment_filename(self, experiment_filename: str):
         if experiment_filename in self.experiment_manager.entries:
             self.experiment_manager.entries_sync.update_key('current', experiment_filename)
-            self.entries_sync.update_key('items', self.entries)
-            self.update_entry('default')
+            self.entries_sync.set_value({**self.entries_sync.value, 'items': self.entries, 'current': self.entry})
 
     def save_entries(self, entry_path: Path = None):
         self.config_model.save(entry_path)
@@ -425,7 +424,7 @@ if __name__ == "__main__":
     from pymodaq_gui.qt_utils import mkQApp
     from pymodaq.dashboard import DashBoard, create_load_dashboard
 
-    app = mkQApp('PresetManager')
+    app = mkQApp('ConfiguratorManager')
 
     shared_ui, dashboard = create_load_dashboard()
     shared_ui.hide()

--- a/packages/pymodaq/src/pymodaq/utils/managers/experiment/experiment_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/experiment/experiment_manager.py
@@ -539,7 +539,7 @@ class ExperimentManager(ManagerBase):
 if __name__ == '__main__':
     from pymodaq_gui.qt_utils import mkQApp
 
-    app = mkQApp('PresetManager')
+    app = mkQApp('ExperimentManager')
 
     prog = ExperimentManager()
     external_ui = QtWidgets.QMainWindow()


### PR DESCRIPTION
Three fixes in this PR:

1. The way the configurator was updated when its associated experiment was changed made its toolbar take `default` entry instead of `self.entry` --> _fixed_
2. Configurator and Experiment managers app where named PresetManager --> _modified_
3. Restored `-p` for ex**P**eriment loading (in order to keep a one letter option). It could also be `-x` but it could be though as "e**x**tension". Or it could be `-e|--experiment` and `-x|--extension`