### PR TITLE
Ux/configurator renaming in state manager

### DIFF
--- a/docs/src/api/api_utility_modules/api_managers.rst
+++ b/docs/src/api/api_utility_modules/api_managers.rst
@@ -77,12 +77,12 @@ API of the various managers, special classes easing the experimental orchestrati
 
 .. autosummary::
     experiment.experiment_manager::ExperimentManager
-    configurator.configurator::Configurator
+    state.state_manager::StateManager
 
 .. currentmodule:: pymodaq.utils.experiment.experiment_manager
 
 .. autoclass:: ExperimentManager
 
-.. py:currentmodule:: pymodaq.utils.managers.configurator.configurator
+.. py:currentmodule:: pymodaq.utils.managers.state.state_manager
 
-.. autoclass:: Configurator
+.. autoclass:: StateManager

--- a/docs/src/modules/DashBoard.rst
+++ b/docs/src/modules/DashBoard.rst
@@ -13,7 +13,8 @@ This module is the heart of PyMoDAQ, it will:
 The flow of this module is as follow:
 
 * At startup you have to define/load/modify an experiment (see :ref:`experiment_manager`) representing an ensemble of actuators and detectors
-* Define/load/modify a Configuration (see :ref:`configurator`) representing a state of the control modules settings and some other special configuration subentries
+* Define/load/modify a State (see :ref:`state_manager`) representing a state of the control modules settings and some other special state subentries
+  like actuator values
 * Define/load/modify eventual overshoots (see :ref:`overshoot_manager`)
 * Define/load/modify eventual ROI (Region of interests) selections (see :ref:`roi_manager`)
 * Use the actuators and detectors manually to drive your experiment
