### PR TITLE
Hotfix/config+backend

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/__init__.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/__init__.py
@@ -15,11 +15,13 @@ def set_and_check_qt_backend_or_die(config):
     if not backend_found:
         #trying in the remaining backends and taking the first one
         logger.warning(f"{backend} is not available. Trying to find another backend.")
-        other_backends = [backend for backend in available_backends if backend != wanted_backend]
-        if len(other_backends) > 0:
+        other_available = [b for b in available_backends if b != wanted_backend]
+        if len(other_available) > 0:
             backend_found = True
-            backend =  other_backends.pop(0)
-            config['gui', 'qtbackend', 'backend'] = [backend] + other_backends
+            backend = other_available[0]
+            # Reorder full list so the working backend is first; preserve all entries
+            full_list = config('gui', 'qtbackend', 'backend')
+            config['gui', 'qtbackend', 'backend'] = [backend] + [b for b in full_list if b != backend]
 
     if backend_found:
         # environment variable is set

--- a/packages/pymodaq_gui/src/pymodaq_gui/examples/parameter_ex.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/examples/parameter_ex.py
@@ -109,6 +109,11 @@ class ParameterEx(ParameterManager):
              'tip': 'Such a parameter display text that are keys of a dict while'
                                                         'values could be any object'
              },
