### PR TITLE
Reset continuous grab on stop grab

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,12 +27,11 @@ Packages
 
 Each package directory can be navigated to for more detailed information about its goal. A link to the official documentation is also provided at the end of each README.
 
+
 Requirements
 --------
 
-PyMoDAQ aims at following `SPEC0 <https://scientific-python.org/specs/spec-0000/>`_.
-
-In practice, that means we will only test python versions still considered `alive <https://devguide.python.org/versions/>`_ and that have been bugfixed for at least a year. Other python versions may still work but we cannot guarantee it.
+PyMoDAQ supports Python versions that are still considered `alive <https://devguide.python.org/versions/>`_ (not end-of-life per the Python devguide) and have been released for at least a year. Other python versions may still work but we cannot guarantee it.
 For now, this reflects into testing support for Python 3.10 - 3.13
 
 

--- a/packages/pymodaq/README.rst
+++ b/packages/pymodaq/README.rst
@@ -11,13 +11,12 @@ PyMoDAQ
    :target: https://pypi.org/project/pymodaq/
    :alt: Latest Version
 
-.. image:: https://readthedocs.org/projects/pymodaq/badge/?version=malik-irain-patch-2
-   :target: https://pymodaq.readthedocs.io/en/stable/?badge=malik-irain-patch-2
+.. image:: https://readthedocs.org/projects/pymodaq/badge/?version=dev
+   :target: https://pymodaq.readthedocs.io/en/stable/?badge=dev
    :alt: Documentation Status
 
-.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/branch/malik-irain-patch-2/graph/badge.svg?token=IQNJRCQDM2 
+.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/branch/dev/graph/badge.svg?token=IQNJRCQDM2 
  :target: https://codecov.io/gh/PyMoDAQ/PyMoDAQ
-
 
 
 +-------------+-------------------+-------------------+---------------------+
@@ -34,40 +33,40 @@ PyMoDAQ
 
 
 
-.. |310-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Linux_3.10_pyqt5.svg
+.. |310-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Linux_3.10_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |310-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Linux_3.10_pyqt6.svg
+.. |310-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Linux_3.10_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |310-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Linux_3.10_pyside6.svg
+.. |310-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Linux_3.10_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |311-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Linux_3.11_pyqt5.svg
+.. |311-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Linux_3.11_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |311-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Linux_3.11_pyqt6.svg
+.. |311-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Linux_3.11_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |311-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Linux_3.11_pyside6.svg
+.. |311-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Linux_3.11_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |312-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Linux_3.12_pyqt5.svg
+.. |312-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Linux_3.12_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |312-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Linux_3.12_pyqt6.svg
+.. |312-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Linux_3.12_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |312-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Linux_3.12_pyside6.svg
+.. |312-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Linux_3.12_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |313-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Linux_3.13_pyqt5.svg
+.. |313-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Linux_3.13_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |313-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Linux_3.13_pyqt6.svg
+.. |313-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Linux_3.13_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |313-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Linux_3.13_pyside6.svg
+.. |313-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Linux_3.13_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
 +-------------+---------------------+---------------------+-----------------------+
@@ -83,40 +82,40 @@ PyMoDAQ
 +-------------+---------------------+---------------------+-----------------------+
 
 
-.. |310-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Windows_3.10_pyqt5.svg
+.. |310-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Windows_3.10_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |310-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Windows_3.10_pyqt6.svg
+.. |310-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Windows_3.10_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |310-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Windows_3.10_pyside6.svg
+.. |310-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Windows_3.10_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |311-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Windows_3.11_pyqt5.svg
+.. |311-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Windows_3.11_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |311-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Windows_3.11_pyqt6.svg
+.. |311-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Windows_3.11_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |311-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Windows_3.11_pyside6.svg
+.. |311-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Windows_3.11_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |312-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Windows_3.12_pyqt5.svg
+.. |312-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Windows_3.12_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |312-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Windows_3.12_pyqt6.svg
+.. |312-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Windows_3.12_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |312-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Windows_3.12_pyside6.svg
+.. |312-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Windows_3.12_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |313-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Windows_3.13_pyqt5.svg
+.. |313-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Windows_3.13_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |313-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Windows_3.13_pyqt6.svg
+.. |313-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Windows_3.13_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
-.. |313-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/malik-irain-patch-2/tests_Windows_3.13_pyside6.svg
+.. |313-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq/dev/tests_Windows_3.13_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-pymodaq.yml
 
 

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
@@ -322,6 +322,8 @@ class DAQ_Viewer(ParameterControlModule):
             self.grab_data(cmd.attribute, snap_state=False)
         elif cmd.command == UiToMainViewer.SNAP:
             self.grab_data(False, snap_state=True)