@@ -91,7 +92,7 @@ The **Tools/Experiment** menu enables to create or modify (using the :ref:`exper
 files defining a set of actuators and detectors used for a given experiment. Each experiment has therefore a corresponding
 experiment file. At startup, the program checks for existing experiment files and create a menu entry for each of them.
 
-The **Configurator Modes** menu, new from version 5.2.x, enables to create or modify (using the :ref:`configurator`)
+The **State** menu, new from version 5.2.x, enables to create or modify (using the :ref:`state_manager`)
 *configurations* that are binary files defining a set of status for the settings of all actuators and detectors
 declared in the DashBoard (from the loaded experiment). One can therefore easily switch between different configurations, hence
 different settings for the control modules. Special *actions* are also available such as the initialization of control

--- a/docs/src/user_folder/dashboard_manager.rst
+++ b/docs/src/user_folder/dashboard_manager.rst
@@ -33,11 +33,11 @@ The entries browsing and execution is incorporated in the DashBoard toolbar (see
    can be browsed and directly executed.
 
 
-Depending on the task, an entry will look different (see below a Preset entry and a Configurator entry). A preset
+Depending on the task, an entry will look different (see below an Experiment entry and a State entry). An experiment
 features a list of actuators and detectors while a configuration is a list of actions one can perform on control
 modules settings for a given *preset*.
 
-.. _preset_manager:
+.. _experiment_manager:
 
 Preset manager
 --------------
@@ -46,7 +46,7 @@ The *Preset manager* is an object that helps to generate, modify and save preset
 A preset is a set of actuators and detectors represented in a tree like structure, see :numref:`preset_fig`.
 
 
-   .. _preset_fig:
+   .. _experiment_fig:
 
 .. figure:: /image/dashboard/preset_fig.png
    :alt: preset_fig
@@ -57,16 +57,16 @@ A preset is a set of actuators and detectors represented in a tree like structur
 Only a few options are available for the preset. It is merely there to configure the type and list of
 control modules to be added in the DashBoard. The only options are related to the master/slave status
 (see :ref:`multiple_hardware`) and if it should be initialized at startup. For configuration of
-the initial settings of the control modules, see below the :ref:`configurator`.
+the initial settings of the control modules, see below the :ref:`state_manager`.
 
 .. note::
 
   Since its modification in version 5.2.0 onwards, *Presets* can be modified at any time and
   a new preset can be loaded also at any time without having to restart the DashBoard!!
 
-.. _configurator:
+.. _state_manager:
 
-Configurator
+StateManager
 ------------
 
 .. note::
@@ -74,7 +74,7 @@ Configurator
   New in version 5.2.0
 
 
-   .. _configurator_fig:
+   .. _state_fig:
 
 .. figure:: /image/dashboard/configurator_fig.png
    :alt: configurator_fig
@@ -84,28 +84,28 @@ Configurator
    Ypiezo actuators and two to set their absolute value. This *default* configuration is executed
    at startup just after the preset is done loading control modules.
 
-Once the :ref:`preset_manager` is done loading its configured control modules, the Configurator
+Once the :ref:`preset_manager` is done loading its configured control modules, the StateManager
 can be opened. In fact, for each preset file, a configuration called *default* (empty by default)
 will be created and loaded after the loading of the control modules. But then any predefined configuration
 can be loaded at any time.
 
-A configuration is made by selecting a given settings (left side of figure :numref:`configurator_fig`)
+A configuration is made by selecting a given settings (left side of figure :numref:`state_fig`)
 and dragging/dropping it to the table on the right. You can also use double clicking
 a setting to move it to a configuration or use the right arrow in the middle of the window.
 If you select a group parameter, all its children will be moved in the configuration.
 All but only the ones that are valid as configurable settings.
 
 Three special *configuration* subentries are available from the context menu (right click while
-the mouse is hovering the configuration table), see :numref:`configurator_context_menu`.
+the mouse is hovering the configuration table), see :numref:`state_context_menu`.
 
-   .. _configurator_context_menu:
+   .. _state_context_menu:
 
 .. figure:: /image/dashboard/configurator_context_menu.png
    :alt: configurator_fig
 
-   The Configurator context menu
+   The StateManager context menu
 
-These allow to configure:
+These allow to define:
 
 * the Initialization of a given control module
 * the value of an Actuator (an absolute move will be done)
@@ -124,7 +124,7 @@ Overshoot manager
 .. note::
 
   As of version 5.2.0 the overshoot manager will be rewritten to use the general framework described above and also
-  to use entries from the Configurator to trigger a *safe* configuration...
+  to use entries from the StateManager to trigger a *safe* state of your experiment setup...
 
 
 The *Overshoot* manager is used to configure **safety actions** (for instance the absolute positioning of one or more

--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -55,7 +55,7 @@ from pymodaq.extensions.utils import get_extensions
 from pymodaq.extensions import  ExtensionEnum
 from pymodaq.utils.shared_ui import SharedUI
 
-from pymodaq.utils.managers.state.configurator import Configurator
+from pymodaq.utils.managers.state.state_manager import StateManager
 
 if TYPE_CHECKING:
     from pymodaq.extensions.custom_ext import CustomExt
@@ -167,7 +167,7 @@ class DashBoard(CustomApp, LECOComponentMixin):
         self.extensions: dict[str, CustomExt] = dict([])
         self.extension_windows = []
         self.experiment_manager: ExperimentManager = None  # instanciation in do_things_after_ui_setup
-        self.configurator: Configurator = None # instanciation in do_things_after_ui_setup
+        self.state_manager: StateManager = None # instanciation in do_things_after_ui_setup
         self.overshooter: Overshooter = None # instanciation in do_things_after_ui_setup
 
         self.dockarea.dock_signal.connect(self.save_layout_state_auto)
@@ -218,13 +218,13 @@ class DashBoard(CustomApp, LECOComponentMixin):
         self.experiment_manager.update_entry()
         self.experiment_manager.entry = 'default'
         self.experiment_manager.applied_entry.connect(self.do_things_after_experiment_set)
-        self.configurator = Configurator(dashboard=self)
+        self.state_manager = StateManager(dashboard=self)
         self.experiment_manager.get_external_toolbar_menu(toolbar=self.get_toolbar('experiment'),
                                                           menu=self.get_menu('experiment'))
         self.experiment_manager.update_menu(self.get_menu('experiment'))
-        self.configurator.get_external_toolbar_menu(toolbar=self.get_toolbar('state'),
-                                                    menu=self.get_menu('state'))
-        self.configurator.update_menu(self.get_menu('state'))
+        self.state_manager.get_external_toolbar_menu(toolbar=self.get_toolbar('state'),
+                                                     menu=self.get_menu('state'))
+        self.state_manager.update_menu(self.get_menu('state'))
         self.overshooter = Overshooter(dashboard=self)
         self.overshooter.get_external_toolbar_menu(toolbar=self.get_toolbar('overshooter'),
                                                    menu=self.get_menu('overshooter'))
@@ -240,7 +240,7 @@ class DashBoard(CustomApp, LECOComponentMixin):
 
     def do_things_after_experiment_set(self, experiment_name: str):
 
-        self.configurator.update_menu(self.get_menu('state'))
+        self.state_manager.update_menu(self.get_menu('state'))
         self.get_menu('state').setEnabled(True)
         self.get_toolbar('state').setEnabled(True)
 
@@ -249,9 +249,9 @@ class DashBoard(CustomApp, LECOComponentMixin):
 
         self.get_menu('extensions').setEnabled(True)
 
-        self.configurator.enable_actions(True)
+        self.state_manager.enable_actions(True)
         self.overshooter.enable_actions(True)
-        self.configurator.execute_entry(self.configurator.entry_filepath)
+        self.state_manager.execute_entry(self.state_manager.entry_filepath)
 
         if self._scripted_experiment_load:
             self._scripted_experiment_load = False
@@ -275,17 +275,17 @@ class DashBoard(CustomApp, LECOComponentMixin):
             }
             self._leco_commands_signal.emit(ThreadCommand(LECODashboardCommands.SEND_DEVICES, devices))
         elif status.command == LECODashboardCommands.GET_CONFIGURATIONS:
-            entries = self.configurator.entries if self.configurator.is_action_enabled(ManagerActions.LIST) else []
+            entries = self.state_manager.entries if self.state_manager.is_action_enabled(ManagerActions.LIST) else []
             self._leco_commands_signal.emit(ThreadCommand(LECODashboardCommands.SEND_CONFIGURATIONS, entries))
         elif status.command == LECODashboardCommands.APPLY_CONFIGURATION:
             configuration = status.attribute
             loaded = False
-            if (configuration in self.configurator.entries and
-                self.configurator.is_action_enabled(ManagerActions.EXECUTE)
+            if (configuration in self.state_manager.entries and
+                self.state_manager.is_action_enabled(ManagerActions.EXECUTE)
             ):
 
-                self.configurator.entry = configuration
-                self.configurator.execute_entry(self.configurator.entry_filepath)
+                self.state_manager.entry = configuration
+                self.state_manager.execute_entry(self.state_manager.entry_filepath)
                 loaded = True
 
             self._leco_commands_signal.emit(ThreadCommand(LECODashboardCommands.APPLIED_CONFIGURATION_DONE, loaded))
@@ -470,7 +470,7 @@ class DashBoard(CustomApp, LECOComponentMixin):
 
         self.add_menu(MenuNames.TOOLS, 'Tools', menubar)
         self.add_menu('experiment', 'Experiment', MenuNames.TOOLS, icon_name='experiment')
-        self.add_menu('state', 'Configurator', MenuNames.TOOLS, icon_name='discover_tune')
+        self.add_menu('state', 'State', MenuNames.TOOLS, icon_name='discover_tune')
         self.get_menu('state').setEnabled(False)
 
         self.add_menu('overshooter', 'Overshooter', MenuNames.TOOLS, icon_name='security')
@@ -498,7 +498,7 @@ class DashBoard(CustomApp, LECOComponentMixin):
 
         self.add_toolbar('experiment', 'Experiment', parent=self.mainwindow,
                          add_break=False)
-        self.add_toolbar('state', 'Configurator', parent=self.mainwindow,
+        self.add_toolbar('state', 'State', parent=self.mainwindow,
                          add_break=False)
         self.add_toolbar('overshooter', 'Overshoot', parent=self.mainwindow,
                          add_break=False)
@@ -534,7 +534,7 @@ class DashBoard(CustomApp, LECOComponentMixin):
             self.add_action(ExtensionEnum[ext_name], ExtensionEnum[ext_name].value,
                             auto_toolbar=False, menu='extensions')
 
-        self.add_action("state", "Configurator", auto_toolbar=False)
+        self.add_action("state", "State", auto_toolbar=False)
 
     def connect_things(self):
         self.status_signal[str].connect(self.add_status)
@@ -721,7 +721,7 @@ class DashBoard(CustomApp, LECOComponentMixin):
                     pass
 
             self.experiment_manager.quit_fun()
-            self.configurator.quit_fun()
+            self.state_manager.quit_fun()
             self.overshooter.quit_fun()
 
             areas = self.dockarea.tempAreas[:]
@@ -1405,7 +1405,7 @@ def load_dashboard_with_experiment(experiment_name: str,
     if experiment_name in dashboard.experiment_manager.entries:
         dashboard.experiment_manager.entry = experiment_name
         if configuration_name is not None:
-            dashboard.configurator.entry = configuration_name
+            dashboard.state_manager.entry = configuration_name
         dashboard.experiment_manager.execute_entry(experiment_path)
 
         if extension_name in ExtensionEnum.names():

--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -55,7 +55,7 @@ from pymodaq.extensions.utils import get_extensions
 from pymodaq.extensions import  ExtensionEnum
 from pymodaq.utils.shared_ui import SharedUI
 
-from pymodaq.utils.managers.configurator.configurator import Configurator
+from pymodaq.utils.managers.state.configurator import Configurator
 
 if TYPE_CHECKING:
     from pymodaq.extensions.custom_ext import CustomExt
@@ -222,16 +222,16 @@ class DashBoard(CustomApp, LECOComponentMixin):
         self.experiment_manager.get_external_toolbar_menu(toolbar=self.get_toolbar('experiment'),
                                                           menu=self.get_menu('experiment'))
         self.experiment_manager.update_menu(self.get_menu('experiment'))
-        self.configurator.get_external_toolbar_menu(toolbar=self.get_toolbar('configurator'),
-                                                    menu=self.get_menu('configurator'))
-        self.configurator.update_menu(self.get_menu('configurator'))
+        self.configurator.get_external_toolbar_menu(toolbar=self.get_toolbar('state'),
+                                                    menu=self.get_menu('state'))
+        self.configurator.update_menu(self.get_menu('state'))
         self.overshooter = Overshooter(dashboard=self)
         self.overshooter.get_external_toolbar_menu(toolbar=self.get_toolbar('overshooter'),
                                                    menu=self.get_menu('overshooter'))
 
         self.affect_to(self.experiment_manager.get_action(ManagerActions.NEW), self.get_menu(MenuNames.FILE))
 
-        self.get_toolbar('configurator').setEnabled(False)
+        self.get_toolbar('state').setEnabled(False)
         self.get_toolbar('overshooter').setEnabled(False)
         self.experiment_manager.enable_actions(True)
 
@@ -240,9 +240,9 @@ class DashBoard(CustomApp, LECOComponentMixin):
 
     def do_things_after_experiment_set(self, experiment_name: str):
 
-        self.configurator.update_menu(self.get_menu('configurator'))
-        self.get_menu('configurator').setEnabled(True)
-        self.get_toolbar('configurator').setEnabled(True)
+        self.configurator.update_menu(self.get_menu('state'))
+        self.get_menu('state').setEnabled(True)
+        self.get_toolbar('state').setEnabled(True)
 
         self.get_menu('overshooter').setEnabled(True)
         self.get_toolbar('overshooter').setEnabled(True)
@@ -470,8 +470,8 @@ class DashBoard(CustomApp, LECOComponentMixin):
 
         self.add_menu(MenuNames.TOOLS, 'Tools', menubar)
         self.add_menu('experiment', 'Experiment', MenuNames.TOOLS, icon_name='experiment')
-        self.add_menu('configurator', 'Configurator', MenuNames.TOOLS, icon_name='discover_tune')
-        self.get_menu('configurator').setEnabled(False)
+        self.add_menu('state', 'Configurator', MenuNames.TOOLS, icon_name='discover_tune')
+        self.get_menu('state').setEnabled(False)
 
         self.add_menu('overshooter', 'Overshooter', MenuNames.TOOLS, icon_name='security')
         self.get_menu('overshooter').setEnabled(False)
@@ -498,7 +498,7 @@ class DashBoard(CustomApp, LECOComponentMixin):
 
         self.add_toolbar('experiment', 'Experiment', parent=self.mainwindow,
                          add_break=False)
-        self.add_toolbar('configurator', 'Configurator', parent=self.mainwindow,
+        self.add_toolbar('state', 'Configurator', parent=self.mainwindow,
                          add_break=False)
         self.add_toolbar('overshooter', 'Overshoot', parent=self.mainwindow,
                          add_break=False)
@@ -534,7 +534,7 @@ class DashBoard(CustomApp, LECOComponentMixin):
             self.add_action(ExtensionEnum[ext_name], ExtensionEnum[ext_name].value,
                             auto_toolbar=False, menu='extensions')
 
-        self.add_action("configurator", "Configurator", auto_toolbar=False)
+        self.add_action("state", "Configurator", auto_toolbar=False)
 
     def connect_things(self):
         self.status_signal[str].connect(self.add_status)

--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -469,11 +469,11 @@ class DashBoard(CustomApp, LECOComponentMixin):
         self.add_menu('docked', 'Docked', MenuNames.VIEW)
 
         self.add_menu(MenuNames.TOOLS, 'Tools', menubar)
-        self.add_menu('experiment', 'Experiment', MenuNames.TOOLS, icon_name='experiment')
-        self.add_menu('state', 'State', MenuNames.TOOLS, icon_name='discover_tune')
+        self.add_menu('experiment', 'Experiment', MenuNames.TOOLS, icon_name=ExperimentManager.icon_name)
+        self.add_menu('state', 'State', MenuNames.TOOLS, icon_name=StateManager.icon_name)
         self.get_menu('state').setEnabled(False)
 
-        self.add_menu('overshooter', 'Overshooter', MenuNames.TOOLS, icon_name='security')
+        self.add_menu('overshooter', 'Overshooter', MenuNames.TOOLS, icon_name=Overshooter.icon_name)
         self.get_menu('overshooter').setEnabled(False)
 
         # self.roi_menu = self.add_menu('roi', 'ROI', auto_menu=False)

--- a/packages/pymodaq/src/pymodaq/extensions/custom_ext.py
+++ b/packages/pymodaq/src/pymodaq/extensions/custom_ext.py
@@ -9,7 +9,7 @@ from pymodaq.utils.managers.modules.modules_manager import ModulesManager
 if TYPE_CHECKING:
     from pymodaq.dashboard import DashBoard
     from pymodaq.utils.managers.experiment.experiment_manager import ExperimentManager
-    from pymodaq.utils.managers.configurator.configurator import Configurator
+    from pymodaq.utils.managers.state.configurator import Configurator
 
 
 class DashBoardToolbarActions(StrEnum):
@@ -118,7 +118,7 @@ class CustomExt(CustomApp):
                                  add_configurator=True,
                                  add_break=True):
         """ Creates and add a toolbar named dashboard containing means to show/hide the dashboard and optionally
-        to display the experiment and configurator manager in this toolbar """
+        to display the experiment and state manager in this toolbar """
 
         self.add_toolbar('dashboard', 'Dashboard Toolbar',
                          parent=self.mainwindow, add_break=add_break)

--- a/packages/pymodaq/src/pymodaq/extensions/custom_ext.py
+++ b/packages/pymodaq/src/pymodaq/extensions/custom_ext.py
@@ -123,8 +123,8 @@ class CustomExt(CustomApp):
         self.add_toolbar('dashboard', 'Dashboard Toolbar',
                          parent=self.mainwindow, add_break=add_break)
         if add_dashboard:
-            self.add_widget(DashBoardToolbarActions.LABEL, QtWidgets.QLabel('Dashboard:'),
-                            toolbar='dashboard')
+            # self.add_widget(DashBoardToolbarActions.LABEL, QtWidgets.QLabel('Dashboard:'),
+            #                 toolbar='dashboard')
             self.add_action(DashBoardToolbarActions.SHOW, 'Show Dashboard', 'visibility',
                             'Show/Hide the Dashboard window', checkable=True,
                             icon_color=self.get_theme().green,

--- a/packages/pymodaq/src/pymodaq/extensions/custom_ext.py
+++ b/packages/pymodaq/src/pymodaq/extensions/custom_ext.py
@@ -9,7 +9,7 @@ from pymodaq.utils.managers.modules.modules_manager import ModulesManager
 if TYPE_CHECKING:
     from pymodaq.dashboard import DashBoard
     from pymodaq.utils.managers.experiment.experiment_manager import ExperimentManager
-    from pymodaq.utils.managers.state.configurator import Configurator
+    from pymodaq.utils.managers.state.state_manager import StateManager
 
 
 class DashBoardToolbarActions(StrEnum):
@@ -84,9 +84,9 @@ class CustomExt(CustomApp):
             self.show_dashboard()
 
     @property
-    def configurator(self) -> 'Configurator':
+    def state_manager(self) -> 'StateManager':
         if self.dashboard is not None:
-            return self.dashboard.configurator
+            return self.dashboard.state_manager
 
     @property
     def splash(self):
@@ -115,7 +115,7 @@ class CustomExt(CustomApp):
     def create_dashboard_toolbar(self,
                                  add_dashboard: bool = True,
                                  add_experiment=True,
-                                 add_configurator=True,
+                                 add_state=True,
                                  add_break=True):
         """ Creates and add a toolbar named dashboard containing means to show/hide the dashboard and optionally
         to display the experiment and state manager in this toolbar """
@@ -137,8 +137,8 @@ class CustomExt(CustomApp):
         if add_experiment:
             self.experiment_manager.get_external_toolbar_menu(toolbar=self.get_toolbar('dashboard'))
             self.get_toolbar('dashboard').addSeparator()
-        if add_configurator:
-            self.configurator.get_external_toolbar_menu(toolbar=self.get_toolbar('dashboard'))
+        if add_state:
+            self.state_manager.get_external_toolbar_menu(toolbar=self.get_toolbar('dashboard'))
             self.get_toolbar('dashboard').addSeparator()
 
     def show_dashboard(self, show: bool = None):

--- a/packages/pymodaq/src/pymodaq/utils/config.py
+++ b/packages/pymodaq/src/pymodaq/utils/config.py
@@ -16,7 +16,7 @@ def get_set_experiment_path(user=False):
 def get_set_state_path(subfolder: str = '', user=False):
     """ creates and return the config folder path for managers files
     """
-    target_path = get_set_config_dir('configurations', user=user).joinpath(subfolder)
+    target_path = get_set_config_dir('states', user=user).joinpath(subfolder)
     target_path.mkdir(parents=True, exist_ok=True)
     
     return target_path

--- a/packages/pymodaq/src/pymodaq/utils/config.py
+++ b/packages/pymodaq/src/pymodaq/utils/config.py
@@ -13,7 +13,7 @@ def get_set_experiment_path(user=False):
     return get_set_config_dir('experiments', user=user)
 
 
-def get_set_configurator_path(subfolder: str = '', user=False):
+def get_set_state_path(subfolder: str = '', user=False):
     """ creates and return the config folder path for managers files
     """
     target_path = get_set_config_dir('configurations', user=user).joinpath(subfolder)

--- a/packages/pymodaq/src/pymodaq/utils/managers/experiment/experiment_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/experiment/experiment_manager.py
@@ -11,7 +11,7 @@ from pymodaq_gui.utils.dock import Dock
 from pymodaq_gui.parameter import Parameter
 from pymodaq_gui.parameter import ioxml
 
-from pymodaq.utils.config import get_set_experiment_path, get_set_overshoot_path, get_set_configurator_path, get_set_remote_path
+from pymodaq.utils.config import get_set_experiment_path, get_set_overshoot_path, get_set_state_path, get_set_remote_path
 from pymodaq_gui.config import get_set_layout_path, get_set_roi_path
 from pymodaq_gui.managers.manager_base import ManagerBase
 from pymodaq.utils.managers.modules.utils import ModuleType
@@ -192,9 +192,9 @@ class ExperimentManager(ManagerBase):
 
     @staticmethod
     def remove_preset_related_files(preset_name: str):
-        for file in get_set_configurator_path(preset_name).iterdir():
+        for file in get_set_state_path(preset_name).iterdir():
             file.unlink(missing_ok=True)
-        get_set_configurator_path(preset_name).rmdir()
+        get_set_state_path(preset_name).rmdir()
         get_set_roi_path().joinpath(preset_name).unlink(missing_ok=True)
         get_set_layout_path().joinpath(preset_name).unlink(missing_ok=True)
         get_set_overshoot_path().joinpath(preset_name).unlink(missing_ok=True)

--- a/packages/pymodaq/src/pymodaq/utils/managers/experiment/experiment_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/experiment/experiment_manager.py
@@ -43,6 +43,7 @@ class ExperimentManager(ManagerBase):
 
     entry_type = 'experiment'
     entry_extension ='.xml'
+    icon_name = 'experiment'
 
     def __init__(self,
                  dashboard: 'DashBoard' = None):

--- a/packages/pymodaq/src/pymodaq/utils/managers/overshoot/overshooter.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/overshoot/overshooter.py
@@ -13,7 +13,7 @@ from pymodaq.utils.config import get_set_experiment_path
 from pymodaq_gui.parameter import Parameter, ioxml
 
 
-from pymodaq.utils.managers.configurator.configurator import Configurator
+from pymodaq.utils.managers.state.configurator import Configurator
 from pymodaq.utils.managers.experiment.experiment_manager import ExperimentManager
 
 from pymodaq.utils.managers.overshoot.utils import ModulesManager, \

--- a/packages/pymodaq/src/pymodaq/utils/managers/overshoot/overshooter.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/overshoot/overshooter.py
@@ -56,7 +56,7 @@ class Overshooter(ManagerBase):
         {'title': 'Overshoots:', 'name': 'overshoots', 'type': 'group_overshoot'},
     ]
 
-    entry_type = 'overshooter'
+    entry_type = 'overshoot'
     entry_extension ='.xml'
     icon_name = 'security'
 

--- a/packages/pymodaq/src/pymodaq/utils/managers/overshoot/overshooter.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/overshoot/overshooter.py
@@ -13,7 +13,7 @@ from pymodaq.utils.config import get_set_experiment_path
 from pymodaq_gui.parameter import Parameter, ioxml
 
 
-from pymodaq.utils.managers.state.configurator import Configurator
+from pymodaq.utils.managers.state.state_manager import StateManager
 from pymodaq.utils.managers.experiment.experiment_manager import ExperimentManager
 
 from pymodaq.utils.managers.overshoot.utils import ModulesManager, \
@@ -63,7 +63,7 @@ class Overshooter(ManagerBase):
 
     def __init__(self, dashboard: 'DashBoard'):
 
-        self._configurator = dashboard.configurator
+        self._state_manager = dashboard.state_manager
 
         super().__init__(dashboard=dashboard,
                          module_manager_class=ModulesManager)
@@ -80,8 +80,8 @@ class Overshooter(ManagerBase):
         self.experiment_manager.applied_entry.connect(self.do_things_after_experiment_set)
         if self.experiment_manager.entry_applied:
             self.do_things_after_experiment_set(self.experiment_manager.entry)
-        self.configurator.new_entry.connect(self.update_configurations)
-        self.configurator.deleted_entry.connect(self.update_configurations)
+        self.state_manager.new_entry.connect(self.update_configurations)
+        self.state_manager.deleted_entry.connect(self.update_configurations)
 
 
     def child_added(self, param: Parameter, data: tuple[Parameter, int]):
@@ -91,25 +91,25 @@ class Overshooter(ManagerBase):
 
     @property
     def experiment_manager(self) -> ExperimentManager:
-        return self.configurator.experiment_manager
+        return self.state_manager.experiment_manager
 
     @property
     def experiment_filename(self) -> str:
-        return self.configurator.experiment_filename
+        return self.state_manager.experiment_filename
 
     @experiment_filename.setter
     def experiment_filename(self, experiment_filename: str):
-        self.configurator.experiment_filename = experiment_filename
+        self.state_manager.experiment_filename = experiment_filename
         self.entries_sync.update_key('items', self.entries)
         self.update_entry()
 
     @property
-    def configurator(self) -> Configurator:
-        return self._configurator
+    def state_manager(self) -> StateManager:
+        return self._state_manager
 
     def apply_config_from_overshoot(self, overshoot: Overshoot):
-        self.configurator._execute_entry(
-            self.configurator.entry_path_from_name(self.settings['configuration']))
+        self.state_manager._execute_entry(
+            self.state_manager.entry_path_from_name(self.settings['configuration']))
         self._overshoot_under_process = False
 
     def show_hide_module_manager_settings(self):
@@ -249,13 +249,13 @@ class Overshooter(ManagerBase):
         self.add_action('update_data', 'Update Data', 'refresh')
 
         self.create_dashboard_toolbar(add_dashboard=__name__ == '__main__',
-                                      add_experiment=True, add_configurator=True, add_break=False)
+                                      add_experiment=True, add_state=True, add_break=False)
 
     def connect_things(self):
         self.connect_action('update_data', self.update_available_data)
 
     def update_configurations(self):
-        configurations = self.configurator.entries
+        configurations = self.state_manager.entries
         self.settings.child('configuration').setLimits(configurations)
 
     def update_available_data(self):

--- a/packages/pymodaq/src/pymodaq/utils/managers/overshoot/overshooter.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/overshoot/overshooter.py
@@ -58,6 +58,7 @@ class Overshooter(ManagerBase):
 
     entry_type = 'overshooter'
     entry_extension ='.xml'
+    icon_name = 'security'
 
     overshoot_signal = QtCore.Signal(Overshoot)
 

--- a/packages/pymodaq/src/pymodaq/utils/managers/overshoot/utils.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/overshoot/utils.py
@@ -9,7 +9,7 @@ from pymodaq_utils.config import GlobalConfig as Config, get_set_config_dir
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils import utils
 from pymodaq_gui.parameter.pymodaq_ptypes import registerParameterType, GroupParameter
-from pymodaq.utils.managers.configurator.configurator import Configurator
+from pymodaq.utils.managers.state.configurator import Configurator
 
 config = Config()
 logger = set_logger(get_module_name(__file__))

--- a/packages/pymodaq/src/pymodaq/utils/managers/overshoot/utils.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/overshoot/utils.py
@@ -9,7 +9,7 @@ from pymodaq_utils.config import GlobalConfig as Config, get_set_config_dir
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils import utils
 from pymodaq_gui.parameter.pymodaq_ptypes import registerParameterType, GroupParameter
-from pymodaq.utils.managers.state.configurator import Configurator
+from pymodaq.utils.managers.state.state_manager import StateManager
 
 config = Config()
 logger = set_logger(get_module_name(__file__))

--- a/packages/pymodaq/src/pymodaq/utils/managers/state/configurator.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/state/configurator.py
@@ -18,9 +18,9 @@ from pymodaq_gui.parameter.utils import ParameterWithPath
 
 from pymodaq_gui.parameter.ioxml import VALID_FOR_CONFIGURATION
 
-from pymodaq.utils.managers.configurator.subentries import (
+from pymodaq.utils.managers.state.subentries import (
     SubEntryHandlerFactory, SubEntryHandler, SubEntryError, SubEntryHandlerTypes, ConfiguratorSubEntry)
-from pymodaq.utils.managers.configurator.utils import (
+from pymodaq.utils.managers.state.utils import (
     ConfiguratorParameterTree, ConfiguratorModel, ConfiguratorTableView,
     get_module_from_param, config_subentries_from_path, ParameterDelegate,
     EntryActions, ModuleType)
@@ -49,7 +49,7 @@ class Configurator(ManagerBase):
 
     """
 
-    entry_type = 'configurator'
+    entry_type = 'state'
     entry_extension ='.config'
 
     def __init__(self,
@@ -72,7 +72,7 @@ class Configurator(ManagerBase):
     def show(self):
         """ Open the Configurator User Interface
 
-        If the Dashboard is not None and has a current experiment set, the configurator experiment name
+        If the Dashboard is not None and has a current experiment set, the state experiment name
         entry will be set as readonly and the settings are taken from the modules
         """
         if self.dashboard is not None:
@@ -154,7 +154,7 @@ class Configurator(ManagerBase):
 
     def populate_from_settings(self, settings: Parameter):
         """
-        Initialize the configurator from a Parameter settings.
+        Initialize the state from a Parameter settings.
 
         Parameters
         ----------
@@ -288,7 +288,7 @@ class Configurator(ManagerBase):
 
         else:
             self.experiment_manager.get_action(ManagerActions.LIST_EXTERNAL).widget.setEnabled(False)
-            self.experiment_manager.applied_entry.connect(self.set_experiment_filename)  #action slot from experiment menu need this to update the list onf configurator entries
+            self.experiment_manager.applied_entry.connect(self.set_experiment_filename)  #action slot from experiment menu need this to update the list onf state entries
 
         self.experiment_manager.entries_sync.value_changed.connect(lambda value: self.set_experiment_filename(value['current']))
     def _update_entry(self, entry: Path):

--- a/packages/pymodaq/src/pymodaq/utils/managers/state/state_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/state/state_manager.py
@@ -19,15 +19,15 @@ from pymodaq_gui.parameter.utils import ParameterWithPath
 from pymodaq_gui.parameter.ioxml import VALID_FOR_CONFIGURATION
 
 from pymodaq.utils.managers.state.subentries import (
-    SubEntryHandlerFactory, SubEntryHandler, SubEntryError, SubEntryHandlerTypes, ConfiguratorSubEntry)
+    SubEntryHandlerFactory, SubEntryHandler, SubEntryError, SubEntryHandlerTypes, StateSubEntry)
 from pymodaq.utils.managers.state.utils import (
-    ConfiguratorParameterTree, ConfiguratorModel, ConfiguratorTableView,
-    get_module_from_param, config_subentries_from_path, ParameterDelegate,
+    StateParameterTree, StateModel, StateTableView,
+    get_module_from_param, state_subentries_from_path, ParameterDelegate,
     EntryActions, ModuleType)
 
 
 
-from pymodaq.utils.config import get_set_configurator_path
+from pymodaq.utils.config import get_set_state_path
 from pymodaq_gui.managers.manager_base import ManagerBase, ManagerActions
 from pymodaq.extensions import ExtensionEnum
 
@@ -39,7 +39,7 @@ logger = set_logger(get_module_name(__file__))
 handler_factory = SubEntryHandlerFactory()
 
 
-class Configurator(ManagerBase):
+class StateManager(ManagerBase):
     """
     Main class managing the configuration of control modules from a Dashboard in terms
     of their settings and actuator's value.
@@ -50,19 +50,19 @@ class Configurator(ManagerBase):
     """
 
     entry_type = 'state'
-    entry_extension ='.config'
+    entry_extension ='.state'
 
     def __init__(self,
                  dashboard: 'DashBoard' = None):
 
         self.subentry_handler: SubEntryHandler = None
-        self.config_model = ConfiguratorModel()
+        self.config_model = StateModel()
         if dashboard is None:
             self._experiment_manager_local = ExperimentManager()
         else:
             self._experiment_manager_local = dashboard.experiment_manager
 
-        super().__init__(dashboard=dashboard, tree=ConfiguratorParameterTree())
+        super().__init__(dashboard=dashboard, tree=StateParameterTree())
 
 
     @property
@@ -70,7 +70,7 @@ class Configurator(ManagerBase):
         return self._experiment_manager_local
 
     def show(self):
-        """ Open the Configurator User Interface
+        """ Open the StateManager User Interface
 
         If the Dashboard is not None and has a current experiment set, the state experiment name
         entry will be set as readonly and the settings are taken from the modules
@@ -88,7 +88,7 @@ class Configurator(ManagerBase):
 
     def get_entry_folder(self, **kwargs_to_entry_folder) -> Path:
         """Get the folder path where the managed entries are stored."""
-        return get_set_configurator_path(self.experiment_filename)
+        return get_set_state_path(self.experiment_filename)
 
     def set_experiment_filename(self, name: str):
         """ convenience method to be used as slot in Qt connection"""
@@ -111,7 +111,7 @@ class Configurator(ManagerBase):
         self.config_model.save(entry_path)
 
     @staticmethod
-    def format_subentries(entries: list[ConfiguratorSubEntry]):
+    def format_subentries(entries: list[StateSubEntry]):
         return [(f'{entry.entry_type.capitalize()} for '
                  f'{entry.module_name} - '
                  f'{entry.setting.parameter.title()} '
@@ -127,7 +127,7 @@ class Configurator(ManagerBase):
         """
         if entry_path is None:
             entry_path = self.entry_filepath
-        config_subentries = config_subentries_from_path(entry_path)
+        config_subentries = state_subentries_from_path(entry_path)
 
         if self.experiment_manager.applied_entry_name != self.experiment_filename:
             logger.warning(f'The current configuration is referring to the prest: {self.experiment_filename} '
@@ -204,7 +204,7 @@ class Configurator(ManagerBase):
         self.tree.setDragDropMode(QtWidgets.QTableView.DragDropMode.DragOnly)
         self.tree.doubleClicked.connect(self.add_setting)
 
-        self.table_out = ConfiguratorTableView(True)
+        self.table_out = StateTableView(True)
         self.table_out.horizontalHeader().ResizeMode(QtWidgets.QHeaderView.ResizeToContents)
         self.table_out.horizontalHeader().setStretchLastSection(True)
         self.table_out.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
@@ -256,7 +256,7 @@ class Configurator(ManagerBase):
                             ' otherwise only configurables ones')
 
         self.create_dashboard_toolbar(add_dashboard=__name__ == '__main__',
-                                      add_experiment=True, add_configurator=False, add_break=False)
+                                      add_experiment=True, add_state=False, add_break=False)
         self.experiment_manager.enable_actions(True)
 
         self.add_action(EntryActions.ADD, 'Add', 'SP_ArrowRight', toolbar='move',
@@ -376,8 +376,8 @@ class Configurator(ManagerBase):
             except KeyError:
                 module = ModuleType.NONE.value
                 module_type = ModuleType.NONE
-            entry = ConfiguratorSubEntry(SubEntryHandlerTypes.SETTINGS, module,
-                                         module_type, ParameterWithPath(current_setting))
+            entry = StateSubEntry(SubEntryHandlerTypes.SETTINGS, module,
+                                  module_type, ParameterWithPath(current_setting))
             entries = self.config_model.split_entry(entry)
             for entry in entries:
                 self.config_model.add_data(self.config_model.rowCount(), entry)
@@ -422,12 +422,12 @@ if __name__ == "__main__":
     from pymodaq_gui.qt_utils import mkQApp
     from pymodaq.dashboard import DashBoard, create_load_dashboard
 
-    app = mkQApp('ConfiguratorManager')
+    app = mkQApp('StateManager')
 
     shared_ui, dashboard = create_load_dashboard()
     shared_ui.hide()
 
-    prog = Configurator(dashboard)
+    prog = StateManager(dashboard)
     prog.update_settings('default')
     prog.mainwindow.show()
     prog.enable_actions(True)

--- a/packages/pymodaq/src/pymodaq/utils/managers/state/state_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/state/state_manager.py
@@ -51,6 +51,7 @@ class StateManager(ManagerBase):
 
     entry_type = 'state'
     entry_extension ='.state'
+    icon_name = 'discover_tune'
 
     def __init__(self,
                  dashboard: 'DashBoard' = None):
@@ -221,39 +222,45 @@ class StateManager(ManagerBase):
         self.delegate = ParameterDelegate()
         self.table_out.setItemDelegate(self.delegate)
 
-        self.set_toolbar(self.add_toolbar('configurations'))
+
 
         vlayout = QtWidgets.QVBoxLayout()
         hwidget = QtWidgets.QWidget()
         hlayout = QtWidgets.QHBoxLayout()
         hwidget.setLayout(hlayout)
-        vlayout_right = QtWidgets.QVBoxLayout()
+        self.vlayout_right = QtWidgets.QVBoxLayout()
         valyout_left = QtWidgets.QVBoxLayout()
 
-        widget_buttons = QtWidgets.QWidget()
-        widget_buttons.setLayout(QtWidgets.QVBoxLayout())
-        widget_buttons.layout().addStretch()
-        move_toolbar = self.add_toolbar('move', 'Move')
-        move_toolbar.setOrientation(QtCore.Qt.Orientation.Vertical)
-        widget_buttons.layout().addWidget(move_toolbar)
-        widget_buttons.layout().addStretch()
+        self.widget_buttons = QtWidgets.QWidget()
+        self.widget_buttons.setLayout(QtWidgets.QVBoxLayout())
+        self.widget_buttons.layout().addStretch()
+
+        self.widget_buttons.layout().addStretch()
 
         vlayout.addWidget(hwidget)
         hlayout.addLayout(valyout_left)
-        hlayout.addWidget(widget_buttons)
-        hlayout.addLayout(vlayout_right)
+        hlayout.addWidget(self.widget_buttons)
+        hlayout.addLayout(self.vlayout_right)
 
         valyout_left.addWidget(self.settings_tree)
-        vlayout_right.addWidget(self.get_toolbar('configurations'))
-        vlayout_right.addWidget(self.table_out)
+        self.vlayout_right.addWidget(self.table_out)
 
         self.main_widget.setLayout(vlayout)
+
+    def setup_menus_and_toolbars(self, menubar: QtWidgets.QMenuBar = None):
+        move_toolbar = self.add_toolbar('move', 'Move')
+        move_toolbar.setOrientation(QtCore.Qt.Orientation.Vertical)
+        self.widget_buttons.layout().insertWidget(1, move_toolbar)
+
+        self.add_toolbar('actions', 'Actions', parent=self.mainwindow)
+        self.vlayout_right.insertWidget(0, self.toolbar)
 
     def setup_actions(self):
         self.add_action('show_all_settings', 'Show All Settings', 'EditFind',
                         checkable=True,
                         tip='If Checked: display all settings (in green, settings that can be configured)'
-                            ' otherwise only configurables ones')
+                            ' otherwise only configurables ones',
+                        toolbar='actions')
 
         self.create_dashboard_toolbar(add_dashboard=__name__ == '__main__',
                                       add_experiment=True, add_state=False, add_break=False)
@@ -272,7 +279,6 @@ class StateManager(ManagerBase):
                         tip='Move Down the current Configuration item ("Ctrl+Down")',
                         shortcut=QKeySequence(Qt.Modifier.CTRL | Qt.Key.Key_Down))
         self.toolbar.addSeparator()
-
 
     def connect_things(self):
         self.connect_action(EntryActions.ADD, self.add_setting)

--- a/packages/pymodaq/src/pymodaq/utils/managers/state/subentries.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/state/subentries.py
@@ -25,7 +25,7 @@ ser_factory = SerializableFactory()
 
 
 if TYPE_CHECKING:
-    from pymodaq.utils.managers.state.utils import ConfiguratorModel
+    from pymodaq.utils.managers.state.utils import StateModel
     from pymodaq.control_modules.daq_move import DAQ_Move
     from  pymodaq.control_modules.daq_viewer import DAQ_Viewer
     from pymodaq.dashboard import DashBoard
@@ -47,24 +47,24 @@ class SubEntryHandlerTypes(StrEnum):
 
 @SerializableFactory.register_decorator()
 @dataclass
-class ConfiguratorSubEntry:
+class StateSubEntry:
     entry_type: SubEntryHandlerTypes
     module_name: str
     module_type: ModuleType
     setting: ParameterWithPath
 
-    def __eq__(self, other: 'ConfiguratorSubEntry'):
+    def __eq__(self, other: 'StateSubEntry'):
         return (self.entry_type == other.entry_type and
                 self.module_name == other.module_name and
                 self.module_type == other.module_type and
                 self.setting == other.setting)
 
     def __repr__(self):
-        return f"ConfiguratorSubEntry({self.entry_type} for {self.module_type} module {self.module_name}:"\
+        return f"StateSubEntry({self.entry_type} for {self.module_type} module {self.module_name}:"\
                f" {self.setting.value()}"
 
     @staticmethod
-    def serialize(entry: 'ConfiguratorSubEntry') -> bytes:
+    def serialize(entry: 'StateSubEntry') -> bytes:
         """
 
         """
@@ -77,8 +77,8 @@ class ConfiguratorSubEntry:
 
     @classmethod
     def deserialize(cls,
-                    bytes_str: bytes) -> Union['ConfiguratorSubEntry',
-    Tuple['ConfiguratorSubEntry', bytes]]:
+                    bytes_str: bytes) -> Union['StateSubEntry',
+    Tuple['StateSubEntry', bytes]]:
         """Convert bytes into a ParameterWithPath object
 
         Returns
@@ -91,20 +91,20 @@ class ConfiguratorSubEntry:
         parameter_with_path, remaining_bytes = ser_factory.get_apply_deserializer(remaining_bytes, False)
         module_name, remaining_bytes = ser_factory.get_apply_deserializer(remaining_bytes, False)
         module_type, remaining_bytes = ser_factory.get_apply_deserializer(remaining_bytes, False)
-        return ConfiguratorSubEntry(entry_type,
-                                    module_name,
-                                    ModuleType(module_type),
-                                    parameter_with_path), remaining_bytes
+        return StateSubEntry(entry_type,
+                             module_name,
+                             ModuleType(module_type),
+                             parameter_with_path), remaining_bytes
 
 
 class SubEntryHandler(QtCore.QObject):
-    new_entry = QtCore.Signal(ConfiguratorSubEntry)
+    new_entry = QtCore.Signal(StateSubEntry)
 
     handler_name: SubEntryHandlerTypes = abstract_attribute()  # to reimplement in real dialogs
     use_dialog = True
 
     def __init__(self,
-                 model: 'ConfiguratorModel',
+                 model: 'StateModel',
                  settings: Parameter,
                  actuators: list[str] = None,
                  detectors: list[str] = None,
@@ -116,10 +116,10 @@ class SubEntryHandler(QtCore.QObject):
         self.actuators: list[str] = actuators if actuators is not None else []
         self.detectors: list[str] = detectors if detectors is not None else []
         self.extensions: list[str] = extensions if extensions is not None else []
-        self.model: ConfiguratorModel = model
+        self.model: StateModel = model
 
     @staticmethod
-    def get_module(entry: ConfiguratorSubEntry, dashboard: 'DashBoard'):
+    def get_module(entry: StateSubEntry, dashboard: 'DashBoard'):
         return dashboard.modules_manager.get_mod_from_name(entry.module_name, entry.module_type)
 
     def show_dialog(self):
@@ -159,13 +159,13 @@ class SubEntryHandler(QtCore.QObject):
         """
         pass
 
-    def get_subentry_from_dialog(self) -> ConfiguratorSubEntry:
-        """ Get a ConfiguratorEntry from the dialog
+    def get_subentry_from_dialog(self) -> StateSubEntry:
+        """ Get a StateSubEntry from the dialog
 
         To be reimplemented """
         raise NotImplementedError
 
-    def execute_subentry(self, entry: ConfiguratorSubEntry,
+    def execute_subentry(self, entry: StateSubEntry,
                          dashboard: 'DashBoard'):
         """ Execute the given subentry """
         raise NotImplementedError
@@ -219,7 +219,7 @@ class SettingsEntryHandler(SubEntryHandler):
     handler_name = SubEntryHandlerTypes.SETTINGS
     use_dialog = False
 
-    def execute_subentry(self, entry: ConfiguratorSubEntry,
+    def execute_subentry(self, entry: StateSubEntry,
                          dashboard: 'DashBoard'):
         """ Execute the given subentry """
         module = self.get_module(entry, dashboard)
@@ -252,8 +252,8 @@ class ActuatorValueSubEntryHandler(SubEntryHandler):
     def update_suffix_in_dialog(self, actuator_name: str):
         self.value_sb.setOpts(suffix=self.get_units_from_module_name(actuator_name))
 
-    def get_subentry_from_dialog(self) -> ConfiguratorSubEntry:
-        return ConfiguratorSubEntry(
+    def get_subentry_from_dialog(self) -> StateSubEntry:
+        return StateSubEntry(
             self.handler_name,
             self.actuator_cb.currentText(),
             module_type=ModuleType.Actuator,
@@ -266,7 +266,7 @@ class ActuatorValueSubEntryHandler(SubEntryHandler):
                     suffix=self.value_sb.opts['suffix']),
             path=()),)
 
-    def execute_subentry(self, entry: ConfiguratorSubEntry,
+    def execute_subentry(self, entry: StateSubEntry,
                          dashboard: 'DashBoard'):
         """ Execute the given subentry """
         module = self.get_module(entry, dashboard)
@@ -293,11 +293,11 @@ class InitSubEntryHandler(SubEntryHandler):
         self.widget.layout().addWidget(self.control_module_cb)
         self.widget.layout().addWidget(self.init_cb)
 
-    def get_subentry_from_dialog(self) -> ConfiguratorSubEntry:
+    def get_subentry_from_dialog(self) -> StateSubEntry:
 
         module_name = self.control_module_cb.currentText()
         module_type = ModuleType.Actuator if module_name in self.actuators else ModuleType.Detector
-        return ConfiguratorSubEntry(
+        return StateSubEntry(
             self.handler_name,
             module_name,
             module_type=module_type,
@@ -309,7 +309,7 @@ class InitSubEntryHandler(SubEntryHandler):
                                                          QtCore.Qt.CheckState.Checked else False,
                                                    )))
 
-    def execute_subentry(self, entry: ConfiguratorSubEntry,
+    def execute_subentry(self, entry: StateSubEntry,
                          dashboard: 'DashBoard'):
         """ Execute the given subentry """
         module = self.get_module(entry, dashboard)
@@ -339,9 +339,9 @@ class WaitSubEntryHandler(SubEntryHandler):
         self.widget.layout().addWidget(label)
         self.widget.layout().addWidget(self.wait_time_sb)
 
-    def get_subentry_from_dialog(self) -> ConfiguratorSubEntry:
+    def get_subentry_from_dialog(self) -> StateSubEntry:
 
-        return ConfiguratorSubEntry(
+        return StateSubEntry(
             self.handler_name,
             str(ModuleType.NONE),
             module_type=ModuleType.NONE,
@@ -354,7 +354,7 @@ class WaitSubEntryHandler(SubEntryHandler):
                                            siPrefix=True,
                                            )))
 
-    def execute_subentry(self, entry: ConfiguratorSubEntry,
+    def execute_subentry(self, entry: StateSubEntry,
                          dashboard: 'DashBoard'):
         """ Execute the given subentry """
         start = time.perf_counter()
@@ -377,8 +377,8 @@ class StopSubEntryHandler(SubEntryHandler):
         self.widget.layout().addWidget(self.module_cb)
         self.widget.layout().addWidget(self.stop_bool)
 
-    def get_subentry_from_dialog(self) -> ConfiguratorSubEntry:
-        return ConfiguratorSubEntry(
+    def get_subentry_from_dialog(self) -> StateSubEntry:
+        return StateSubEntry(
             self.handler_name,
             self.module_cb.currentText(),
             module_type=ModuleType.Actuator if self.module_cb.currentText() in self.actuators else ModuleType.Detector,
@@ -390,7 +390,7 @@ class StopSubEntryHandler(SubEntryHandler):
                     value=self.stop_bool.checkState() == QtCore.Qt.CheckState.Checked,),
             path=()),)
 
-    def execute_subentry(self, entry: ConfiguratorSubEntry,
+    def execute_subentry(self, entry: StateSubEntry,
                          dashboard: 'DashBoard'):
         """ Execute the given subentry """
         module = self.get_module(entry, dashboard)
@@ -413,8 +413,8 @@ class StopAllSubEntryHandler(SubEntryHandler):
         self.widget.layout().addWidget(label)
         self.widget.layout().addWidget(self.stop_bool)
 
-    def get_subentry_from_dialog(self) -> ConfiguratorSubEntry:
-        return ConfiguratorSubEntry(
+    def get_subentry_from_dialog(self) -> StateSubEntry:
+        return StateSubEntry(
             self.handler_name,
             ModuleType.NONE.value,
             module_type=ModuleType.Control,
@@ -426,7 +426,7 @@ class StopAllSubEntryHandler(SubEntryHandler):
                     value=self.stop_bool.checkState() == QtCore.Qt.CheckState.Checked,),
             path=()),)
 
-    def execute_subentry(self, entry: ConfiguratorSubEntry,
+    def execute_subentry(self, entry: StateSubEntry,
                          dashboard: 'DashBoard'):
         """ Execute the given subentry """
         try:
@@ -452,8 +452,8 @@ class StopExtensionSubEntryHandler(SubEntryHandler):
         self.widget.layout().addWidget(self.extension_cb)
         self.widget.layout().addWidget(self.stop_bool)
 
-    def get_subentry_from_dialog(self) -> ConfiguratorSubEntry:
-        return ConfiguratorSubEntry(
+    def get_subentry_from_dialog(self) -> StateSubEntry:
+        return StateSubEntry(
             self.handler_name,
             self.extension_cb.currentText(),
             module_type=ModuleType.Extension,
@@ -465,7 +465,7 @@ class StopExtensionSubEntryHandler(SubEntryHandler):
                     value=self.stop_bool.checkState() == QtCore.Qt.CheckState.Checked,),
             path=()),)
 
-    def execute_subentry(self, entry: ConfiguratorSubEntry,
+    def execute_subentry(self, entry: StateSubEntry,
                          dashboard: 'DashBoard'):
         """ Execute the given subentry """
         try:
@@ -480,7 +480,7 @@ if __name__ == '__main__':
     from pymodaq_gui.qt_utils import mkQApp
 
     class MockModel:
-        def add_data(self, index, data: ConfiguratorSubEntry):
+        def add_data(self, index, data: StateSubEntry):
             print(data)
 
         def rowCount(self):

--- a/packages/pymodaq/src/pymodaq/utils/managers/state/subentries.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/state/subentries.py
@@ -25,7 +25,7 @@ ser_factory = SerializableFactory()
 
 
 if TYPE_CHECKING:
-    from pymodaq.utils.managers.configurator.utils import ConfiguratorModel
+    from pymodaq.utils.managers.state.utils import ConfiguratorModel
     from pymodaq.control_modules.daq_move import DAQ_Move
     from  pymodaq.control_modules.daq_viewer import DAQ_Viewer
     from pymodaq.dashboard import DashBoard

--- a/packages/pymodaq/src/pymodaq/utils/managers/state/utils.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/state/utils.py
@@ -5,7 +5,7 @@ from qtpy import QtWidgets, QtCore
 
 from qtpy.QtCore import QMimeData, Qt, QModelIndex
 from qtpy.QtWidgets import QDialogButtonBox, QDialog
-from pymodaq.utils.managers.configurator.subentries import SubEntryHandlerFactory, SubEntryHandlerTypes, \
+from pymodaq.utils.managers.state.subentries import SubEntryHandlerFactory, SubEntryHandlerTypes, \
     ConfiguratorSubEntry
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.enums import StrEnum

--- a/packages/pymodaq/src/pymodaq/utils/managers/state/utils.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/state/utils.py
@@ -6,7 +6,7 @@ from qtpy import QtWidgets, QtCore
 from qtpy.QtCore import QMimeData, Qt, QModelIndex
 from qtpy.QtWidgets import QDialogButtonBox, QDialog
 from pymodaq.utils.managers.state.subentries import SubEntryHandlerFactory, SubEntryHandlerTypes, \
-    ConfiguratorSubEntry
+    StateSubEntry
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.enums import StrEnum
 from pymodaq_utils.array_manipulation import are_elements_contiguous
@@ -22,7 +22,7 @@ from pymodaq_gui import utils as gutils
 
 from serializall import SerializableFactory
 
-from pymodaq.utils.config import get_set_configurator_path
+from pymodaq.utils.config import get_set_state_path
 from pymodaq.utils.managers.modules import ModuleType
 import copy
 
@@ -147,7 +147,7 @@ def get_module_from_param(param: ParameterWithPath) -> Union[tuple[str, ModuleTy
     return module, module_type
 
 
-def config_subentries_from_path(fname: Path) -> list[ConfiguratorSubEntry]:
+def state_subentries_from_path(fname: Path) -> list[StateSubEntry]:
     if not fname.exists():
         return []
     with open(fname, 'rb') as file:
@@ -157,30 +157,30 @@ def config_subentries_from_path(fname: Path) -> list[ConfiguratorSubEntry]:
         all_lines += line
     data = []
     while len(all_lines) > 0:
-        entry, all_lines = ConfiguratorSubEntry.deserialize(all_lines)
+        entry, all_lines = StateSubEntry.deserialize(all_lines)
         data.append(entry)
     return data
 
 
 mock_list = ['elt1', 'elt2', 'elt3']
-mock_entry = ConfiguratorSubEntry('settings',
+mock_entry = StateSubEntry('settings',
                                'Photodiode',
-                                  ModuleType.Detector,
-                                  ParameterWithPath(
+                           ModuleType.Detector,
+                           ParameterWithPath(
                                    parameter=Parameter.create(title='mytitle', name='myname',
                                                               type='list', value=mock_list[0],
                                                               limits=mock_list)))
 
 
 
-class ConfiguratorModel(TableModel):
+class StateModel(TableModel):
 
     update_delegate = QtCore.Signal()
 
-    def __init__(self, data: list[ConfiguratorSubEntry]=None,
+    def __init__(self, data: list[StateSubEntry]=None,
                  header=('Type', 'Module', 'Title', 'Value'),
                  ):
-        self._data: list[ConfiguratorSubEntry] = None
+        self._data: list[StateSubEntry] = None
         if data is None:
             data = []
         super().__init__(data, header, editable=[False, False, False, True])
@@ -192,7 +192,7 @@ class ConfiguratorModel(TableModel):
     def mimeTypes(self):
         types = super().mimeTypes()
         types.append('pymodaq/parameter_with_path')
-        types.append('pymodaq/configurator_entry')
+        types.append('pymodaq/state_entry')
         return types
 
     def mimeData(self, items):
@@ -200,13 +200,13 @@ class ConfiguratorModel(TableModel):
         rows = list(set([item.row() for item in items]))
         if are_elements_contiguous(rows):
             entries = [self._data[raw] for raw in rows]
-            data.setData('pymodaq/configurator_entry', ser_factory.get_apply_serializer(entries))
+            data.setData('pymodaq/state_entry', ser_factory.get_apply_serializer(entries))
         return data
 
     def data(self, index: QModelIndex, role: Qt.ItemDataRole):
         if index.isValid():
             if role == Qt.ItemDataRole.DisplayRole or role == Qt.ItemDataRole.EditRole:
-                entry: ConfiguratorSubEntry = self._data[index.row()]
+                entry: StateSubEntry = self._data[index.row()]
                 if index.column() == 0:
                     dat = entry.entry_type.capitalize()
                 elif index.column() == 1:
@@ -224,7 +224,7 @@ class ConfiguratorModel(TableModel):
                 else:
                     return Qt.CheckState.Unchecked
             elif role == Qt.ItemDataRole.ToolTipRole:
-                entry: ConfiguratorSubEntry = self._data[index.row()]
+                entry: StateSubEntry = self._data[index.row()]
                 return repr(entry)
         return QVariant()
 
@@ -232,10 +232,10 @@ class ConfiguratorModel(TableModel):
     def dropMimeData(self, data: QMimeData, action: Qt.DropAction, row: int, column: int, parent: QModelIndex):
         if row == -1:
             row = self.rowCount(parent)
-        if data.hasFormat('pymodaq/configurator_entry'):
-            entries: list[ConfiguratorSubEntry] = (
+        if data.hasFormat('pymodaq/state_entry'):
+            entries: list[StateSubEntry] = (
                 ser_factory.get_apply_deserializer(
-                    data.data('pymodaq/configurator_entry').data()))
+                    data.data('pymodaq/state_entry').data()))
         else:
             entries = [mock_entry]
 
@@ -274,9 +274,9 @@ class ConfiguratorModel(TableModel):
                 return True
         return False
 
-    def split_entry(self, entry: ConfiguratorSubEntry,
-                    entries: list[ConfiguratorSubEntry] = None) -> list[ConfiguratorSubEntry]:
-        """ Split A ConfiguratorEntry into multiple entries if its underlying parameter has children"""
+    def split_entry(self, entry: StateSubEntry,
+                    entries: list[StateSubEntry] = None) -> list[StateSubEntry]:
+        """ Split A StateEntry into multiple entries if its underlying parameter has children"""
         if entries is None:
             entries = []
         if not entry.setting.parameter.hasChildren():
@@ -286,7 +286,7 @@ class ConfiguratorModel(TableModel):
             for child in entry.setting.parameter.children():
                 if child.opts.get(VALID_FOR_CONFIGURATION, True) :  # only add the ones specifying they are configurable
                     pwp = ParameterWithPath(parameter=child, path=entry.setting.path + [child.name()])
-                    config_entry = ConfiguratorSubEntry(entry.entry_type, entry.module_name, entry.module_type, pwp)
+                    config_entry = StateSubEntry(entry.entry_type, entry.module_name, entry.module_type, pwp)
                     self.split_entry(config_entry, entries)
         return entries
 
@@ -335,7 +335,7 @@ class ConfiguratorModel(TableModel):
         vlayout.addWidget(QtWidgets.QLabel(
             f'Setting from module {entry.module_name} with path:\n {entry.setting.path[module_index+2:]}'))
         setting = Parameter.create(name='settings', type='group', children=[entry.setting.parameter.saveState()])
-        tree = ConfiguratorParameterTree(parent=dialog)
+        tree = StateParameterTree(parent=dialog)
         tree.setParameters(setting, showTop=False)
         buttonBox = QDialogButtonBox(parent=dialog)
         buttonBox.addButton("Done", QDialogButtonBox.ButtonRole.AcceptRole)
@@ -351,7 +351,7 @@ class ConfiguratorModel(TableModel):
         if res:
             entry.setting.parameter.setValue(setting.children()[0].value())
 
-    def add_data(self, row, data: ConfiguratorSubEntry):
+    def add_data(self, row, data: StateSubEntry):
         if data is not None:
             if data in self._data:
                 return
@@ -364,11 +364,11 @@ class ConfiguratorModel(TableModel):
 
     def load(self, fname: Union[str, Path] = None):
         if fname is None:
-            fname = gutils.select_file(start_path=get_set_configurator_path(), save=False, ext='*')
+            fname = gutils.select_file(start_path=get_set_state_path(), save=False, ext='*')
         if fname is not None and fname != '':
             while self.rowCount(self.index(-1, -1)) > 0:
                 self.remove_row(0)
-            data = config_subentries_from_path(Path(fname))
+            data = state_subentries_from_path(Path(fname))
 
             for row in data:
                 self.insert_data(self.rowCount(self.index(-1, -1)), row)
@@ -376,13 +376,13 @@ class ConfiguratorModel(TableModel):
 
     def save(self, fname: str = None):
         if fname is None:
-            fname = gutils.select_file(start_path=get_set_configurator_path(), save=True, ext='config',
+            fname = gutils.select_file(start_path=get_set_state_path(), save=True, ext='config',
                                        force_save_extension=True)
         with open(fname, 'wb') as file:
-            file.writelines([ConfiguratorSubEntry.serialize(entry) for entry in self._data])
+            file.writelines([StateSubEntry.serialize(entry) for entry in self._data])
 
 
-class ConfiguratorTableView(QtWidgets.QTableView):
+class StateTableView(QtWidgets.QTableView):
     """
     """
 
@@ -416,8 +416,8 @@ class ConfiguratorTableView(QtWidgets.QTableView):
             self.menu.addAction('Remove selected row', self.remove)
             self.menu.addAction('Clear all', self.clear)
             self.menu.addSeparator()
-            self.menu.addAction('Load Configurator file', lambda: self.load_data_signal.emit())
-            self.menu.addAction('Save Configurator file', lambda: self.save_data_signal.emit())
+            self.menu.addAction('Load StateManager file', lambda: self.load_data_signal.emit())
+            self.menu.addAction('Save StateManager file', lambda: self.save_data_signal.emit())
         else:
             self.menu = None
 
@@ -462,14 +462,14 @@ class ConfiguratorTableView(QtWidgets.QTableView):
 
 
 
-class ConfiguratorParameterTree(ParameterTree):
+class StateParameterTree(ParameterTree):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def mimeTypes(self):
         types = super().mimeTypes()
         types.append('pymodaq/parameter_with_path')
-        types.append('pymodaq/configurator_entry')
+        types.append('pymodaq/state_entry')
         return types
 
     def mimeData(self, items):
@@ -481,8 +481,8 @@ class ConfiguratorParameterTree(ParameterTree):
             module = ModuleType.NONE.value
             module_type = ModuleType.NONE
         if module is not None:
-            entry = ConfiguratorSubEntry(SubEntryHandlerTypes.SETTINGS,
-                                         module, module_type, param_with_path)
-            data.setData('pymodaq/configurator_entry',
+            entry = StateSubEntry(SubEntryHandlerTypes.SETTINGS,
+                                  module, module_type, param_with_path)
+            data.setData('pymodaq/state_entry',
                          ser_factory.get_apply_serializer([entry]))
         return data

--- a/packages/pymodaq/tests/utils/managers/configurator_manager_test.py
+++ b/packages/pymodaq/tests/utils/managers/configurator_manager_test.py
@@ -7,8 +7,8 @@ Created the 07/11/2023
 import pytest
 from pathlib import Path
 from qtpy import QtWidgets
-from pymodaq.utils.managers.configurator.configurator import Configurator
-from pymodaq.utils.managers.configurator.subentries import (
+from pymodaq.utils.managers.state.configurator import Configurator
+from pymodaq.utils.managers.state.subentries import (
     SubEntryHandlerFactory, SubEntryHandlerTypes)
 
 
@@ -48,7 +48,7 @@ class TestConfigurator:
         """
         configurator, qtbot = ini_configurator
 
-        assert configurator.entry_type == 'configurator'
+        assert configurator.entry_type == 'state'
         assert configurator.entry_extension == '.config'
 
 

--- a/packages/pymodaq/tests/utils/managers/configurator_manager_test.py
+++ b/packages/pymodaq/tests/utils/managers/configurator_manager_test.py
@@ -7,7 +7,7 @@ Created the 07/11/2023
 import pytest
 from pathlib import Path
 from qtpy import QtWidgets
-from pymodaq.utils.managers.state.configurator import Configurator
+from pymodaq.utils.managers.state.state_manager import StateManager
 from pymodaq.utils.managers.state.subentries import (
     SubEntryHandlerFactory, SubEntryHandlerTypes)
 
@@ -21,35 +21,35 @@ def init_qt(qtbot):
 
 
 @pytest.fixture
-def ini_configurator(init_qt):
+def ini_state_manager(init_qt):
 
     qtbot = init_qt
 
     external_ui = QtWidgets.QMainWindow()
 
-    configurator = Configurator()
-    configurator.settings = Path(__file__).parent.joinpath('settings.xml')
+    state_manager = StateManager()
+    state_manager.settings = Path(__file__).parent.joinpath('settings.xml')
 
-    configurator.update_entry()
-    qtbot.addWidget(configurator.mainwindow)
-    configurator.mainwindow.show()
+    state_manager.update_entry()
+    qtbot.addWidget(state_manager.mainwindow)
+    state_manager.mainwindow.show()
     qtbot.addWidget(external_ui)
 
-    yield configurator, qtbot
+    yield state_manager, qtbot
 
-    configurator.mainwindow.close()
+    state_manager.mainwindow.close()
     external_ui.close()
 
 
-class TestConfigurator:
+class TestStateManager:
 
-    def test_ini(self, ini_configurator):
+    def test_ini(self, ini_state_manager):
         """
         """
-        configurator, qtbot = ini_configurator
+        state_manager, qtbot = ini_state_manager
 
-        assert configurator.entry_type == 'state'
-        assert configurator.entry_extension == '.config'
+        assert state_manager.entry_type == 'state'
+        assert state_manager.entry_extension == '.config'
 
 
 class TestSpecialEntryFactory:

--- a/packages/pymodaq/tests/utils/managers/state_manager_test.py
+++ b/packages/pymodaq/tests/utils/managers/state_manager_test.py
@@ -49,7 +49,7 @@ class TestStateManager:
         state_manager, qtbot = ini_state_manager
 
         assert state_manager.entry_type == 'state'
-        assert state_manager.entry_extension == '.config'
+        assert state_manager.entry_extension == '.state'
 
 
 class TestSpecialEntryFactory:

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
@@ -255,8 +255,8 @@ def addwidget(klass: Union[str, QtWidgets.QWidget, object], *args, tip='',
     if toolbar is not None:
 
         action: QtWidgets.QAction = toolbar.addWidget(widget)
-        action.setVisible(visible)
-        action.setToolTip(tip)
+        widget.setVisible(visible)
+        widget.setToolTip(tip)
         widget = WidgetActionProxy(widget, action)
     else:
         widget.setVisible(visible)

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
@@ -99,6 +99,9 @@ class WidgetActionProxy(QtWidgets.QWidget):
         self._widget.setVisible(visible)
         super().setVisible(visible)
 
+    def isVisible(self) -> bool:
+        return self.widget.isVisible()
+
     @property
     def widget(self) -> QtWidgets.QWidget:
         return self._widget
@@ -255,7 +258,7 @@ def addwidget(klass: Union[str, QtWidgets.QWidget, object], *args, tip='',
     if toolbar is not None:
 
         action: QtWidgets.QAction = toolbar.addWidget(widget)
-        widget.setVisible(visible)
+        action.setVisible(visible)
         widget.setToolTip(tip)
         widget = WidgetActionProxy(widget, action)
     else:

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -313,7 +313,7 @@ class ManagerBase(CustomExt):
         self.affect_to(ManagerActions.OPEN, menu)
 
         self.add_widget(ManagerActions.LIST_EXTERNAL, ComboBox(), toolbar=toolbar,
-                        tip=f'Name of the current {self.entry_type}',)
+                        tip=f'List of possible {self.entry_type}s',)
         self.sync_entries_with(self.get_action(ManagerActions.LIST_EXTERNAL).widget)
         self.affect_to(ManagerActions.EXECUTE, toolbar)
         return toolbar, menu

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -109,6 +109,7 @@ class ManagerBase(CustomExt):
     entry_extension: str
 
     execute_action_checkable = False
+    icon_name = 'build_circle'  # the default icon to represent the manager in Toolbar and Menus
 
     def __init__(self,
                  dashboard: 'DashBoard' = None,
@@ -250,14 +251,11 @@ class ManagerBase(CustomExt):
         """ Get an action name given a file and the manager name"""
         return f"{file.stem}_{self.manager_name}"
 
-    def setup_menus_and_toolbars(self, menubar: QtWidgets.QMenuBar = None):
-        self.add_toolbar(self.manager_name.lower(), self.manager_name, self.mainwindow, add_break=False)
-
     def setup_actions_base(self):
 
         # ACTIONS in Manager
-        self.add_widget('entry_label', QtWidgets.QLabel(
-            f'{self.entry_type.capitalize()}:'))
+        # self.add_widget('entry_label', QtWidgets.QLabel(
+        #     f'{self.entry_type.capitalize()}:'))
         self.add_widget(ManagerActions.LIST, ComboBox(),
                         tip=f'Name of the current {self.entry_type}',
                         kwargs={'setReadOnly': True})
@@ -293,7 +291,7 @@ class ManagerBase(CustomExt):
                         tip=f'Execute the current {self.entry_type} file ("Ctrl+Shift+E")',
                         shortcut=QKeySequence(Qt.Modifier.CTRL | Qt.Modifier.SHIFT | Qt.Key.Key_E))
         self.add_action(ManagerActions.OPEN, f"{self.entry_type.capitalize()} Manager",
-                        "build_circle",
+                        self.icon_name,
                         icon_color=self.get_theme().blue,
                         tip=f'Open the {self.entry_type.capitalize()} Manager',
                         checkable=True,
@@ -309,12 +307,13 @@ class ManagerBase(CustomExt):
         if menu is None:
             menu = QtWidgets.QMenu(f'{self.entry_type.capitalize()}')
 
-        self.add_widget(ManagerActions.LABEL_EXTERNAL, QtWidgets.QLabel(f'{self.entry_type.capitalize()}:'),
-                        toolbar=toolbar,)
+        # self.add_widget(ManagerActions.LABEL_EXTERNAL, QtWidgets.QLabel(f'{self.entry_type.capitalize()}:'),
+        #                 toolbar=toolbar,)
         self.affect_to(ManagerActions.OPEN, toolbar)
         self.affect_to(ManagerActions.OPEN, menu)
 
-        self.add_widget(ManagerActions.LIST_EXTERNAL, ComboBox(), toolbar=toolbar)
+        self.add_widget(ManagerActions.LIST_EXTERNAL, ComboBox(), toolbar=toolbar,
+                        tip=f'Name of the current {self.entry_type}',)
         self.sync_entries_with(self.get_action(ManagerActions.LIST_EXTERNAL).widget)
         self.affect_to(ManagerActions.EXECUTE, toolbar)
         return toolbar, menu


### PR DESCRIPTION
I renamed in this PR the Configurator to StateManager as it is managing state of the experiment setup. Configurator was a bit misleading wrt the preferences/configurations

Also removed the QLabel associated with the Managers and make them obvious by using a dedicated icon to open/describe  them:

<img width="752" height="182" alt="image" src="https://github.com/user-attachments/assets/f29882c0-0b3d-4aac-969c-d5077bb2d499" />


However, I'm not sur the one I picked for the StateManager is the best... @runrunm any suggestions?