### PR TITLE
Bugfix/param list as dict

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/ioxml.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/ioxml.py
@@ -1,21 +1,48 @@
 from __future__ import annotations
 
-from typing import Union
+from typing import Union, Any
 from pathlib import Path
+
+import numpy as np
 
 import importlib
 import json
 from pathlib import Path
 from xml.etree import ElementTree as ET
 from collections import OrderedDict
+
+import numpy as np
 from qtpy import QtGui
 from qtpy.QtCore import QDateTime, QTime
+
+from pymodaq_utils.logger import set_logger, get_module_name
+
 from pymodaq_gui.parameter import Parameter
 
 from pyqtgraph.parametertree.Parameter import PARAM_TYPES, PARAM_NAMES
 
 
 VALID_FOR_CONFIGURATION = 'valid_for_configuration'
+logger = set_logger(get_module_name(__file__))
+
+
+def basic_serialization(param_val: Any, within_dict=False) -> str:
+    if param_val is np.nan:
+        text = f"np.nan"
+    elif isinstance(param_val, str):
+        if not within_dict:
+            text = f"str({param_val!r})"  # Export repr() for handling non-printable characters
+        else:
+            text = param_val
+    elif isinstance(param_val, int):
+        text = f"int({param_val})"
+    elif isinstance(param_val, float):
+        text = f"float({param_val})"
+    else:
+        logger.exception(f"Serializing as xml the Parameter value: {param_val} as a simple string\n"
+                         f"May not be reimportable...")
+        text = str(param_val)
+    return text
 
 
 def walk_parameters_to_xml(parent_elt=None, param=None):
@@ -92,14 +119,7 @@ def add_text_to_elt(elt, param):
     elif param_type == 'color':
         text = str([param_val.red(), param_val.green(), param_val.blue(), param_val.alpha()])
     elif param_type == 'list':
-        if isinstance(param_val, str):
-            text = f"str({param_val!r})"    # Export repr() for hangling non-printable characters
-        elif isinstance(param_val, int):
-            text = f"int({param_val})"
-        elif isinstance(param_val, float):
-            text = f"float({param_val})"
-        else:
-            text = str(param_val)
+        text = basic_serialization(param_val)
     elif param_type == 'int':
         if param_val is True:  # known bug is True should be clearly specified here
             val = 1
@@ -126,7 +146,7 @@ def add_text_to_elt(elt, param):
     elt.text = text
 
 
