### PR TITLE
Patch/data filtering and extra data in daq scan

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
@@ -20,6 +20,7 @@ import numpy as np
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt, QObject, Slot, QThread, Signal
 
+from pymodaq_data import DataSource
 from pymodaq_data.data import DataToExport, Axis, DataDistribution
 from pymodaq.utils.data import DataFromPlugins
 
@@ -604,7 +605,8 @@ class DAQ_Viewer(ParameterControlModule):
         self.settings.child('saver_settings', 'N_saved').setValue(self.settings['saver_settings', 'N_saved'] + 1)
 
     def insert_data(self, indexes: Tuple[int], where: Union[Node, str] = None,
-                    distribution=DataDistribution['uniform']):
+                    distribution=DataDistribution.uniform,
+                    extra_data: DataToExport = None):
         """Insert DataToExport to a DetectorExtendedSaver at specified indexes
 
         Method to be used when saving into an already initialized array within a h5file (DAQ_Scan for instance)
@@ -615,11 +617,15 @@ class DAQ_Viewer(ParameterControlModule):
             The indexes within the extended array where to place these data
         where: Node or str
         distribution: DataDistribution enum
+        extra_data: DataToExport
+            If not None add its content to the saved data
 
         See Also
         --------
         DAQ_Scan, DetectorExtendedSaver
         """
+        if extra_data is not None:
+            self._data_to_save_export.append(extra_data.data)
         self._add_data_to_saver(self._data_to_save_export, init_step=np.all(np.array(indexes) == 0), where=where,
                                 indexes=indexes, distribution=distribution)
 
@@ -644,13 +650,7 @@ class DAQ_Viewer(ParameterControlModule):
         """
         if dte is not None:
             detector_node = self.module_and_data_saver.get_set_node(where)
-            dte = dte if not self.module_and_data_saver.h5saver.settings['save_raw_only'] else \
-                dte.get_data_from_source('raw')  # filters depending on the source: raw or calculated
-
-            dte = DataToExport(name=dte.name, data=  # filters depending on the extra argument 'save'
-                               [dwa for dwa in dte if ('do_save' not in dwa.extra_attributes) or
-                                ('do_save' in dwa.extra_attributes and dwa.do_save)])
-
+            dte = self.module_and_data_saver.filter_data(dte)
             self.module_and_data_saver.add_data(detector_node, dte, **kwargs)
 
             if init_step:

--- a/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan.py
+++ b/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan.py
@@ -925,9 +925,7 @@ class DAQScan(CustomExt):
             ind_scan = status.attribute.pop('ind_scan')
             self.module_and_data_saver.add_data(dte=status.attribute.pop('extra_data', None), **status.attribute)
             self.module_and_data_saver.add_time(status.attribute['indexes'])
-            if ind_scan == 0:  #only the h5arrays initialization can take some time and one need to make sure
-                # it is finished
-                self.command_daq_signal.emit(utils.ThreadCommand("data_saved"))
+            self.command_daq_signal.emit(utils.ThreadCommand("data_saved"))
 
         elif status.command == 'add_nav_axes':
             self.module_and_data_saver.add_nav_axes(status.attribute)
@@ -1429,16 +1427,16 @@ class DAQScanAcquisition(QObject):
                                     dict(indexes=indexes, distribution=self.scanner.distribution,
                                          ind_scan=self.ind_scan,
                                          extra_data=data_temp if self.scanner.scanner.do_process_data else None,)))
+
+            while not self._data_saved_flag:  # this flag is changed by a command from the add_data process in main thread
+                QThread.msleep(50)
+                QtWidgets.QApplication.processEvents()
+
             if self.ind_scan == 0:
-                while not self._data_saved_flag:  # this flag is changed by a command from the add_data process in main thread
-                    QThread.msleep(50)
-                    QtWidgets.QApplication.processEvents()
                 self.status_sig.emit(utils.ThreadCommand("Update_Status", attribute="Acquisition has started"))
                 self.status_sig.emit(utils.ThreadCommand("splash", attribute=None))
 
             self.det_done_flag = True
-
-
             self.scan_data_tmp.emit(ScanDataTemp(self.ind_scan, indexes, data_temp))
 
         except Exception as e:

--- a/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan.py
+++ b/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan.py
@@ -25,7 +25,7 @@ from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.config import GlobalConfig as Config
 from pymodaq_utils import utils
 
-from pymodaq_data import data as data_mod, DataDistribution, DataDim
+from pymodaq_data import data as data_mod, DataDistribution, DataDim, DataToExport
 from pymodaq_data.h5modules import data_saving
 
 from pymodaq_gui.parameter import ioxml, Parameter
@@ -76,7 +76,6 @@ class DAQScan(CustomExt):
     """
     settings_name = 'daq_scan_settings'
     command_daq_signal = Signal(utils.ThreadCommand)