+        elif cmd.command == UiToMainViewer.RESET_LIVE:
+            self.reset_live_averaging()
         elif cmd.command == UiToMainViewer.SAVE_CURRENT:
             self.save_current()
         elif cmd.command == UiToMainViewer.DETECTOR_CHANGED:
@@ -432,8 +434,7 @@ class DAQ_Viewer(ParameterControlModule):
                               dict(Naverage=self.settings['main_settings', 'Naverage'])))
         else:
             if not grab_state:
-                self.update_status(f'{self._title}: Stop Grab')
-                self.command_hardware.emit(ThreadCommand(ControlToHardwareViewer.STOP_GRAB))
+                self.stop()
             else:
                 self.thread_status(ThreadCommand(ThreadStatusViewer.UPDATE_CHANNELS))
                 self.update_status(f'{self._title}: Continuous Grab')
@@ -454,7 +455,7 @@ class DAQ_Viewer(ParameterControlModule):
         self.stop_grab()
 
     def stop_grab(self):
-        """ Stop the current continuous grabbing and unchecked the stop button of the UI
+        """ Stop the current continuous grabbing and unchecked the Grab button of the UI
 
         See Also
         --------
@@ -470,6 +471,8 @@ class DAQ_Viewer(ParameterControlModule):
         self.update_status(f'{self._title}: Stop Grab')
         self.command_hardware.emit(ThreadCommand(ControlToHardwareViewer.STOP_GRAB))
         self._grabing = False
+
+    def reset_live_averaging(self):
         self._ind_continuous_grab = 0
 
     # -------------------------------------------------------------------------
@@ -862,9 +865,10 @@ class DAQ_Viewer(ParameterControlModule):
 
         elif param.name() == 'live_averaging':
             self.settings.child('main_settings', 'show_averaging').setValue(False)
+            self.ui.get_action('reset_live').setVisible(param.value())
             if param.value():
                 self.settings.child('main_settings', 'N_live_averaging').show()
-                self._ind_continuous_grab = 0
+                self.reset_live_averaging()
                 self.settings.child('main_settings', 'N_live_averaging').setValue(0)
             else:
                 self.settings.child('main_settings', 'N_live_averaging').hide()

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
@@ -470,6 +470,7 @@ class DAQ_Viewer(ParameterControlModule):
         self.update_status(f'{self._title}: Stop Grab')
         self.command_hardware.emit(ThreadCommand(ControlToHardwareViewer.STOP_GRAB))
         self._grabing = False
+        self._ind_continuous_grab = 0
 
     # -------------------------------------------------------------------------
     # Data handling

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer_ui/ui_base.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer_ui/ui_base.py
@@ -44,6 +44,7 @@ class ActionIconNames(StrEnum):
     GRAB = 'repeat'
     GRAB_STOP = 'repeat_on'
     INI = 'cable'
+    RESET = 'replay'
 
 
 class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
@@ -174,6 +175,9 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
         self.add_action('grab', 'Grab', ActionIconNames.GRAB, "Grab data from the detector", checkable=True,
                         icon_checked=ActionIconNames.GRAB_STOP,
                         icon_checked_color=self.get_theme().green)
+        self.add_action('reset_live', 'ResetLive', ActionIconNames.RESET,
+                        "Reset The current live averaging",
+                        visible=False)
         self.add_action('show_graphs', 'ShowGraphs', 'bid_landscape', 'Show/Hide the Graphs Area',
                         checkable=True, icon_checked='bid_landscape_disabled',
                         icon_color=self.get_theme().green, icon_checked_color=self.get_theme().red)
@@ -190,6 +194,7 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
 
         self.connect_action('grab', self._grab)
         self.connect_action('snap', lambda: self.command_sig.emit(ThreadCommand(UiToMainViewer.SNAP, )))
+        self.connect_action('reset_live', lambda: self.command_sig.emit(ThreadCommand(UiToMainViewer.RESET_LIVE)))
         self.connect_action('save_current', lambda: self.command_sig.emit(ThreadCommand(UiToMainViewer.SAVE_CURRENT, )))
 
         self.selector.module_changed.connect(self._detector_changed)
@@ -273,7 +278,8 @@ class DAQ_Viewer_UI(ControlModuleUI, ViewerDispatcher):
         """Slot from the *grab* action"""
         self.command_sig.emit(ThreadCommand(UiToMainViewer.GRAB, attribute=self.is_action_checked('grab')))
         self.enable_actions(not self.is_action_checked('grab'),
-                            all_except=('grab', 'selector', 'show_settings', 'show_graphs'))
+                            all_except=('grab', 'selector', 'show_settings', 'show_graphs',
+                                        'reset_live'))
 
         if not self.config('pymodaq', 'viewer', 'allow_settings_edition'):
             self._settings_widget.setEnabled(not self.is_action_checked('grab'))