+            {'title': 'List with unavailable items:', 'name': 'unavailable_list', 'type': 'list',
+             'limits': ['pyqt6', 'pyqt5', 'pyside6'], 'value': 'pyqt6',
+             'unavailable': ['pyqt5'],
+             'tip': 'Items listed in "unavailable" are shown greyed-out and cannot be selected '
+                    '(used e.g. to display backends that are not installed)'},
         ]},
         {'title': 'Browsing files:', 'name': 'browser', 'type': 'group', 'children': [
             {'title': 'Look for a file:', 'name': 'afile', 'type': 'browsepath', 'value': r'D:\Data', 'filetype': True,

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/list.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/list.py
@@ -109,6 +109,27 @@ class ListParameterItem(ListParameterItem):
                     self.limitsChanged(self.param, self.param.opts['limits'])
                     self.param.setValue(text)
 
+    def _apply_unavailable(self, unavailable: list[str]):
+        """Disable combo items that are in *unavailable* and add a tooltip to them."""
+        if not hasattr(self, 'widget') or self.widget is None:
+            return
+        combo = self.widget.combo
+        model = combo.model()
+        for i in range(combo.count()):
+            item = model.item(i)
+            if combo.itemText(i) in unavailable:
+                item.setEnabled(False)
+                item.setToolTip('Not installed')
+            else:
+                item.setEnabled(True)
+                item.setToolTip('')
+
+    def limitsChanged(self, param, limits):
+        super().limitsChanged(param, limits)
+        unavailable = param.opts.get('unavailable', [])
+        if unavailable:
+            self._apply_unavailable(unavailable)
+
     def optsChanged(self, param, opts):
         """
             Called when any options are changed that are not name, value, default, or limits.
@@ -128,6 +149,8 @@ class ListParameterItem(ListParameterItem):
             self.widget.add_pb.setVisible(opts['show_pb'])
         if 'enabled' in opts:
             self.widget.setEnabled(opts['enabled'])
+        if 'unavailable' in opts:
+            self._apply_unavailable(opts['unavailable'])
 
 
 class ListParameter(ListParameter):

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/tree_toml.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/tree_toml.py
@@ -4,6 +4,7 @@ Created the 19/10/2023
 
 @author: Sebastien Weber
 """
+import contextlib
 import sys
 from typing import Union, Any
 import datetime
@@ -41,6 +42,58 @@ class TreeFromToml(ParameterManager, QObject):
 
         self._cached_config_changes = {}
         self.dialog = None
+        self._post_process_params()
+
+    def _post_process_params(self):
+        """For every list param named 'backend': expand limits from the template (so the full
+        list of known backends is always shown) and grey out items not installed."""
+        import pkgutil
+        import toml
+        from pathlib import Path
+        from pymodaq_utils.config import GlobalConfig, BaseConfig
+
+        installed_lower = {mod.name.lower() for mod in pkgutil.iter_modules()}
+
+        def annotate(param_group, template_dict):
+            for child in param_group.children():
+                key = child.name()
+                tval = template_dict.get(key) if isinstance(template_dict, dict) else None
+                if child.opts.get('type') == 'list' and key == 'backend':
+                    current = list(child.opts.get('limits', []))
+                    full = list(tval) if isinstance(tval, list) else list(current)
+                    for item in current:  # keep any user-added entries not in template
+                        if item not in full:
+                            full.append(item)
+                    unavailable = [x for x in full if isinstance(x, str)
+                                   and x.lower() not in installed_lower]
+                    update = {'unavailable': unavailable}
+                    if full != current:
+                        update['limits'] = full
+                    child.setOpts(**update)
+                elif child.hasChildren():
+                    annotate(child, tval if isinstance(tval, dict) else {})
+
+        # Resolve (param_root, template) pairs so both start at the same nesting level
+        if isinstance(self._config, GlobalConfig):
+            for cfg_name, cfg in self._config._configs.items():
+                tpath = getattr(cfg, 'config_template_path', None)
+                if not (tpath and Path(tpath).is_file()):
+                    continue
+                template = toml.load(tpath)
+                if self.start_path and self.start_path[0] == cfg_name:
+                    for k in self.start_path[1:]:
+                        template = template.get(k, {})
+                    annotate(self.settings, template)
+                elif not self.start_path:
+                    with contextlib.suppress(Exception):
+                        annotate(self.settings.child(cfg_name), template)
+        elif isinstance(self._config, BaseConfig):
+            tpath = getattr(self._config, 'config_template_path', None)
+            if tpath and Path(tpath).is_file():
+                template = toml.load(tpath)
+                for k in self.start_path:
+                    template = template.get(k, {})
+                annotate(self.settings, template)
 
     def value_changed(self, param):
         path = tuple(get_param_path(param)[1:])

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/tree_toml.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/tree_toml.py
@@ -54,6 +54,13 @@ class TreeFromToml(ParameterManager, QObject):
 
         installed_lower = {mod.name.lower() for mod in pkgutil.iter_modules()}
 
+        # Some backend names are not pip package names; map them to their actual package.
+        _backend_pkg_alias = {'qt': 'qtpy'}
+
+        def _backend_available(name: str) -> bool:
+            pkg = _backend_pkg_alias.get(name.lower(), name.lower())
+            return pkg in installed_lower
+
         def annotate(param_group, template_dict):
             for child in param_group.children():
                 key = child.name()
@@ -65,7 +72,7 @@ class TreeFromToml(ParameterManager, QObject):
                         if item not in full:
                             full.append(item)
                     unavailable = [x for x in full if isinstance(x, str)
-                                   and x.lower() not in installed_lower]
+                                   and not _backend_available(x)]
                     update = {'unavailable': unavailable}
                     if full != current:
                         update['limits'] = full


### PR DESCRIPTION
## Fix backend config list management and grey out unavailable backends in preferences
                                                                                                                                                                 
### Problem

When PyMoDAQ started with a fallback Qt backend (e.g. falling back from pyqt6 to pyside6 because pyqt6 was not installed), it saved only the currently available backends to the user config. On subsequent runs, the user config overrode the full system list, making newly installed backends invisible to PyMoDAQ.                                                                                                                                                                 

###Changes

pymodaq_gui/__init__.py — set_and_check_qt_backend_or_die: on fallback, reorder the full backend list (working backend first) instead of pruning it to only installed entries. The saved config now always retains all known backends.
                                                                                                                                                                   parameter/pymodaq_ptypes/list.py — ListParameterItem gains an unavailable opt. Items listed in unavailable are shown greyed-out and non-selectable in the combo   box, with a "Not installed" tooltip. The state is re-applied on every limitsChanged (repopulation) and optsChanged.

utils/widgets/tree_toml.py — TreeFromToml._post_process_params: after the parameter tree is built, walks it recursively alongside each config's template. For every list param named backend, expands the displayed limits to the full template list (so all known backends are always visible) and marks non-installed ones as unavailable. Covers Qt, HDF5 and plotting backends with no special-casing.                                                                                  
  
examples/parameter_ex.py — adds a demo entry in the Lists section showing the unavailable opt in action.                                                         

<img width="807" height="820" alt="image" src="https://github.com/user-attachments/assets/ca9e20c1-994b-4076-989e-b880a3e15c82" />