-    live_data_1D_signal = Signal(list)
 
     icon_name = 'qr_code_scanner'
 
@@ -177,7 +176,7 @@ class DAQScan(CustomExt):
         self.ui.command_sig.connect(self.process_ui_cmds)
         self.ui.finalize_ui(self)
 
-        self.connect_things()
+        self.setup_ui()
 
         self.create_dataset_settings()
 
@@ -193,9 +192,14 @@ class DAQScan(CustomExt):
 
         if self.dashboard.experiment_manager.entry_applied:
             self.ui.enable_start_stop(True)
-            self.scan_manager.enable_actions()
+            self.ini_scan_manager()
 
         logger.info('DAQScan Initialized')
+
+    def ini_scan_manager(self):
+        self.scan_manager.enable_actions()
+        self.scan_manager.modules_manager.actuators_all = self.modules_manager.actuators_all
+        self.scan_manager.modules_manager.detectors_all = self.modules_manager.detectors_all
 
     def get_app_toolbars(self) -> list[QtWidgets.QToolBar]:
         """ Get the main toolbars widget to be eventually added in the main window toolbararea
@@ -213,8 +217,20 @@ class DAQScan(CustomExt):
         self.settings.child('plot_options', 'plot_1d').setValue(
             dict(all_items=data1D_names, selected=data1D_names))
 
+    ####
+    def setup_docks_and_widgets(self):
+        """ Mandatory even if empty"""
+        pass
+
+    def setup_menus_and_toolbars(self, menubar: QtWidgets.QMenuBar = None):
+        """ Mandatory even if empty"""
+
+    def setup_actions(self):
+        """ Mandatory even if empty"""
+
     def connect_things(self):
         self.scanner.scanner_updated_signal.connect(self.do_things_after_scanner_changed)
+    ####
 
     def do_things_after_scanner_changed(self):
         self.ui.set_action_enabled('ini_positions',
@@ -236,8 +252,9 @@ class DAQScan(CustomExt):
 
         if self.ui is not None:
             self.ui.enable_start_stop(True)
+
         if hasattr(self, 'scan_manager'):
-            self.scan_manager.enable_actions()
+            self.ini_scan_manager()
 
     ################
     #  CONFIG/SETUP UI / EXIT
@@ -906,7 +923,7 @@ class DAQScan(CustomExt):
 
         elif status.command == 'add_data':
             ind_scan = status.attribute.pop('ind_scan')
-            self.module_and_data_saver.add_data(**status.attribute)
+            self.module_and_data_saver.add_data(dte=status.attribute.pop('extra_data', None), **status.attribute)
             self.module_and_data_saver.add_time(status.attribute['indexes'])
             if ind_scan == 0:  #only the h5arrays initialization can take some time and one need to make sure
                 # it is finished
@@ -914,6 +931,13 @@ class DAQScan(CustomExt):
 
         elif status.command == 'add_nav_axes':
             self.module_and_data_saver.add_nav_axes(status.attribute)
+
+        elif status.command == 'splash':
+            if status.attribute is None:
+                self.splash_sc.setVisible(False)
+            else:
+                self.splash_sc.show()
+                self.splash_sc.showMessage(status.attribute)
 
     ############
     #  PLOTTING
@@ -1376,10 +1400,11 @@ class DAQScanAcquisition(QObject):
                 indexes = [self.ind_average] + list(indexes)
             indexes = tuple(indexes)
             if self.ind_scan == 0:
-                self.status_sig.emit(utils.ThreadCommand("Update_Status",
+                self.status_sig.emit(utils.ThreadCommand("splash",
                                                          "Creating the arrays nodes in the h5file, please be patient"))
                 QtWidgets.QApplication.processEvents()
                 QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.CursorShape.WaitCursor)
+                QThread.msleep(50)
                 nav_axes = self.scanner.get_nav_axes()
                 if self.Naverage > 1:
                     for nav_axis in nav_axes:
@@ -1387,21 +1412,6 @@ class DAQScanAcquisition(QObject):
                     nav_axes.append(data_mod.Axis('Average', data=np.linspace(0, self.Naverage - 1, self.Naverage),
                                                   index=0))
                 self.status_sig.emit(utils.ThreadCommand("add_nav_axes", nav_axes))
-
-
-            # async saving command sent to all concerned detector control modules
-            # because async if the first initialization takes a long time, the next async move will timeout therefore wait for the _data_saved_flag to be run
-            self.status_sig.emit(
-                utils.ThreadCommand("add_data",
-                                    dict(indexes=indexes, distribution=self.scanner.distribution,
-                                         ind_scan=self.ind_scan)))
-            if self.ind_scan == 0:
-                while not self._data_saved_flag:  # this flag is changed by a command from the add_data process in main thread
-                    QThread.msleep(50)
-                    QtWidgets.QApplication.processEvents()
-                self.status_sig.emit(utils.ThreadCommand("Update_Status", attribute="Acquisition has started"))
-
-            self.det_done_flag = True
 
             if self.scanner.scanner.do_process_data:
                 data_temp = self.scanner.scanner.process_data(det_done_datas)
@@ -1411,6 +1421,23 @@ class DAQScanAcquisition(QObject):
                 data_temp = det_done_datas.get_data_from_full_names(full_names, deepcopy=False)
                 n_nav_axis_selection = 2-len(indexes) + 1 if self.Naverage > 1 else 2-len(indexes)
                 data_temp = data_temp.get_data_with_naxes_lower_than(n_nav_axis_selection)  # maximum Data2D included nav indexes
+
+            # async saving command sent to all concerned detector control modules
+            # because async if the first initialization takes a long time, the next async move will timeout therefore wait for the _data_saved_flag to be run
+            self.status_sig.emit(
+                utils.ThreadCommand("add_data",
+                                    dict(indexes=indexes, distribution=self.scanner.distribution,
+                                         ind_scan=self.ind_scan,
+                                         extra_data=data_temp if self.scanner.scanner.do_process_data else None,)))
+            if self.ind_scan == 0:
+                while not self._data_saved_flag:  # this flag is changed by a command from the add_data process in main thread
+                    QThread.msleep(50)
+                    QtWidgets.QApplication.processEvents()
+                self.status_sig.emit(utils.ThreadCommand("Update_Status", attribute="Acquisition has started"))
+                self.status_sig.emit(utils.ThreadCommand("splash", attribute=None))
+
+            self.det_done_flag = True
+
 
             self.scan_data_tmp.emit(ScanDataTemp(self.ind_scan, indexes, data_temp))
 

--- a/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan_ui.py
+++ b/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan_ui.py
@@ -60,7 +60,6 @@ class DAQScanUI(CustomApp, ViewerDispatcher):
         widget_command = QtWidgets.QWidget()
         widget_command.setLayout(QtWidgets.QVBoxLayout())
         self.dock_command.addWidget(widget_command)
-        widget_command.layout().addWidget(self.toolbar)
 
         splitter_widget = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
         splitter_v_widget = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)

--- a/packages/pymodaq/src/pymodaq/extensions/scan/scan_manager.py
+++ b/packages/pymodaq/src/pymodaq/extensions/scan/scan_manager.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
 
 EXTENSION_PATH = get_set_path(get_set_local_dir(user=True), 'DAQ_SCAN')
+SCANNER_FILES_PATH = get_set_path(EXTENSION_PATH, 'scanners')
+
 logger = set_logger(get_module_name(__file__))
 
 class ScanManager(ManagerBase):
@@ -73,7 +75,7 @@ class ScanManager(ManagerBase):
 
     def get_entry_folder(self, **kwargs_to_entry_folder) -> Path:
         """Get the folder path where the managed entries are stored."""
-        return get_set_path(EXTENSION_PATH, 'scanners')
+        return SCANNER_FILES_PATH
 
     def setup_docks_and_widgets(self):
         self.main_widget.setLayout(QtWidgets.QHBoxLayout())

--- a/packages/pymodaq/src/pymodaq/utils/data.py
+++ b/packages/pymodaq/src/pymodaq/utils/data.py
@@ -84,10 +84,10 @@ class DataFromPlugins(DataRaw):
             kwargs['do_save'] = do_save
         #######
 
-        if 'do_plot' not in kwargs:
-            kwargs['do_plot'] = True
-        if 'do_save' not in kwargs:
-            kwargs['do_save'] = True
+        # if 'do_plot' not in kwargs:
+        #     kwargs['do_plot'] = True
+        # if 'do_save' not in kwargs:
+        #     kwargs['do_save'] = True
         super().__init__(*args, **kwargs)
 
 

--- a/packages/pymodaq/src/pymodaq/utils/h5modules/module_saving.py
+++ b/packages/pymodaq/src/pymodaq/utils/h5modules/module_saving.py
@@ -12,12 +12,14 @@ import xml.etree.ElementTree as ET
 
 
 import numpy as np
+
+from pymodaq_data import DataDim, DataWithAxes
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.enums import BaseEnum
 from pymodaq_utils.abstract import ABCMeta, abstract_attribute, abstractmethod
 from pymodaq_utils.utils import capitalize
-from pymodaq_data.data import Axis, DataToExport, DataDistribution, DataRaw
-from pymodaq_data.h5modules.saving import H5SaverLowLevel
+from pymodaq_data.data import Axis, DataToExport, DataDistribution, DataRaw, DataSource
+from pymodaq_gui.h5modules.saving import H5SaverBase
 from pymodaq_data.h5modules.backends import GROUP, Node
 from pymodaq_data.h5modules.data_saving import (
     DataToExportSaver, DataToExportEnlargeableSaver,
@@ -45,7 +47,7 @@ class ModuleSaver(metaclass=ABCMeta):
     """Abstract base class to save info and data from main modules (DAQScan, DAQViewer, DAQMove, ...)"""
     group_type: GroupModuleType = abstract_attribute()
     _module = abstract_attribute()
-    _h5saver: H5SaverLowLevel = abstract_attribute()
+    _h5saver: H5SaverBase = abstract_attribute()
     _module_group: GROUP = abstract_attribute()
     main_module = True
 
@@ -119,7 +121,7 @@ class ModuleSaver(metaclass=ABCMeta):
         return self._h5saver
 
     @h5saver.setter
-    def h5saver(self, _h5saver: H5SaverLowLevel):
+    def h5saver(self, _h5saver: H5SaverBase):
         self._h5saver = _h5saver
         self.update_after_h5changed()
 
@@ -188,6 +190,33 @@ class DetectorSaver(ModuleSaver):
 
     def add_data(self, where: Union[Node, str], data: DataToExport, **kwargs):
         self._datatoexport_saver.add_data(where, data, **kwargs)
+
+    def filter_data(self, dte: DataToExport) -> DataToExport:
+        """ Filter Data to be saved depending on first the presence of the extra_attribute: *do_save* and then on
+        the H5Saver settings
+        """
+        dte_filtered = DataToExport('Filtered')
+        for dwa in dte:
+            flag = True
+            if 'do_save' in dwa.extra_attributes:  # this is the main filter
+                flag = flag and dwa.do_save
+            else:
+                flag = flag and self.filter_data_wrt_settings(dwa)
+            if flag:
+                dte_filtered.append(dwa)
+        return dte_filtered
+
+    def filter_data_wrt_settings(self, dwa: DataWithAxes) -> bool:
+        """ Check if this DataWithAxes should be saved depending on the H5Saver settings
+
+        Return True if it should be saved
+        """
+        flag = True
+        if not self.h5saver.settings['save_2D']:  # exclude 2D data and above
+            flag = flag and not (dwa.dim == DataDim.Data2D or dwa.dim == DataDim.DataND)
+        if self.h5saver.settings['save_raw_only']:  # exclude Calculated data
+            flag = flag and dwa.source == DataSource.raw
+        return flag
 
     def add_bkg(self, where: Union[Node, str], data_bkg: DataToExport):
         """ Adds a DataToExport as a background node in the h5file
