### PR TITLE
Hotifx/double_entry_in_logger

### DIFF
--- a/packages/pymodaq_utils/src/pymodaq_utils/logger.py
+++ b/packages/pymodaq_utils/src/pymodaq_utils/logger.py
@@ -48,7 +48,7 @@ def set_logger(logger_name, add_handler=False, base_logger=False, add_to_console
             sys.exit(-1)
         log_level = log_level[0]
     logger.setLevel(log_level)
-    if add_handler:
+    if add_handler and not logger.handlers:
         try:
             log_path = get_set_config_dir('log', user=True)
             log_file_path = log_path.joinpath(f'{logger_base_name}.log')


### PR DESCRIPTION
There is a bug in pymodaq_utils/src/pymodaq_utils/logger.py leading to duplicate entries with pymodaq.

The underlying pattern is:
- pymodaq/__init__.py import pymodaq_utils
- pymodaq_utils/__init__.py → set_logger('pymodaq', add_handler=True) → 1st handler
- pymodaq/__init__.py → set_logger('pymodaq', add_handler=True) → 2nd handler 

Updating ` if add_handler: → if add_handler and not logger.handlers:.`


