### PR TITLE
hotfix/live_averaging

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
@@ -785,10 +785,12 @@ class DAQ_Viewer(ParameterControlModule):
                 self.settings.child('main_settings', 'N_live_averaging').setValue(self._ind_continuous_grab)
                 _current_data = dte.deepcopy()
 
-                self._ind_continuous_grab += 1
-                if self._ind_continuous_grab > 1:
+                if self._ind_continuous_grab == 0:
+                    self._data_to_save_export = _current_data
+                else:
                     self._data_to_save_export = \
                         _current_data.average(self._data_to_save_export, self._ind_continuous_grab)
+                self._ind_continuous_grab += 1
             else:
                 for dwa in dte:
                     dwa.origin = self._title


### PR DESCRIPTION
Checking #1042, I realized that the indexing used for live_averaging in daq_viewer was off.
This PR fixes it.