--- a/packages/pymodaq/src/pymodaq/control_modules/thread_commands.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/thread_commands.py
@@ -146,6 +146,7 @@ class UiToMainViewer(StrEnum):
     SAVE_CURRENT = 'save_current'
     SAVE_NEW = 'save_new'
     OPEN = 'open'
+    RESET_LIVE = 'reset_live'
 
     DETECTOR_CHANGED = 'detector_changed'
     VIEWERS_CHANGED = 'viewers_changed'

--- a/packages/pymodaq_data/README.rst
+++ b/packages/pymodaq_data/README.rst
@@ -11,11 +11,11 @@ PyMoDAQ Data
    :target: https://pypi.org/project/pymodaq_data/
    :alt: Latest Version
 
-.. image:: https://readthedocs.org/projects/pymodaq/badge/?version=malik-irain-patch-2
-   :target: https://pymodaq.readthedocs.io/en/stable/?badge=malik-irain-patch-2
+.. image:: https://readthedocs.org/projects/pymodaq/badge/?version=dev
+   :target: https://pymodaq.readthedocs.io/en/stable/?badge=dev
    :alt: Documentation Status
 
-.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/branch/malik-irain-patch-2/graph/badge.svg?token=IQNJRCQDM2 
+.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/branch/dev/graph/badge.svg?token=IQNJRCQDM2 
  :target: https://codecov.io/gh/PyMoDAQ/PyMoDAQ
 
 +-------------+-------------+---------------+
@@ -34,28 +34,28 @@ PyMoDAQ Data
 
 
 
-.. |310-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/malik-irain-patch-2/tests_Linux_3.10.svg
+.. |310-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/dev/tests_Linux_3.10.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
-.. |311-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/malik-irain-patch-2/tests_Linux_3.11.svg
+.. |311-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/dev/tests_Linux_3.11.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
-.. |312-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/malik-irain-patch-2/tests_Linux_3.12.svg
+.. |312-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/dev/tests_Linux_3.12.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
-.. |313-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/malik-irain-patch-2/tests_Linux_3.13.svg
+.. |313-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/dev/tests_Linux_3.13.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
-.. |310-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/malik-irain-patch-2/tests_Windows_3.10.svg
+.. |310-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/dev/tests_Windows_3.10.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
-.. |311-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/malik-irain-patch-2/tests_Windows_3.11.svg
+.. |311-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/dev/tests_Windows_3.11.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
-.. |312-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/malik-irain-patch-2/tests_Windows_3.12.svg
+.. |312-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/dev/tests_Windows_3.12.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
-.. |313-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/malik-irain-patch-2/tests_Windows_3.13.svg
+.. |313-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_data/dev/tests_Windows_3.13.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-data.yml
 
 

--- a/packages/pymodaq_gui/README.rst
+++ b/packages/pymodaq_gui/README.rst
@@ -11,13 +11,12 @@ PyMoDAQ GUI
    :target: https://pypi.org/project/pymodaq_gui/
    :alt: Latest Version
 
-.. image:: https://readthedocs.org/projects/pymodaq/badge/?version=malik-irain-patch-2
-   :target: https://pymodaq.readthedocs.io/en/stable/?badge=malik-irain-patch-2
+.. image:: https://readthedocs.org/projects/pymodaq/badge/?version=dev
+   :target: https://pymodaq.readthedocs.io/en/stable/?badge=dev
    :alt: Documentation Status
 
-.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/branch/malik-irain-patch-2/graph/badge.svg?token=IQNJRCQDM2 
+.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/branch/dev/graph/badge.svg?token=IQNJRCQDM2 
  :target: https://codecov.io/gh/PyMoDAQ/PyMoDAQ
-
 
 
 +-------------+-------------------+-------------------+---------------------+
@@ -34,40 +33,40 @@ PyMoDAQ GUI
 
 
 
-.. |310-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Linux_3.10_pyqt5.svg
+.. |310-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Linux_3.10_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |310-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Linux_3.10_pyqt6.svg
+.. |310-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Linux_3.10_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |310-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Linux_3.10_pyside6.svg
+.. |310-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Linux_3.10_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |311-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Linux_3.11_pyqt5.svg
+.. |311-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Linux_3.11_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |311-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Linux_3.11_pyqt6.svg
+.. |311-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Linux_3.11_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |311-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Linux_3.11_pyside6.svg
+.. |311-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Linux_3.11_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |312-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Linux_3.12_pyqt5.svg
+.. |312-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Linux_3.12_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |312-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Linux_3.12_pyqt6.svg
+.. |312-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Linux_3.12_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |312-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Linux_3.12_pyside6.svg
+.. |312-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Linux_3.12_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |313-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Linux_3.13_pyqt5.svg
+.. |313-linux-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Linux_3.13_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |313-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Linux_3.13_pyqt6.svg
+.. |313-linux-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Linux_3.13_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |313-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Linux_3.13_pyside6.svg
+.. |313-linux-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Linux_3.13_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 +-------------+---------------------+---------------------+-----------------------+
@@ -83,40 +82,40 @@ PyMoDAQ GUI
 +-------------+---------------------+---------------------+-----------------------+
 
 