@@ -460,7 +489,8 @@ class ScanSaver(ModuleSaver):
                  distribution=DataDistribution.uniform, **kwargs):
         for detector in self._module.modules_manager.detectors:
             try:
-                detector.insert_data(indexes, where=self._module_group, distribution=distribution)
+                detector.insert_data(indexes, where=self._module_group, distribution=distribution,
+                                     extra_data=dte)
             except Exception as e:
                 logger.exception(f'Cannot insert data: {str(e)}')
 

--- a/packages/pymodaq/src/pymodaq/utils/h5modules/module_saving.py
+++ b/packages/pymodaq/src/pymodaq/utils/h5modules/module_saving.py
@@ -487,10 +487,10 @@ class ScanSaver(ModuleSaver):
 
     def add_data(self, dte: DataToExport = None, indexes: Tuple[int] = None,
                  distribution=DataDistribution.uniform, **kwargs):
-        for detector in self._module.modules_manager.detectors:
+        for ind, detector in enumerate(self._module.modules_manager.detectors):
             try:
                 detector.insert_data(indexes, where=self._module_group, distribution=distribution,
-                                     extra_data=dte)
+                                     extra_data=dte if ind == 0 else None,)
             except Exception as e:
                 logger.exception(f'Cannot insert data: {str(e)}')
 

