### PR TITLE
UX: Feature/highlight manager entry

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -16,7 +16,7 @@ from pymodaq_utils.enums import StrEnum
 from pymodaq_gui.messenger import dialog
 from pymodaq_gui.qt_utils import center_widget_on_screen_and_show, mkQApp
 from pymodaq_gui.utils.splash import get_pymodaq_pixmap
-from pymodaq_gui.utils.widgets.combo import ComboBox
+from pymodaq_gui.utils.widgets.highlighted_combo import HighlightedComboBox as ComboBox
 
 from pymodaq_gui.utils.widget_sync import WidgetSync, SyncMode
 
@@ -134,6 +134,7 @@ class ManagerBase(CustomExt):
                 'items': [],
                 'current': None,
                 'enabled': False,
+                'highlighted': None
         })
 
         self.setup_ui()
@@ -312,13 +313,19 @@ class ManagerBase(CustomExt):
         self.affect_to(ManagerActions.OPEN, toolbar)
         self.affect_to(ManagerActions.OPEN, menu)
 
-        self.add_widget(ManagerActions.LIST_EXTERNAL, ComboBox(), toolbar=toolbar,
+        external_combo = ComboBox()
+        self.add_widget(ManagerActions.LIST_EXTERNAL, external_combo, toolbar=toolbar,
                         tip=f'List of possible {self.entry_type}s')
         self.sync_entries_with(self.get_action(ManagerActions.LIST_EXTERNAL).widget)
         self.affect_to(ManagerActions.EXECUTE, toolbar)
         return toolbar, menu
 
+    def update_highlighted_item(self, item: str):
+        self.entries_sync.update_key('highlighted', item, force_emit=True)
+
     def connect_things_base(self):
+        self.applied_entry.connect(self.update_highlighted_item)
+
         self.connect_action(ManagerActions.COPY, lambda: self.copy_entry())
         self.connect_action(ManagerActions.NEW, lambda: self.create_entry())
         self.connect_action(ManagerActions.DELETE, lambda: self.delete_entry())
@@ -353,6 +360,10 @@ class ManagerBase(CustomExt):
                     'setter': combo.setEnabled,
                     'mode': SyncMode.BIDIRECTIONAL,
                 },
+                'highlighted': {
+                    'setter': combo.set_highlighted_item,
+                    'mode': SyncMode.FROM_SYNC
+                }
             },
         )
 

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -258,7 +258,8 @@ class ManagerBase(CustomExt):
         # self.add_widget('entry_label', QtWidgets.QLabel(
         #     f'{self.entry_type.capitalize()}:'))
         self.add_widget(ManagerActions.LIST, ComboBox(),
-                        tip=f'Name of the current {self.entry_type}',
+                        tip=f'List of possible {self.entry_type}s, '
+                            f'in green the one currently activated',
                         kwargs={'setReadOnly': True})
         self.get_action_list().addItems(self.entries)
 
@@ -315,13 +316,14 @@ class ManagerBase(CustomExt):
 
         external_combo = ComboBox()
         self.add_widget(ManagerActions.LIST_EXTERNAL, external_combo, toolbar=toolbar,
-                        tip=f'List of possible {self.entry_type}s')
+                        tip=f'List of possible {self.entry_type}s, '
+                            f'in green the one currently activated',)
         self.sync_entries_with(self.get_action(ManagerActions.LIST_EXTERNAL).widget)
         self.affect_to(ManagerActions.EXECUTE, toolbar)
         return toolbar, menu
 
     def update_highlighted_item(self, item: str):
-        self.entries_sync.update_key('highlighted', item, force_emit=True)
+        self.entries_sync.update_key('highlighted', item)
 
     def connect_things_base(self):
         self.applied_entry.connect(self.update_highlighted_item)

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/highlighted_combo.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/highlighted_combo.py
@@ -51,9 +51,12 @@ class HighlightedComboBox(ComboBox):
 
         self.setModel(ComboModel(parent=self))
         self.currentIndexChanged.connect(self.set_style)
-        self.currentTextChanged.connect(self.set_style)
 
         self._activated_color = get_theme().green
+
+    def setCurrentText(self, text: str):
+        super().setCurrentText(text)
+        self.set_style(self.get_items().index(text))
 
     @property
     def activated_color(self):
@@ -89,7 +92,7 @@ class HighlightedComboBox(ComboBox):
         return self.combo_model().highlighted_index
 
     def set_style(self, index: int = None):
-        if index is None or isinstance(index, str):
+        if index is None:
             index = self.currentIndex()
         if self.highlighted_index == index:
             self.setStyleSheet(

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/highlighted_combo.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/highlighted_combo.py
@@ -17,6 +17,9 @@ class ComboModel(QtCore.QAbstractListModel):
     def set_data(self, data: list[str]):
         self._data = data
 
+    def get_data(self) -> list[str]:
+        return self._data
+
     def set_highlighted_index(self, index: int):
         self.highlighted_index = index
 
@@ -48,6 +51,7 @@ class HighlightedComboBox(ComboBox):
 
         self.setModel(ComboModel(parent=self))
         self.currentIndexChanged.connect(self.set_style)
+        self.currentTextChanged.connect(self.set_style)
 
         self._activated_color = get_theme().green
 
@@ -72,13 +76,20 @@ class HighlightedComboBox(ComboBox):
     def set_highlighted_index(self, index: int):
         self.combo_model().set_highlighted_index(index)
         self.currentIndexChanged.emit(self.currentIndex())
+        self.set_style(self.currentIndex())
+
+    def set_highlighted_item(self, item: str):
+        try:
+            self.set_highlighted_index(self.get_items().index(item))
+        except ValueError:
+            pass
 
     @property
     def highlighted_index(self) -> int:
         return self.combo_model().highlighted_index
 
     def set_style(self, index: int = None):
-        if index is None:
+        if index is None or isinstance(index, str):
             index = self.currentIndex()
         if self.highlighted_index == index:
             self.setStyleSheet(


### PR DESCRIPTION
In this PR, I added the highlighting of the entry of the manager that is currently being activated

When nothing is activated, it looks as usual

but it looks like this when BeamSteering experiment is active:

<img width="1248" height="665" alt="image" src="https://github.com/user-attachments/assets/6c9323aa-866d-4391-a5c8-3a5afd1081c0" />

and like this again if another experiment is selected but not yet activated:
<img width="1122" height="683" alt="image" src="https://github.com/user-attachments/assets/a221977c-5dce-4b0b-b68e-0f9a49917f77" />

This is valid for all Managers inheriting from ManagerBase !!

I'm not hundred percent satisfied but styling combobox is tricky...