-def dict_from_param(param):
+def dict_from_param(param: Parameter):
     """Get Parameter properties as a dictionary
 
     Parameters
@@ -177,14 +197,14 @@ def dict_from_param(param):
     if VALID_FOR_CONFIGURATION in param.opts:
         opts.update({VALID_FOR_CONFIGURATION: '1' if param.opts[VALID_FOR_CONFIGURATION] else '0'})
 
-    # if 'limits' in param.opts:
-    #     values = str(param.opts['limits'])
-    #     opts.update(dict(values=values))
-
     if 'limits' in param.opts:
-        limits = str(param.opts['limits'])
+        if isinstance(param.opts['limits'], list):
+            limits = str(param.opts['limits'])
+        elif isinstance(param.opts['limits'], dict):
+            limits = {}
+            for key in param.opts['limits']:
+                limits[key] = basic_serialization(param.opts['limits'][key], within_dict=True)
         opts.update(dict(limits=limits))
-        # opts.update(dict(values=limits))
 
     if 'addList' in param.opts:
         addList = str(param.opts['addList'])
@@ -313,20 +333,18 @@ def elt_to_dict(el):
         suffix = str(el.get('suffix'))
         param.update(dict(suffix=suffix))
 
-    # if 'limits' in el.attrib.keys():
-    #     try:
-    #         values = list(eval(el.get('limits')))  # make sure the evaluated values are returned as list (in case another
-    #     # iterator type has been used
-    #         param.update(dict(values=values))
-    #     except:
-    #         pass
-
     if 'limits' in el.attrib.keys():
         try:
             limits = eval(el.get('limits'))
+            if isinstance(limits, dict):
+                for key, val in limits.items():
+                    try:
+                        limits[key] = eval(val)
+                    except NameError:
+                        limits[key] = val
             param.update(dict(limits=limits))
-        except:
-            pass
+        except Exception as e:
+            logger.exception(e)
 
     return param
 

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/ioxml.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/ioxml.py
@@ -198,12 +198,12 @@ def dict_from_param(param: Parameter):
         opts.update({VALID_FOR_CONFIGURATION: '1' if param.opts[VALID_FOR_CONFIGURATION] else '0'})
 
     if 'limits' in param.opts:
-        if isinstance(param.opts['limits'], list):
-            limits = str(param.opts['limits'])
-        elif isinstance(param.opts['limits'], dict):
+        if isinstance(param.opts['limits'], dict):
             limits = {}
             for key in param.opts['limits']:
                 limits[key] = basic_serialization(param.opts['limits'][key], within_dict=True)
+        else:
+            limits = str(param.opts['limits'])
         opts.update(dict(limits=limits))
 
     if 'addList' in param.opts:

--- a/packages/pymodaq_gui/tests/parameter_test/param_ioxml_test.py
+++ b/packages/pymodaq_gui/tests/parameter_test/param_ioxml_test.py
@@ -28,72 +28,84 @@ settings = Parameter.create(name='settings', type='group', children=params)
 string = ioxml.parameter_to_xml_string(settings.child('axes'))
 
 ioxml.XML_string_to_pobject(string)
+list_limits = ['DAQ0D', 'DAQ1D', 'DAQ2D', 'DAQND']
+dict_limits = {'a_nan': np.nan, 'an_int': 21, 'a_str': 'astr'}
 
 
-class TestListParameter:
-
-    list_limits = ['DAQ0D', 'DAQ1D', 'DAQ2D', 'DAQND']
-    dict_limits = {'a_nan': np.nan, 'an_int': 21, 'a_str': 'astr'}
+@pytest.fixture
+def ini_parameter(qtbot):
 
     params = [{'name': 'list_param', 'type': 'list', 'limits': list_limits},
               {'name': 'dict_param', 'type': 'list', 'limits': dict_limits},
               ]
 
     settings = Parameter.create(name='settings', children=params)
+    tree = ParameterTree()
+    qtbot.addWidget(tree)
+    tree.setParameters(settings, showTop=False)
+    yield settings, tree
+    tree.close()
+    
+    
+class TestListParameter:
 
-    def test_value(self, qtbot):
-        tree = ParameterTree()
-        tree.setParameters(self.settings, showTop=False)
+    def test_value(self, ini_parameter):
+        settings, tree = ini_parameter
 
-        assert self.settings['list_param'] == 'DAQ0D'
-        assert self.settings['dict_param'] == 0
+        assert settings['list_param'] == 'DAQ0D'
+        assert settings['dict_param'] is np.nan
 
         list_item, _ = find_objects_in_list_from_attr_name_val(tree.listAllItems(),
-                                                               'param', self.settings.child('list_param'))
+                                                               'param', settings.child('list_param'))
         dict_item, _ = find_objects_in_list_from_attr_name_val(tree.listAllItems(), 'param',
-                                                               self.settings.child('dict_param'))
+                                                               settings.child('dict_param'))
         list_widget: QtWidgets.QComboBox = list_item.widget.combo
         dict_widget: QtWidgets.QComboBox = dict_item.widget.combo
 
         list_item.setValue('DAQND')
-        dict_item.setValue(3)
+        dict_item.setValue('astr')
 
-        assert self.settings['list_param'] == 'DAQND'
-        assert self.settings['dict_param'] == 3
+        assert settings['list_param'] == 'DAQND'
+        assert settings['dict_param'] == 'astr'
 
         list_item.setValue('DAQ4D')  # not in limits so should be set to the first element of the underlying combobox
         dict_item.setValue('DAQ1D')  # not in limits (because should be values of the dict, not keys) so should be
         # set to the first element of the underlying combobox
 
-        assert self.settings['list_param'] == list_widget.itemText(0)
-        assert self.settings['dict_param'] == self.dict_limits[dict_widget.itemText(0)]
+        assert settings['list_param'] == list_widget.itemText(0)
+        try:
+            assert settings['dict_param'] == dict_limits[dict_widget.itemText(0)]
+        except AssertionError:
+            assert settings['dict_param'] is dict_limits[dict_widget.itemText(0)]
 
-    def test_save_xml_list(self):
-        xml_string = ioxml.parameter_to_xml_string(self.settings.child('list_param'))
+    def test_save_xml_list(self, ini_parameter):
+        settings, tree = ini_parameter
+        xml_string = ioxml.parameter_to_xml_string(settings.child('list_param'))
 
         param_back = ioxml.XML_string_to_pobject(xml_string).child('list_param')
-        assert param_back.name() == self.settings.child('list_param').name()
-        assert param_back.title() == self.settings.child('list_param').title()
-        assert param_back.value() == self.settings.child('list_param').value()
-        assert param_back.readonly() == self.settings.child('list_param').readonly()
-        assert param_back.opts['limits'] == self.settings.child('list_param').opts['limits']
-        assert param_back.opts['removable'] == self.settings.child('list_param').opts['removable']
+        assert param_back.name() == settings.child('list_param').name()
+        assert param_back.title() == settings.child('list_param').title()
+        assert param_back.value() == settings.child('list_param').value()
+        assert param_back.readonly() == settings.child('list_param').readonly()
+        assert param_back.opts['limits'] == settings.child('list_param').opts['limits']
+        assert param_back.opts['removable'] == settings.child('list_param').opts['removable']
 
-    def test_save_xml_dict(self):
-        for value_key in self.dict_limits:
-            self.settings.child('dict_param').setValue(self.dict_limits[value_key])
-            xml_string = ioxml.parameter_to_xml_string(self.settings.child('dict_param'))
+    def test_save_xml_dict(self, ini_parameter):
+        settings, tree = ini_parameter
+        for value_key in dict_limits:
+            settings.child('dict_param').setValue(dict_limits[value_key])
+            xml_string = ioxml.parameter_to_xml_string(settings.child('dict_param'))
 
             param_back = ioxml.XML_string_to_pobject(xml_string).child('dict_param')
-            assert param_back.name() == self.settings.child('dict_param').name()
-            assert param_back.title() == self.settings.child('dict_param').title()
+            assert param_back.name() == settings.child('dict_param').name()
+            assert param_back.title() == settings.child('dict_param').title()
             try:
-                assert param_back.value() == self.settings.child('dict_param').value()
+                assert param_back.value() == settings.child('dict_param').value()
             except AssertionError:
-                assert param_back.value() is self.settings.child('dict_param').value()
-            assert param_back.readonly() == self.settings.child('dict_param').readonly()
-            assert param_back.opts['limits'] == self.settings.child('dict_param').opts['limits']
-            assert param_back.opts['removable'] == self.settings.child('dict_param').opts['removable']
+                assert param_back.value() is settings.child('dict_param').value()
+            assert param_back.readonly() == settings.child('dict_param').readonly()
+            assert param_back.opts['limits'] == settings.child('dict_param').opts['limits']
+            assert param_back.opts['removable'] == settings.child('dict_param').opts['removable']
 
 
 class TestXMLbackForth():
@@ -103,8 +115,8 @@ class TestXMLbackForth():
 
     def test_save_load_xml(self):
 
-        param_back = ioxml.XML_string_to_pobject(ioxml.parameter_to_xml_string(self.settings))
-        children_list_in = putils.iter_children_params(self.settings)
+        param_back = ioxml.XML_string_to_pobject(ioxml.parameter_to_xml_string(settings))
+        children_list_in = putils.iter_children_params(settings)
         children_list_back = putils.iter_children_params(param_back)
         for child, child_back in zip(children_list_in,children_list_back):
             assert child_back.name() == child.name()

--- a/packages/pymodaq_gui/tests/parameter_test/param_ioxml_test.py
+++ b/packages/pymodaq_gui/tests/parameter_test/param_ioxml_test.py
@@ -5,7 +5,7 @@ Created the 29/08/2023
 @author: Sebastien Weber
 """
 import pytest
