### PR TITLE
Feature/custom menu+persistent

### DIFF
--- a/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan_ui.py
+++ b/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan_ui.py
@@ -97,9 +97,9 @@ class DAQScanUI(CustomApp, ViewerDispatcher):
         self.settings_toolbox.addItem(self.scanner_widget, 'Scanner Settings')
 
     def setup_menus_and_toolbars(self, menubar: QtWidgets.QMenuBar = None):
-        self.add_menu(MenuNames.FILE, MenuNames.FILE.capitalize(), menubar)
-        self.add_menu(MenuNames.TOOLS, MenuNames.TOOLS.capitalize(), menubar)
-        self.add_menu('actions', 'Actions', menubar)
+        self.add_menu(MenuNames.FILE, MenuNames.FILE.capitalize(), parent_menu=menubar)
+        self.add_menu(MenuNames.TOOLS, MenuNames.TOOLS.capitalize(), parent_menu=menubar)
+        self.add_menu('actions', 'Actions', parent_menu=menubar)
 
     def setup_actions(self):
         self.add_action('ini_positions', 'Init Positions', 'arrows_input', menu='actions')

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/action_manager_example.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/action_manager_example.py
@@ -131,11 +131,11 @@ class ActionManagerExample(QtWidgets.QMainWindow, ActionManager):
         view_menu = self.add_menu('view', 'View')
 
         # Level 1: Panels menu
-        panels_menu = self.add_menu('panels', 'Panels', menu=view_menu)
+        panels_menu = self.add_menu('panels', 'Panels', parent_menu=view_menu)
 
         # Level 2: Left Panel menu
         left_panel_menu = self.add_menu('left_panel', 'Left Panel',
-                                       menu=panels_menu)
+                                       parent_menu=panels_menu)
         self.add_action('left_files', 'File Explorer', icon_name='Folder',
                        menu=left_panel_menu, toolbar=view_toolbar,
                        checkable=True, checked=True, tip='Toggle file explorer panel')
@@ -146,7 +146,7 @@ class ActionManagerExample(QtWidgets.QMainWindow, ActionManager):
 
         # Level 2: Right Panel menu
         right_panel_menu = self.add_menu('right_panel', 'Right Panel',
-                                        menu=panels_menu)
+                                        parent_menu=panels_menu)
         self.add_action('right_outline', 'Outline',
                        menu=right_panel_menu, checkable=True)
         self.add_action('right_terminal', 'Terminal',
@@ -154,7 +154,7 @@ class ActionManagerExample(QtWidgets.QMainWindow, ActionManager):
 
         # Level 2: Bottom Panel menu
         bottom_panel_menu = self.add_menu('bottom_panel', 'Bottom Panel',
-                                         menu=panels_menu)
+                                         parent_menu=panels_menu)
         self.add_action('bottom_console', 'Console',
                        menu=bottom_panel_menu, checkable=True, checked=True)
         self.add_action('bottom_problems', 'Problems',
@@ -167,17 +167,17 @@ class ActionManagerExample(QtWidgets.QMainWindow, ActionManager):
 
         # Add appearance menu to View
         appearance_menu = self.add_menu('appearance', 'Appearance',
-                                       menu=view_menu)
+                                       parent_menu=view_menu)
 
         # Theme menu (3 levels deep!)
-        theme_menu = self.add_menu('theme', 'Theme', menu=appearance_menu)
+        theme_menu = self.add_menu('theme', 'Theme', parent_menu=appearance_menu)
         self.add_action('theme_light', 'Light', menu=theme_menu, tip='Switch to light theme')
         self.add_action('theme_dark', 'Dark', menu=theme_menu, tip='Switch to dark theme')
         self.add_action('theme_auto', 'Auto', menu=theme_menu, toolbar=view_toolbar,
                        tip='Auto-detect theme based on system')
 
         # Font size menu (3 levels deep!)