--- a/packages/pymodaq/src/pymodaq/utils/h5modules/module_saving.py
+++ b/packages/pymodaq/src/pymodaq/utils/h5modules/module_saving.py
@@ -234,12 +234,12 @@ class DetectorSaver(ModuleSaver):
         """
         self._datatoexport_saver.add_bkg(where, data_bkg)
 
-    def add_external_h5(self, other_h5data: H5SaverLowLevel):
+    def add_external_h5(self, other_h5data: H5SaverBase):
         if other_h5data is not None:
             external_group = self._h5saver.add_group('external_data', 'external_h5', self.module_group)
             try:
                 if not other_h5data.isopen:
-                    h5saver = H5SaverLowLevel()
+                    h5saver = H5SaverBase()
                     h5saver.init_file(addhoc_file_path=other_h5data.filename)
                     h5_file = h5saver.h5_file
                 else:

--- a/packages/pymodaq/src/pymodaq/utils/h5modules/module_saving.py
+++ b/packages/pymodaq/src/pymodaq/utils/h5modules/module_saving.py
@@ -198,12 +198,10 @@ class DetectorSaver(ModuleSaver):
         """
         dte_filtered = DataToExport('Filtered')
         for dwa in dte:
-            flag = True
             if 'do_save' in dwa.extra_attributes:  # this is the main filter
