### PR TITLE
Feature/adding viewer config to config gui

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer0D.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer0D.py
@@ -7,6 +7,7 @@ import sys
 import pyqtgraph
 
 from pymodaq_utils import utils
+from pymodaq_utils.config import GlobalConfig as Config
 from pymodaq_data import data as data_mod
 from pymodaq_data.plotting.utils import PlotColors
 from pymodaq_utils.logger import set_logger, get_module_name
@@ -201,8 +202,6 @@ class View0D(ActionManager, QObject):
         if not show_toolbar:
             self.splitter.setSizes([0,1])
 
-        self.get_action('Nhistory').setValue(200)  #default history length
-
     def setup_actions(self):
         self.add_action('clear', 'Clear plot', 'clear2', 'Clear the current plots')
         self.add_widget('Nhistory', pyqtgraph.SpinBox, tip='Set the history length of the plot',
@@ -246,7 +245,13 @@ class View0D(ActionManager, QObject):
     def _prepare_ui(self):
         """add here everything needed at startup"""
         self.values_list.setVisible(False)
-        self.get_action('sync_x_axis').setChecked(True)
+        config = Config()
+        self.get_action('Nhistory').setValue(config('gui', 'viewer', 'viewer0D', 'Nhistory'))
+        for action_name in ('show_data_as_list', 'show_min_max'):
+            if config('gui', 'viewer', 'viewer0D', action_name):
+                self.get_action(action_name).trigger()
+        if not config('gui', 'viewer', 'viewer0D', 'sync_x_axis'):
+            self.get_action('sync_x_axis').trigger()
 
     def get_double_clicked(self):
         return self.plot_widget.view.sig_double_clicked

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer1D.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer1D.py
@@ -11,6 +11,7 @@ import numpy as np
 import pymodaq_data.plotting.utils
 from pymodaq_data.data import DataRaw, DataFromRoi, Axis, DataToExport, DataCalculated, DataWithAxes
 from pymodaq_utils.logger import set_logger, get_module_name
+from pymodaq_utils.config import GlobalConfig as Config
 from pymodaq_gui.parameter import utils as putils
 from pymodaq_gui.plotting.items.crosshair import Crosshair
 from pymodaq_utils import utils
@@ -374,6 +375,11 @@ class View1D(ActionManager, QObject):
 
     def prepare_ui(self):
         self.show_hide_crosshair(False)
+        config = Config()
+        for action_name in ('do_math', 'crosshair', 'aspect_ratio', 'scatter',
+                            'overlay', 'errors', 'sort', 'ROIselect'):
+            if config('gui', 'viewer', 'viewer1D', action_name):
+                self.get_action(action_name).trigger()
 
     def do_math(self):
         try:

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer2D.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer2D.py
@@ -12,6 +12,7 @@ from pyqtgraph.graphicsItems.GradientEditorItem import Gradients
 from pyqtgraph import ROI as pgROI
 
 from pymodaq_utils import utils
+from pymodaq_utils.config import GlobalConfig as Config
 from pymodaq_utils.logger import set_logger, get_module_name
 
 from pymodaq_data.data import (Axis, DataToExport, DataFromRoi, DataRaw,
@@ -537,6 +538,14 @@ class View2D(ActionManager, QtCore.QObject):
         self.ROIselect.setVisible(False)
         self.show_hide_crosshair(False)
         self.show_lineout_widgets()
+        config = Config()
+        for action_name in ('autolevels', 'auto_levels_sym', 'histo', 'roi', 'isocurve',
+                            'crosshair', 'ROIselect', 'flip_ud', 'flip_lr', 'rotate',
+                            'opposite', 'legend'):
+            if config('gui', 'viewer', 'viewer2D', action_name):
+                self.get_action(action_name).trigger()
+        if not config('gui', 'viewer', 'viewer2D', 'aspect_ratio'):
+            self.get_action('aspect_ratio').trigger()
 
     @Slot(DataRaw)
     def display_images(self, datas):

--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewerND.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewerND.py
@@ -15,6 +15,7 @@ from qtpy import QtWidgets
 from qtpy.QtCore import QObject, Slot, Signal, QRectF, QPointF
 
 from pymodaq_utils.logger import set_logger, get_module_name
+from pymodaq_utils.config import GlobalConfig as Config
 from pymodaq_gui.utils.dock import DockArea, Dock
 from pymodaq_gui.plotting.data_viewers.viewer1D import Viewer1D
 from pymodaq_gui.plotting.utils.axes_viewer import AxesViewer
@@ -709,6 +710,10 @@ class ViewerND(ParameterManager, ActionManager, ViewerBase):
         self.viewer2D.setVisible(False)
         self.navigator1D.setVisible(False)
         self.viewer2D.setVisible(False)
+        config = Config()
+        for action_name in ('setaxes', 'integrate_nav'):
+            if config('gui', 'viewer', 'viewerND', action_name):
+                self.get_action(action_name).trigger()
 
     def setup_actions(self):
         self.add_action('setaxes', icon_name='cartesian', checkable=True, tip='Change navigation/signal axes')

--- a/packages/pymodaq_gui/src/pymodaq_gui/resources/config_template.toml
+++ b/packages/pymodaq_gui/src/pymodaq_gui/resources/config_template.toml
@@ -29,3 +29,40 @@ country = "UnitedStates"
     size = [40, 20]  # pymodaq uses the first elt in config
     style = ['rounded']  # pymodaq uses the first elt in config
 
+[viewer]
+
+    [viewer.viewer0D]
+    show_data_as_list = false  # display last values as numbers in a side panel
+    show_min_max = false       # display horizontal dashed lines for min/max of each channel
+    sync_x_axis = true         # adding a new channel resets all histories so curves share the same x-axis origin
+    Nhistory = 200             # number of samples kept in the plot history
+
+    [viewer.viewer1D]
+    do_math = false     # enable ROI-based math operations
+    crosshair = false   # show data cursor
+    aspect_ratio = false  # fix the aspect ratio to 1:1
+    scatter = false     # switch to scatter plot instead of line plot
+    overlay = false     # plot overlays of current data
+    errors = false      # plot boundaries (error bars) of the data
+    sort = false        # display data sorted along the axis
+    ROIselect = false   # show the ROI selection area
+
+    [viewer.viewer2D]
+    autolevels = false      # auto-scale histogram to min/max intensity
+    auto_levels_sym = false # make auto-scale symmetric around 0
+    histo = false           # show the histogram panel
+    roi = false             # show the ROI manager
+    isocurve = false        # show iso-curve overlay
+    aspect_ratio = true     # fix the image aspect ratio
+    crosshair = false       # show the data crosshair
+    ROIselect = false       # show the rectangular ROI selection area
+    flip_ud = false         # flip the image up/down
+    flip_lr = false         # flip the image left/right
+    rotate = false          # rotate the image 90°
+    opposite = false        # display the opposite (negated) image
+    legend = false          # show the channel legend
+
+    [viewer.viewerND]
+    setaxes = false       # open the navigation/signal axes configuration panel
+    integrate_nav = false # integrate over the navigation axes
+


### PR DESCRIPTION
# Add viewer UI defaults to config

This PR exposes viewer toolbar/action defaults in the global config file, allowing users to persist their preferred viewer state across sessions.

Changes:
- Added a [viewer] section to config_template.toml covering viewer0D, viewer1D, viewer2D, and viewerND, with one entry per configurable toolbar action and a comment explaining each
- On startup, each viewer now reads its config section and triggers the appropriate actions to match stored defaults (replacing the previous hardcoded defaults)

How to test:
1. Open ~/.pymodaq/config.toml and set e.g. [viewer.viewer2D] histo = true
2. Open a Viewer2D — the histogram panel should be visible by default