-        font_menu = self.add_menu('font', 'Font Size', menu=appearance_menu)
+        font_menu = self.add_menu('font', 'Font Size', parent_menu=appearance_menu)
         self.add_action('font_small', 'Small', menu=font_menu)
         self.add_action('font_medium', 'Medium', menu=font_menu)
         self.add_action('font_large', 'Large', menu=font_menu)
@@ -190,11 +190,11 @@ class ActionManagerExample(QtWidgets.QMainWindow, ActionManager):
                        menu='tools', toolbar=tools_toolbar, tip='Format current document')
 
         settings_menu = self.add_menu('settings', 'Settings',
-                                     menu=tools_menu, icon_name='Params')
+                                     parent_menu=tools_menu, icon_name='Params')
 
         # General settings
         general_settings = self.add_menu('general_settings',
-                                        'General', menu=settings_menu)
+                                        'General', parent_menu=settings_menu)
         self.add_action('auto_save', 'Auto Save',
                        menu=general_settings, checkable=True, checked=True)
         self.add_action('show_tooltips', 'Show Tooltips',
@@ -202,7 +202,7 @@ class ActionManagerExample(QtWidgets.QMainWindow, ActionManager):
 
         # Advanced settings
         advanced_settings = self.add_menu('advanced_settings',
-                                         'Advanced', menu=settings_menu)
+                                         'Advanced', parent_menu=settings_menu)
         self.add_action('debug_mode', 'Debug Mode',
                        menu=advanced_settings, checkable=True)
         self.add_action('verbose_logging', 'Verbose Logging',

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/shared_ui.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/shared_ui.py
@@ -25,10 +25,10 @@ class MyApp(CustomApp):
         if menubar is None:
             menubar = self.menubar
         self.create_object_toolbar(add_break=True)
-        self.add_menu('file', 'File', menubar)
-        self.add_menu('tools', 'Tools', menubar)
-        self.add_menu('subtools', 'SubTools', 'tools')
-        self.add_toolbar('file', 'file', self.mainwindow, add_break=False)
+        self.add_menu('file', 'File', parent_menu=menubar)
+        self.add_menu('tools', 'Tools', parent_menu=menubar)
+        self.add_menu('subtools', 'SubTools', parent_menu='tools')
+        self.add_toolbar('file', 'file', parent_menu=self.mainwindow, add_break=False)
 
 
     def setup_actions(self):

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/sticky_menu_demo.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/sticky_menu_demo.py
@@ -1,0 +1,85 @@
+"""Demo of StickyMenu with three configurations:
+
+* Default (checkable-only): menu stays open only when a checkable action is clicked.
+* sticky_all=True: menu stays open for every click, checkable or not.
+* sticky_predicate: custom rule — here, only actions whose text starts with '[pin]' stay open.
+"""
+import sys
+
+from qtpy import QtWidgets
+
+from pymodaq_gui.utils.custom_app import CustomApp
+from pymodaq_gui.utils.dock import Dock
+from pymodaq_gui.utils.utils import mkQApp
+from pymodaq_gui.utils.widgets.window import make_window
+from pymodaq_gui.utils.menu_utils import StickyMenu
+
+
+class StickyMenuDemo(CustomApp):
+
+    params = []
+
+    def __init__(self, dockarea):
+        super().__init__(dockarea)
+        self.setup_ui()
+
+    def setup_docks_and_widgets(self):
+        dock = Dock('Log', size=(600, 300))
+        self.dockarea.addDock(dock)
+        self._log = QtWidgets.QPlainTextEdit()
+        self._log.setReadOnly(True)
+        dock.addWidget(self._log)
+
+    def setup_menus_and_toolbars(self, menubar=None):
+        # 1. Default StickyMenu — stays open only for checkable actions
+        self.add_menu('checkable', 'Checkable-only (default)',
+                      self.menubar, menu=StickyMenu())
+
+        # 2. sticky_all=True — stays open for every click
+        self.add_menu('all', 'All-sticky',
+                      self.menubar, menu=StickyMenu(sticky_all=True))
+
+        # 3. Custom predicate — stays open when action text starts with '[pin]'
+        self.add_menu('custom', 'Custom predicate',
+                      self.menubar,
+                      menu=StickyMenu(sticky_predicate=lambda a: a.text().startswith('[pin]')))
+
+    def setup_actions(self):
+        # --- Checkable-only menu ---
+        self.add_action('ch_toggle1', 'Toggle A', checkable=True, menu='checkable')
+        self.add_action('ch_toggle2', 'Toggle B', checkable=True, menu='checkable')
+        self.add_action('ch_normal',  'Normal action (closes menu)', menu='checkable')
+
+        # --- All-sticky menu ---
+        self.add_action('all_toggle', 'Toggle', checkable=True, menu='all')
+        self.add_action('all_normal', 'Normal action (stays open)', menu='all')
+
+        # --- Custom predicate menu ---
+        self.add_action('pin_a',   '[pin] Pinned action A', menu='custom')
+        self.add_action('pin_b',   '[pin] Pinned action B', checkable=True, menu='custom')
+        self.add_action('unpin_c', 'Unpinned action C (closes menu)', menu='custom')
+
+    def connect_things(self):
+        for name in ('ch_toggle1', 'ch_toggle2', 'ch_normal',
+                     'all_toggle', 'all_normal',
+                     'pin_a', 'pin_b', 'unpin_c'):
+            self.connect_action(name, lambda checked=False, n=name: self._log_action(n))
+
+    def _log_action(self, name):
+        self._log.appendPlainText(f'triggered: {name}')
+
+
+def main():
+    app = mkQApp('StickyMenuDemo')
+    win, area = make_window(title='StickyMenu Demo')
+    prog = StickyMenuDemo(area)
+
+    from pymodaq_gui.utils.shared_ui import SharedUI
+    shared_ui = SharedUI(win)
+    shared_ui.affect_application(prog)
+
+    sys.exit(app.exec())
+
+
+if __name__ == '__main__':
+    main()

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
@@ -454,7 +454,7 @@ class ActionManager:
             warnings.warn(UserWarning(f'Impossible to add the widget {short_name} and type {klass} to the toolbar'))
         return widget
 
-    def add_menu(self, short_name: str, title: str,
+    def add_menu(self, short_name: str, title: str = '',
                  parent_menu: QtWidgets.QMenuBar | QtWidgets.QMenu | str = None,
                  icon_name: Union[str, Path, QtGui.QIcon] = '', auto_menu=True,
                  menu: QtWidgets.QMenu = None) -> QtWidgets.QMenu:
@@ -464,8 +464,9 @@ class ActionManager:
         ----------
         short_name: str
             the name as referenced in the dict self._menus
-        title: str
-            Displayed title of the menu
+        title: str, optional
+            Displayed title of the menu. When *menu* is also provided and *title*
+            is non-empty, the title overrides the instance's own title.
         parent_menu: QMenuBar, QMenu, str, optional
             the parent menu or menubar where this menu should be added. If None, uses the default menu
         icon_name: str / Path / QtGui.QIcon / enum name, optional
@@ -476,8 +477,6 @@ class ActionManager:
             if True add this menu to the defined parent menu
         menu: QMenu, optional
             an existing QMenu instance to register instead of creating a new one.
-            Useful for passing custom subclasses. When provided,
-            *title* is ignored (the instance already has a title).
 
         Returns
         -------
@@ -489,7 +488,7 @@ class ActionManager:
         add_action, get_menu
         """
         if auto_menu and parent_menu is None:
-                parent_menu = self._menu
+            parent_menu = self._menu
         if isinstance(parent_menu, str):
             parent_menu = self.get_menu(parent_menu)
 
@@ -497,6 +496,8 @@ class ActionManager:
             new_menu = QtWidgets.QMenu(title, parent=parent_menu)
         else:
             new_menu = menu
+            if title:
+                new_menu.setTitle(title)
 
         # Set icon if provided
         if icon_name and icon_name != '':

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
@@ -122,6 +122,7 @@ def addaction(name: str = '', icon_name: Union[str, Path, QtGui.QIcon]= '', tip=
               icon_checked_color: Union[QtGui.QColor, str] = None,
               flip_h: bool = False,
               flip_v: bool = False,
+              before: QtQAction = None,
               ):
     """Create a new action and add it eventually to a toolbar and a menu
 
@@ -164,6 +165,9 @@ def addaction(name: str = '', icon_name: Union[str, Path, QtGui.QIcon]= '', tip=
         mirror the icon horizontally (left ↔ right)
     flip_v: bool
         mirror the icon vertically (top ↔ bottom)
+    before: QAction, optional
+        if set, the action is inserted before this action in the toolbar/menu;
+        if None the action is appended at the end
     """
 
     if icon_name is None or icon_name == '':
@@ -184,9 +188,15 @@ def addaction(name: str = '', icon_name: Union[str, Path, QtGui.QIcon]= '', tip=
             action.set_icon()
     action.setToolTip(tip)
     if toolbar is not None:
-        toolbar.addAction(action)
+        if before is not None:
+            toolbar.insertAction(before, action)
+        else:
+            toolbar.addAction(action)
     if menu is not None:
-        menu.addAction(action)
+        if before is not None:
+            menu.insertAction(before, action)
+        else:
+            menu.addAction(action)
     if shortcut is not None:
         action.setShortcut(shortcut)
     action.setVisible(visible)
@@ -287,6 +297,69 @@ class ActionManager:
             self.reference_menu('default', menu)
             self.set_menu(menu)
 
+    def _resolve_toolbar(self, toolbar: Union[str, QtWidgets.QToolBar, None],
+                         auto: bool = True) -> Union[QtWidgets.QToolBar, None]:
+        """Resolve a toolbar reference to a QToolBar instance.
+
+        Parameters
+        ----------
+        toolbar: str, QToolBar, or None
+            str: looked up by name via get_toolbar
+            QToolBar: returned as-is
+            None + auto=True: returns the default toolbar (creating one if needed)
+            None + auto=False: returns None
+        """
+        if toolbar is not None:
+            if isinstance(toolbar, str):
+                return self.get_toolbar(toolbar)
+            if not isinstance(toolbar, QtWidgets.QToolBar):
+                raise TypeError(f'toolbar must be None, a str, or QToolBar, got {type(toolbar)}')
+            return toolbar
+        return self.toolbar if auto else None
+
+    def _resolve_menu(self, menu: Union[str, QtWidgets.QMenu, None],
+                      auto: bool = True) -> Union[QtWidgets.QMenu, None]:
+        """Resolve a menu reference to a QMenu instance.
+
+        Parameters
+        ----------
+        menu: str, QMenu, QMenuBar, or None
+            str: looked up by name via get_menu
+            QMenu/QMenuBar: returned as-is
+            None + auto=True: returns the default menu (creating one if needed)
+            None + auto=False: returns None
+        """
+        if menu is not None:
+            if isinstance(menu, str):
+                return self.get_menu(menu)
+            if not isinstance(menu, (QtWidgets.QMenu, QtWidgets.QMenuBar)):
+                raise TypeError(f'menu must be None, a str, QMenu, or QMenuBar, got {type(menu)}')
+            return menu
+        return self.menu if auto else None
+
+    def _resolve_action(self, action: Union[str, 'QAction', WidgetActionProxy, None]) -> Union['QAction', None]:
+        """Resolve an action reference to a QAction instance.
+
+        Parameters
+        ----------
+        action: str, QAction, WidgetActionProxy, or None
+            str: looked up by name via get_action
+            WidgetActionProxy: unwrapped to its underlying QAction
+            QAction: returned as-is
+            None: returned as None
+        """
+        if action is None:
+            return None
+        if isinstance(action, str):
+            action = self.get_action(action)
+        if isinstance(action, WidgetActionProxy):
+            return action._action
+        if isinstance(action, QtWidgets.QMenu):
+            return action.menuAction()
+        if not isinstance(action, QtQAction):
+            raise TypeError(f'action must be None, a str, QAction, WidgetActionProxy, or QMenu, got {type(action)}')
+        return action
+
     def setup_actions(self):
         """Method where to create actions to be subclassed. Mandatory
 
@@ -317,6 +390,7 @@ class ActionManager:
                    icon_checked_color: Union[QtGui.QColor, bytes, str]=None,
                    flip_h: bool = False,
                    flip_v: bool = False,
+                   before: Union[str, 'QAction', WidgetActionProxy, None] = None,
                    ):
         """Create a new action and add it to toolbar and menu
 
@@ -371,27 +445,18 @@ class ActionManager:
             mirror the icon horizontally (left ↔ right)
         flip_v: bool
             mirror the icon vertically (top ↔ bottom)
+        before: str, QAction, WidgetActionProxy, or None, optional
+            if set, the action is inserted before this action in the toolbar/menu;
+            accepts a short_name str, a QAction instance, or a WidgetActionProxy
 
         See Also
         --------
         affect_to, pymodaq.resources.QtDesigner_Ressources.icon_library,
         pymodaq.utils.managers.action_manager.add_action
         """
-        if toolbar is not None or auto_toolbar:
-            if toolbar is None:
-                toolbar = self.toolbar
-            elif isinstance(toolbar, str):
-                toolbar = self.get_toolbar(toolbar)
-            elif not isinstance(toolbar, QtWidgets.QToolBar):
-                raise TypeError(f'toolbar must be either None, a string, or QToolBar, got {type(toolbar)}')
-
-        if menu is not None or auto_menu:
-            if menu is None:
-                menu = self.menu
-            elif isinstance(menu, str):
-                menu = self.get_menu(menu)
-            elif not isinstance(menu, QtWidgets.QMenu):
-                raise TypeError(f'menu must be either None, a string, or QMenu, got {type(menu)}')
+        toolbar = self._resolve_toolbar(toolbar, auto=auto_toolbar)
+        menu = self._resolve_menu(menu, auto=auto_menu)
+        before = self._resolve_action(before)
 
         self._actions[short_name] = addaction(name, icon_name, tip, checkable=checkable,
                                               checked=checked, toolbar=toolbar, menu=menu,
@@ -400,7 +465,8 @@ class ActionManager:
                                               icon_color=icon_color,
                                               icon_checked_color=icon_checked_color,
                                               flip_h=flip_h,
-                                              flip_v=flip_v)
+                                              flip_v=flip_v,
+                                              before=before)
         return self._actions[short_name]
 
     def add_widget(self, short_name, klass: Union[str, QtWidgets.QWidget, object], *args, tip='',
@@ -437,13 +503,7 @@ class ActionManager:
         -------
         QtWidgets.QWidget
         """
-        if auto_toolbar:
-            if toolbar is None:
-                toolbar = self.toolbar
-            elif isinstance(toolbar, str):
-                toolbar = self.get_toolbar(toolbar)
-            elif not isinstance(toolbar, QtWidgets.QToolBar):
-                raise TypeError(f'toolbar must be either None, a string, or QToolBar, got {type(toolbar)}')
+        toolbar = self._resolve_toolbar(toolbar, auto=auto_toolbar)
 
         widget = addwidget(klass, *args, tip=tip, toolbar=toolbar, visible=visible, signal_str=signal_str,
                            slot=slot, enabled=enabled, **kwargs)
@@ -457,7 +517,8 @@ class ActionManager:
     def add_menu(self, short_name: str, title: str = '',
                  parent_menu: QtWidgets.QMenuBar | QtWidgets.QMenu | str = None,
                  icon_name: Union[str, Path, QtGui.QIcon] = '', auto_menu=True,
-                 menu: QtWidgets.QMenu = None) -> QtWidgets.QMenu:
+                 menu: QtWidgets.QMenu = None,
+                 before: Union[QtWidgets.QMenu, str, None] = None) -> QtWidgets.QMenu:
         """Create and add a menu to a parent menu
 
         Parameters
@@ -477,6 +538,9 @@ class ActionManager:
             if True add this menu to the defined parent menu
         menu: QMenu, optional
             an existing QMenu instance to register instead of creating a new one.
+        before: QMenu, str, or None, optional
+            if specified, the new menu will be inserted before this menu (by instance or short_name);
+            if None the menu is appended at the end
 
         Returns
         -------
@@ -489,8 +553,9 @@ class ActionManager:
         """
         if auto_menu and parent_menu is None:
             parent_menu = self._menu
-        if isinstance(parent_menu, str):
+        elif isinstance(parent_menu, str):
             parent_menu = self.get_menu(parent_menu)
+        before = self._resolve_menu(before, auto=False)
 
         if menu is None:
             new_menu = QtWidgets.QMenu(title, parent=parent_menu)
@@ -508,7 +573,10 @@ class ActionManager:
 
         # Add to parent menu if specified
         if parent_menu is not None:
-            parent_menu.addMenu(new_menu)
+            if before is None:
+                parent_menu.addMenu(new_menu)
+            else:
+                parent_menu.insertMenu(before.menuAction(), new_menu)
 
         # Store reference
         self._menus[short_name] = new_menu
@@ -534,7 +602,7 @@ class ActionManager:
     def add_toolbar(self, short_name: str, title: str = '', parent: QtWidgets.QWidget = None,
                     toolbar: QtWidgets.QToolBar = None,
                     area = QtCore.Qt.ToolBarArea.TopToolBarArea, add_break=True,
-                    before: QtWidgets.QToolBar = None) -> QtWidgets.QToolBar:
+                    before: Union[str, QtWidgets.QToolBar, None] = None) -> QtWidgets.QToolBar:
         """Create and add a toolbar
 
         Parameters
@@ -552,8 +620,8 @@ class ActionManager:
         add_break: bool, optional
             If True, a toolbar break is added in the given area before adding the toolbar, valid only for a
             QMainWindow parent
-        before: QToolbar, optional
-            if specified, the new toolbar will be inserted before this toolbar
+        before: str or QToolBar or None, optional
+            if specified, the new toolbar will be inserted before this toolbar (by instance or short_name)
         Returns
         -------
         QtWidgets.QToolBar
@@ -563,6 +631,8 @@ class ActionManager:
         --------
         add_action, get_toolbar
         """
+        before = self._resolve_toolbar(before, auto=False)
+
         if isinstance(parent, QtWidgets.QMainWindow) and add_break:
             parent.addToolBarBreak(area)
         if toolbar is None:

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
@@ -454,8 +454,10 @@ class ActionManager:
             warnings.warn(UserWarning(f'Impossible to add the widget {short_name} and type {klass} to the toolbar'))
         return widget
 
-    def add_menu(self, short_name: str, title: str, menu: QtWidgets.QMenuBar | QtWidgets.QMenu | str = None,
-                 icon_name: Union[str, Path, QtGui.QIcon] = '', auto_menu=True) -> QtWidgets.QMenu:
+    def add_menu(self, short_name: str, title: str,
+                 parent_menu: QtWidgets.QMenuBar | QtWidgets.QMenu | str = None,
+                 icon_name: Union[str, Path, QtGui.QIcon] = '', auto_menu=True,
+                 menu: QtWidgets.QMenu = None) -> QtWidgets.QMenu:
         """Create and add a menu to a parent menu
 
         Parameters
@@ -464,31 +466,37 @@ class ActionManager:
             the name as referenced in the dict self._menus
         title: str
             Displayed title of the menu
-        menu: QMenuBar, QMenu, str, optional
-            a parent menu where this menu should be added. If None, uses the default menu
+        parent_menu: QMenuBar, QMenu, str, optional
+            the parent menu or menubar where this menu should be added. If None, uses the default menu
         icon_name: str / Path / QtGui.QIcon / enum name, optional
             str/Path: the png file name/path to produce the icon
             QtGui.QIcon: the instance of a QIcon element
             ThemeIcon enum: the value of QtGui.QIcon.ThemeIcon (requires Qt>=6.7)
         auto_menu: bool
             if True add this menu to the defined parent menu
+        menu: QMenu, optional
+            an existing QMenu instance to register instead of creating a new one.
+            Useful for passing custom subclasses. When provided,
+            *title* is ignored (the instance already has a title).
 
         Returns
         -------
         QtWidgets.QMenu
-            The created menu
+            The created (or provided) menu
 
         See Also
         --------
         add_action, get_menu
         """
-        if auto_menu:
-            if menu is None:
-                menu = self._menu
-        if isinstance(menu, str):
-            menu = self.get_menu(menu)
+        if auto_menu and parent_menu is None:
+                parent_menu = self._menu
+        if isinstance(parent_menu, str):
+            parent_menu = self.get_menu(parent_menu)
 
-        new_menu = QtWidgets.QMenu(title, parent=menu)
+        if menu is None:
+            new_menu = QtWidgets.QMenu(title, parent=parent_menu)
+        else:
+            new_menu = menu
 
         # Set icon if provided
         if icon_name and icon_name != '':
@@ -498,8 +506,8 @@ class ActionManager:
                 new_menu.setIcon(create_icon(icon_name))
 
         # Add to parent menu if specified
-        if menu is not None:
-            menu.addMenu(new_menu)
+        if parent_menu is not None:
+            parent_menu.addMenu(new_menu)
 
         # Store reference
         self._menus[short_name] = new_menu

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/menu_utils.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/menu_utils.py
@@ -3,9 +3,52 @@
 Uses ``QMenu(title, parent)`` to create submenus so that Qt takes C++
 ownership and PySide6 does not garbage-collect them prematurely.
 """
-from typing import Callable
+from typing import Callable, Optional
 
-from qtpy import QtWidgets
+from qtpy import QtWidgets, QtGui
+
+
+class StickyMenu(QtWidgets.QMenu):
+    """A :class:`QMenu` that stays open after an action is triggered.
+
+    By default the menu remains open only when a **checkable** action is
+    clicked (the typical use-case for toolbar-visibility toggles).  Pass
+    ``sticky_all=True`` to keep the menu open after *any* action click,
+    which is useful for multi-selection menus.  For fine-grained control
+    supply a *sticky_predicate*: a callable that receives the triggered
+    ``QAction`` and returns ``True`` when the menu should stay open.
+
+    Parameters
+    ----------
+    *args :
+        Forwarded to :class:`QMenu` (title, parent, …).
+    sticky_all : bool
+        When ``True`` the menu never closes on a click regardless of whether
+        the action is checkable.  Ignored if *sticky_predicate* is given.
+    sticky_predicate : callable(QAction) -> bool, optional
+        Custom predicate that decides per-action whether the menu stays open.
+        When provided, *sticky_all* is ignored.
+    **kwargs :
+        Forwarded to :class:`QMenu`.
+    """
+
+    def __init__(self, *args, sticky_all: bool = False,
+                 sticky_predicate: Optional[Callable[[QtWidgets.QAction], bool]] = None,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        if sticky_predicate is not None:
+            self._is_sticky = sticky_predicate
+        elif sticky_all:
+            self._is_sticky = lambda action: True
+        else:
+            self._is_sticky = lambda action: action.isCheckable()
+
+    def mouseReleaseEvent(self, event: QtGui.QMouseEvent) -> None:
+        action = self.activeAction()
+        if action and self._is_sticky(action):
+            action.trigger()
+        else:
+            super().mouseReleaseEvent(event)
 
 
 def build_menu_from_iterable(

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/shared_ui.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/shared_ui.py
@@ -27,6 +27,7 @@ from pymodaq_utils.utils import get_version
 from pymodaq_utils.config import GlobalConfig as Config
 from pymodaq_utils.utils import get_module_path
 from pymodaq_gui.utils.custom_app import CustomApp
+from pymodaq_gui.utils.menu_utils import StickyMenu
 
 
 logger = set_logger(get_module_name(__file__))
@@ -183,7 +184,8 @@ class SharedUI(CustomApp):
         self.add_menu(MenuNames.VIEW, MenuNames.VIEW.capitalize(), menubar)
         self.get_menu(MenuNames.VIEW).addSeparator()
 
-        self.add_menu(MenuNames.TOOLBARS, MenuNames.TOOLBARS.capitalize(), MenuNames.VIEW)
+        self.add_menu(MenuNames.TOOLBARS, MenuNames.TOOLBARS.capitalize(), MenuNames.VIEW,
+                      menu=StickyMenu(MenuNames.TOOLBARS.capitalize()))
 
         self.add_menu(MenuNames.TOOLS, 'Tools', menubar)
         self.get_menu(MenuNames.TOOLS).addSeparator()

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/shared_ui.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/shared_ui.py
@@ -185,7 +185,7 @@ class SharedUI(CustomApp):
         self.get_menu(MenuNames.VIEW).addSeparator()
 
         self.add_menu(MenuNames.TOOLBARS, MenuNames.TOOLBARS.capitalize(), MenuNames.VIEW,
-                      menu=StickyMenu(MenuNames.TOOLBARS.capitalize()))
+                      menu=StickyMenu())
 
         self.add_menu(MenuNames.TOOLS, 'Tools', menubar)
         self.get_menu(MenuNames.TOOLS).addSeparator()

--- a/packages/pymodaq_gui/tests/managers/action_manager_test.py
+++ b/packages/pymodaq_gui/tests/managers/action_manager_test.py
@@ -112,7 +112,7 @@ def test_nested_menus(qtbot):
     parent_menu = action_manager.add_menu('parent', 'Parent Menu')
 
     # Create child menu within parent
-    child_menu = action_manager.add_menu('child', 'Child Menu', menu=parent_menu)
+    child_menu = action_manager.add_menu('child', 'Child Menu', parent_menu=parent_menu)
 
     assert action_manager.has_menu('parent')
     assert action_manager.has_menu('child')
@@ -219,7 +219,7 @@ def test_shared_menu(qtbot):
     view_menu = action_manager.add_menu('view', 'View')
 
     # Create a shared menu (add to file menu first)
-    shared_menu = action_manager.add_menu('recent', 'Recent Files', menu=file_menu)
+    shared_menu = action_manager.add_menu('recent', 'Recent Files', parent_menu=file_menu)
 
     # Add the same menu to view menu
     view_menu.addMenu(shared_menu)
@@ -614,7 +614,7 @@ def test_complex_menu_toolbar_structure(qtbot):
 
     # Create nested menu structure
     file_menu = action_manager.add_menu('file', 'File')
-    recent_menu = action_manager.add_menu('recent', 'Recent', menu=file_menu)
+    recent_menu = action_manager.add_menu('recent', 'Recent', parent_menu=file_menu)
 
     # Add actions to both menu and toolbar
     action_manager.add_action('new', 'New', icon_name='NewFile',


### PR DESCRIPTION
Little PR following #999 

- It changes the add_menu of ActionManager to accept custom menu instead of always creating a new one. In that case, the title of the given menu is taken as default. If a title is given, it replaces the menu's one
- Adding StickyMenu as a new menu type dedicated to keeping the menu open when checking/unchecking action. 
**sticky_menu_demo.py** lists the different use case.