-                flag = flag and dwa.do_save
-            else:
-                flag = flag and self.filter_data_wrt_settings(dwa)
-            if flag:
+                if dwa.do_save:
+                    dte_filtered.append(dwa)
+            elif self.filter_data_wrt_settings(dwa):
                 dte_filtered.append(dwa)
         return dte_filtered
 

--- a/packages/pymodaq/src/pymodaq/utils/h5modules/module_saving.py
+++ b/packages/pymodaq/src/pymodaq/utils/h5modules/module_saving.py
@@ -10,20 +10,21 @@ from typing import Union, List, Tuple, TYPE_CHECKING, Iterable
 import time
 import xml.etree.ElementTree as ET
 
-
 import numpy as np
 
-from pymodaq_data import DataDim, DataWithAxes
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.enums import BaseEnum
 from pymodaq_utils.abstract import ABCMeta, abstract_attribute, abstractmethod
 from pymodaq_utils.utils import capitalize
+
+from pymodaq_data import DataDim, DataWithAxes
 from pymodaq_data.data import Axis, DataToExport, DataDistribution, DataRaw, DataSource
-from pymodaq_gui.h5modules.saving import H5SaverBase
-from pymodaq_data.h5modules.backends import GROUP, Node
 from pymodaq_data.h5modules.data_saving import (
     DataToExportSaver, DataToExportEnlargeableSaver,
     DataToExportTimedSaver, DataToExportExtendedSaver)
