### PR TITLE
Updating python versioning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,11 +31,15 @@ Requirements
 --------
 
 Pymodaq aims at following `SPEC0`_.
+.. _SPEC0 :https://scientific-python.org/specs/spec-0000/
+
+
 In practice, that means we will only test python versions still considered `alive`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it. 
 For now, this reflects into support in: Python 3.10+ - 3.13
-We usually recommend to use the python distribution that left or will soon leave bugfix status: python 3.12-3.13
-.. _SPEC0 :https://scientific-python.org/specs/spec-0000/
 .. _alive:https://devguide.python.org/versions/
+
+
+We usually recommend to use the python distribution that left or will soon leave bugfix status: python 3.12-3.13
 
 Published under the MIT FREE SOFTWARE LICENSE
 

--- a/README.rst
+++ b/README.rst
@@ -31,12 +31,12 @@ Requirements
 --------
 
 Pymodaq aims at following `SPEC0`_.
-.. _SPEC0 :https://scientific-python.org/specs/spec-0000/
+.. _SPEC0: https://scientific-python.org/specs/spec-0000/
 
 
 In practice, that means we will only test python versions still considered `alive`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it. 
 For now, this reflects into support in: Python 3.10+ - 3.13
-.. _alive:https://devguide.python.org/versions/
+.. _alive: https://devguide.python.org/versions/
 
 
 We usually recommend to use the python distribution that left or will soon leave bugfix status: python 3.12-3.13

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Each package directory can be navigated to for more detailed information about i
 Requirements
 --------
 
-Pymodaq aims at following `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_.
+PyMoDAQ aims at following `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_.
 
 In practice, that means we will only test python versions still considered `alive <https://devguide.python.org/versions/>`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it.
 For now, this reflects into testing support for Python 3.10 - 3.13

--- a/README.rst
+++ b/README.rst
@@ -30,13 +30,10 @@ Each package directory can be navigated to for more detailed information about i
 Requirements
 --------
 
-Pymodaq aims at following `SPEC0`_.
-.. _SPEC0: https://scientific-python.org/specs/spec-0000/
+Pymodaq aims at following `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_.
 
-
-In practice, that means we will only test python versions still considered `alive`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it. 
+In practice, that means we will only test python versions still considered `alive <https://devguide.python.org/versions/>`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it.
 For now, this reflects into support in: Python 3.10+ - 3.13
-.. _alive: https://devguide.python.org/versions/
 
 
 We usually recommend to use the python distribution that left or will soon leave bugfix status: python 3.12-3.13

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,15 @@ Packages
 
 Each package directory can be navigated to for more detailed information about its goal. A link to the official documentation is also provided at the end of each README.
 
+Requirements
+--------
 
+Pymodaq aims at following `SPEC0`_.
+In practice, that means we will only test python versions still considered `alive`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it. 
+For now, this reflects into support in: Python 3.10+ - 3.13
+We usually recommend to use the python distribution that left or will soon leave bugfix status: python 3.12-3.13
+.. _SPEC0 :https://scientific-python.org/specs/spec-0000/
+.. _alive:https://devguide.python.org/versions/
 
 Published under the MIT FREE SOFTWARE LICENSE
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Requirements
 Pymodaq aims at following `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_.
 
 In practice, that means we will only test python versions still considered `alive <https://devguide.python.org/versions/>`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it.
-For now, this reflects into support in: Python 3.10+ - 3.13
+For now, this reflects into testing support for Python 3.10 - 3.13
 
 
 We usually recommend to use the python distribution that left or will soon leave bugfix status: python 3.12-3.13

--- a/README.rst.tpl
+++ b/README.rst.tpl
@@ -26,11 +26,15 @@ Requirements
 --------
 
 Pymodaq aims at following `SPEC0`_.
+.. _SPEC0: https://scientific-python.org/specs/spec-0000/
+
+
 In practice, that means we will only test python versions still considered `alive`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it. 
 For now, this reflects into support in: Python 3.10+ - 3.13
+.. _alive: https://devguide.python.org/versions/
+
+
 We usually recommend to use the python distribution that left or will soon leave bugfix status: python 3.12-3.13
-.. _SPEC0 :https://scientific-python.org/specs/spec-0000/
-.. _alive:https://devguide.python.org/versions/
 
 Published under the MIT FREE SOFTWARE LICENSE
 

--- a/README.rst.tpl
+++ b/README.rst.tpl
@@ -25,7 +25,7 @@ Each package directory can be navigated to for more detailed information about i
 Requirements
 --------
 
-Pymodaq aims at following `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_.
+PyMoDAQ aims at following `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_.
 
 In practice, that means we will only test python versions still considered `alive <https://devguide.python.org/versions/>`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it.
 For now, this reflects into testing support for Python 3.10 - 3.13

--- a/README.rst.tpl
+++ b/README.rst.tpl
@@ -25,9 +25,7 @@ Each package directory can be navigated to for more detailed information about i
 Requirements
 --------
 
-PyMoDAQ aims at following `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_.
-
-In practice, that means we will only test python versions still considered `alive <https://devguide.python.org/versions/>`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it.
+PyMoDAQ supports Python versions that are still considered `alive <https://devguide.python.org/versions/>`_ (not end-of-life per the Python devguide) and have been released for at least a year. Other python versions may still work but we cannot guarantee it.
 For now, this reflects into testing support for Python 3.10 - 3.13
 
 