-.. |310-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Windows_3.10_pyqt5.svg
+.. |310-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Windows_3.10_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |310-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Windows_3.10_pyqt6.svg
+.. |310-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Windows_3.10_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |310-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Windows_3.10_pyside6.svg
+.. |310-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Windows_3.10_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |311-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Windows_3.11_pyqt5.svg
+.. |311-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Windows_3.11_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |311-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Windows_3.11_pyqt6.svg
+.. |311-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Windows_3.11_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |311-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Windows_3.11_pyside6.svg
+.. |311-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Windows_3.11_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |312-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Windows_3.12_pyqt5.svg
+.. |312-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Windows_3.12_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |312-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Windows_3.12_pyqt6.svg
+.. |312-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Windows_3.12_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |312-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Windows_3.12_pyside6.svg
+.. |312-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Windows_3.12_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |313-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Windows_3.13_pyqt5.svg
+.. |313-windows-pyqt5| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Windows_3.13_pyqt5.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |313-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Windows_3.13_pyqt6.svg
+.. |313-windows-pyqt6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Windows_3.13_pyqt6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
-.. |313-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/malik-irain-patch-2/tests_Windows_3.13_pyside6.svg
+.. |313-windows-pyside6| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_gui/dev/tests_Windows_3.13_pyside6.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-gui.yml
 
 .. figure:: http://pymodaq.cnrs.fr/en/latest/_static/splash.png

--- a/packages/pymodaq_utils/README.rst
+++ b/packages/pymodaq_utils/README.rst
@@ -11,11 +11,11 @@ PyMoDAQ Utils
    :target: https://pypi.org/project/pymodaq_utils/
    :alt: Latest Version
 
-.. image:: https://readthedocs.org/projects/pymodaq/badge/?version=malik-irain-patch-2
-   :target: https://pymodaq.readthedocs.io/en/stable/?badge=malik-irain-patch-2
+.. image:: https://readthedocs.org/projects/pymodaq/badge/?version=dev
+   :target: https://pymodaq.readthedocs.io/en/stable/?badge=dev
    :alt: Documentation Status
 
-.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/branch/malik-irain-patch-2/graph/badge.svg?token=IQNJRCQDM2 
+.. image:: https://codecov.io/gh/PyMoDAQ/PyMoDAQ/branch/dev/graph/badge.svg?token=IQNJRCQDM2 
  :target: https://codecov.io/gh/PyMoDAQ/PyMoDAQ
 
 +-------------+-------------+---------------+
@@ -34,28 +34,28 @@ PyMoDAQ Utils
 
 
 
-.. |310-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/malik-irain-patch-2/tests_Linux_3.10.svg
+.. |310-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/dev/tests_Linux_3.10.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
-.. |311-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/malik-irain-patch-2/tests_Linux_3.11.svg
+.. |311-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/dev/tests_Linux_3.11.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
-.. |312-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/malik-irain-patch-2/tests_Linux_3.12.svg
+.. |312-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/dev/tests_Linux_3.12.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
-.. |313-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/malik-irain-patch-2/tests_Linux_3.13.svg
+.. |313-linux| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/dev/tests_Linux_3.13.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
-.. |310-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/malik-irain-patch-2/tests_Windows_3.10.svg
+.. |310-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/dev/tests_Windows_3.10.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
-.. |311-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/malik-irain-patch-2/tests_Windows_3.11.svg
+.. |311-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/dev/tests_Windows_3.11.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
-.. |312-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/malik-irain-patch-2/tests_Windows_3.12.svg
+.. |312-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/dev/tests_Windows_3.12.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
-.. |313-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/malik-irain-patch-2/tests_Windows_3.13.svg
+.. |313-windows| image:: https://raw.githubusercontent.com/PyMoDAQ/PyMoDAQ/badges/pymodaq_utils/dev/tests_Windows_3.13.svg
     :target: https://github.com/PyMoDAQ/PyMoDAQ/actions/workflows/tests-utils.yml
 
 


### PR DESCRIPTION
The live averaging reset when clicking on "stop": before we needed to click live averaging twice.