### PR TITLE
Fix bug to allow 10+ actuators/detectors in an experiment (5.1)

### DIFF
--- a/packages/pymodaq/src/pymodaq/utils/managers/preset_manager_utils.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/preset_manager_utils.py
@@ -34,7 +34,7 @@ def iterative_show_pb(params):
 
 def find_last_index(list_children:list=[], name_prefix ='',format_string='02.0f'):
     # Custom function to find last available index
-    child_indexes = ([int(par.name()[len(name_prefix) + 1:]) for par in list_children if name_prefix in par.name()])
+    child_indexes = ([int(par.name()[len(name_prefix):]) for par in list_children if name_prefix in par.name()])
     if child_indexes == []:
         newindex = 0
     else:


### PR DESCRIPTION
find_last_digit took only the last digit of the "actuator__" string, which limited an experiment with 10 actuators (similarly 10 detectors).

Fixes #1051 