--- a/README.rst.tpl
+++ b/README.rst.tpl
@@ -22,6 +22,11 @@ Packages
 Each package directory can be navigated to for more detailed information about its goal. A link to the official documentation is also provided at the end of each README.
 
 
+Requirements:
+Pymodaq aims at following _SPEC 0:https://scientific-python.org/specs/spec-0000/
+In practice, that means we will only test python versions still considered _alive:https://devguide.python.org/versions/ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it. 
+For now, this reflects into support in: Python 3.10+ - 3.13
+We usually recommend to use the python distribution that left or will soon leave bugfix status: python 3.12-3.13
 
 Published under the MIT FREE SOFTWARE LICENSE
 

--- a/README.rst.tpl
+++ b/README.rst.tpl
@@ -25,13 +25,10 @@ Each package directory can be navigated to for more detailed information about i
 Requirements
 --------
 
-Pymodaq aims at following `SPEC0`_.
-.. _SPEC0: https://scientific-python.org/specs/spec-0000/
+Pymodaq aims at following `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_.
 
-
-In practice, that means we will only test python versions still considered `alive`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it. 
+In practice, that means we will only test python versions still considered `alive <https://devguide.python.org/versions/>`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it.
 For now, this reflects into support in: Python 3.10+ - 3.13
-.. _alive: https://devguide.python.org/versions/
 
 
 We usually recommend to use the python distribution that left or will soon leave bugfix status: python 3.12-3.13

--- a/README.rst.tpl
+++ b/README.rst.tpl
@@ -25,10 +25,12 @@ Each package directory can be navigated to for more detailed information about i
 Requirements
 --------
 
-Pymodaq aims at following _SPEC 0:https://scientific-python.org/specs/spec-0000/
-In practice, that means we will only test python versions still considered _alive:https://devguide.python.org/versions/ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it. 
+Pymodaq aims at following `SPEC0`_.
+In practice, that means we will only test python versions still considered `alive`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it. 
 For now, this reflects into support in: Python 3.10+ - 3.13
 We usually recommend to use the python distribution that left or will soon leave bugfix status: python 3.12-3.13
+.. _SPEC0 :https://scientific-python.org/specs/spec-0000/
+.. _alive:https://devguide.python.org/versions/
 
 Published under the MIT FREE SOFTWARE LICENSE
 

--- a/README.rst.tpl
+++ b/README.rst.tpl
@@ -22,7 +22,9 @@ Packages
 Each package directory can be navigated to for more detailed information about its goal. A link to the official documentation is also provided at the end of each README.
 
 
-Requirements:
+Requirements
+--------
+
 Pymodaq aims at following _SPEC 0:https://scientific-python.org/specs/spec-0000/
 In practice, that means we will only test python versions still considered _alive:https://devguide.python.org/versions/ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it. 
 For now, this reflects into support in: Python 3.10+ - 3.13

--- a/README.rst.tpl
+++ b/README.rst.tpl
@@ -28,7 +28,7 @@ Requirements
 Pymodaq aims at following `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_.
 
 In practice, that means we will only test python versions still considered `alive <https://devguide.python.org/versions/>`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it.
-For now, this reflects into support in: Python 3.10+ - 3.13
+For now, this reflects into testing support for Python 3.10 - 3.13
 
 
 We usually recommend to use the python distribution that left or will soon leave bugfix status: python 3.12-3.13

--- a/packages/pymodaq/pyproject.toml
+++ b/packages/pymodaq/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = [
 description = "Modular Data Acquisition with Python"
 readme = "README.rst"
 license = { file="LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     { name = "Sébastien Weber", email = "sebastien.weber@cemes.fr" },
 ]
@@ -21,10 +21,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",    
     "Topic :: Scientific/Engineering :: Human Machine Interfaces",
     "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -38,7 +38,7 @@ dependencies = [
     "pymodaq_plugins_mock>=5.0.12",
     "simple_pid",
     "qtconsole",
-    "pyleco>0.3; python_version>=\"3.8\"",
+    "pyleco>0.3; python_version>=\"3.10\"",
     "bayesian-optimization>=2.0",
     "adaptive",
 ]

--- a/packages/pymodaq_data/pyproject.toml
+++ b/packages/pymodaq_data/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = [
 description = "Modular Data Acquisition with Python"
 readme = "README.rst"
 license = { file="LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     { name = "Sébastien Weber", email = "sebastien.weber@cemes.fr" },
 ]
@@ -21,10 +21,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",    
     "Topic :: Scientific/Engineering :: Human Machine Interfaces",
     "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/packages/pymodaq_gui/pyproject.toml
+++ b/packages/pymodaq_gui/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = [
 description = "User Interface components for PyMoDAQ"
 readme = "README.rst"
 license = { file="LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     { name = "Sébastien Weber", email = "sebastien.weber@cemes.fr" },
 ]
@@ -22,10 +22,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",    
     "Topic :: Scientific/Engineering :: Human Machine Interfaces",
     "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/packages/pymodaq_utils/pyproject.toml
+++ b/packages/pymodaq_utils/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = [
 description = "Modular Data Acquisition with Python"
 readme = "README.rst"
 license = { file="LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     { name = "Sébastien Weber", email = "sebastien.weber@cemes.fr" },
 ]
@@ -21,10 +21,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",    
     "Topic :: Scientific/Engineering :: Human Machine Interfaces",
     "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
Adressing  #1010
- Changing python base version to 3.10 and extending it to 3.13. This now matches also the github workflows' tests.