+from pymodaq_data.h5modules.backends import GROUP, Node
+
+from pymodaq_gui.h5modules.saving import H5SaverBase
 from pymodaq_gui.parameter import ioxml
 
 if TYPE_CHECKING:

--- a/packages/pymodaq/src/pymodaq/utils/scanner/scanner.py
+++ b/packages/pymodaq/src/pymodaq/utils/scanner/scanner.py
@@ -47,7 +47,8 @@ class Scanner(QObject, ParameterManager):
     settings_name = 'scanner'
 
     params = [
-        {'title': 'Calculate positions:', 'name': 'calculate_positions', 'type': 'action'},
+        {'title': 'Calculate positions:', 'name': 'calculate_positions', 'type': 'bool_push',
+         'label': 'Calculate positions'},
         {'title': 'N steps:', 'name': 'n_steps', 'type': 'int', 'value': 0, 'readonly': True},
         {'title': 'Scan type:', 'name': 'scan_type', 'type': 'list',
          'limits': scanner_factory.scan_types()},
@@ -119,6 +120,10 @@ class Scanner(QObject, ParameterManager):
         return self._scanner.settings
 
     def value_changed(self, param: Parameter):
+        if param.name() == 'calculate_positions':
+            if param.value():
+
+                param.setValue(False)
         if param.name() == 'scan_type':
             self.settings.child('scan_sub_type').setOpts(
                 limits=scanner_factory.scan_sub_types(param.value()))
@@ -191,7 +196,6 @@ class Scanner(QObject, ParameterManager):
         return self.settings['scan_sub_type']
 
     def connect_things(self):
-        self.settings.child('calculate_positions').sigActivated.connect(self.set_scan)
         self.scanner_updated_signal.connect(self.save_scanner_settings)
 
     def save_scanner_settings(self):

--- a/packages/pymodaq/tests/utils/data_test.py
+++ b/packages/pymodaq/tests/utils/data_test.py
@@ -51,13 +51,12 @@ class TestDataFromPlugins:
 
     def test_attributes(self):
         dwa = data_mod.DataFromPlugins(name='blabla', data=[DATA1D])
-
-        assert hasattr(dwa, 'do_plot')
-        assert dwa.do_plot is True
-
-        assert hasattr(dwa, 'do_save')
-        assert dwa.do_save is True
-
+        # no more valid for pymodaq >= 5.2
+        # assert hasattr(dwa, 'do_plot')
+        # assert dwa.do_plot is True
+        #
+        # assert hasattr(dwa, 'do_save')
+        # assert dwa.do_save is True
 
 
 class TestDataActuator:


### PR DESCRIPTION
This PR fix a few things in the DAQ_SCAN

* make sure data are saved before moving to next step
* properly filter data to be saved depending if the DWA has a do_save extra argument, if it is True and the H5saver settings are taken into account
* one can add some extra data to be saved into the h5file (on top of the one from the DAQ_Viewers). This is used here to save the result of the processed data from the scanner custom process_data method.