-
+import numpy as np
 
 from qtpy import QtWidgets
 
@@ -33,7 +33,7 @@ ioxml.XML_string_to_pobject(string)
 class TestListParameter:
 
     list_limits = ['DAQ0D', 'DAQ1D', 'DAQ2D', 'DAQND']
-    dict_limits = {'DAQ0D': 0, 'DAQ1D': 1, 'DAQ2D': 2, 'DAQND': 3}
+    dict_limits = {'a_nan': np.nan, 'an_int': 21, 'a_str': 'astr'}
 
     params = [{'name': 'list_param', 'type': 'list', 'limits': list_limits},
               {'name': 'dict_param', 'type': 'list', 'limits': dict_limits},
@@ -80,15 +80,20 @@ class TestListParameter:
         assert param_back.opts['removable'] == self.settings.child('list_param').opts['removable']
 
     def test_save_xml_dict(self):
-        xml_string = ioxml.parameter_to_xml_string(self.settings.child('dict_param'))
+        for value_key in self.dict_limits:
+            self.settings.child('dict_param').setValue(self.dict_limits[value_key])
+            xml_string = ioxml.parameter_to_xml_string(self.settings.child('dict_param'))
 
-        param_back = ioxml.XML_string_to_pobject(xml_string).child('dict_param')
-        assert param_back.name() == self.settings.child('dict_param').name()
-        assert param_back.title() == self.settings.child('dict_param').title()
-        assert param_back.value() == self.settings.child('dict_param').value()
-        assert param_back.readonly() == self.settings.child('dict_param').readonly()
-        assert param_back.opts['limits'] == self.settings.child('dict_param').opts['limits']
-        assert param_back.opts['removable'] == self.settings.child('dict_param').opts['removable']
+            param_back = ioxml.XML_string_to_pobject(xml_string).child('dict_param')
+            assert param_back.name() == self.settings.child('dict_param').name()
+            assert param_back.title() == self.settings.child('dict_param').title()
+            try:
+                assert param_back.value() == self.settings.child('dict_param').value()
+            except AssertionError:
+                assert param_back.value() is self.settings.child('dict_param').value()
+            assert param_back.readonly() == self.settings.child('dict_param').readonly()
+            assert param_back.opts['limits'] == self.settings.child('dict_param').opts['limits']
+            assert param_back.opts['removable'] == self.settings.child('dict_param').opts['removable']
 
 
 class TestXMLbackForth():


### PR DESCRIPTION
Only a subset of object type could be saved as limits of a list Parameter (when using a dict). In particular, using as a value np.nan was not serialized properly messing with the scan_manager...

This few cases are now handled but could lead to further issue in the future, what we really need is: https://github.com/pyqtgraph/pyqtgraph/pull/3444