### PR TITLE
fix(dashboard): preserve startup visibility

### DIFF
--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -1440,8 +1440,8 @@ def main():
     else:
         win, dashboard = create_load_dashboard()
 
-    win.show()
-
+    # SharedUI shows the dashboard on creation; preserve visibility changes
+    # made while loading.
     # Run application
     sys.exit(app.exec())
 

--- a/packages/pymodaq/tests/dashboard_test.py
+++ b/packages/pymodaq/tests/dashboard_test.py
@@ -1,6 +1,10 @@
+import sys
+
+import pymodaq.dashboard as dashboard_module
+from pymodaq_gui import qt_utils
 from pymodaq.utils.config import get_set_experiment_path
 from pymodaq_utils.config import GlobalConfig
-from pytest import fixture, mark
+from pytest import fixture, raises
 from pymodaq.dashboard import create_load_dashboard
 
 import qt_themes
@@ -26,3 +30,39 @@ class TestGeneral:
         dashboard.experiment_manager.execute_entry()
 
         dashboard.quit_fun()
+
+    def test_main_preserves_dashboard_visibility_after_loading(
+        self, init_qt, monkeypatch
+    ):
+        qtbot = init_qt
+        shared_ui, dashboard = create_load_dashboard()
+        qtbot.addWidget(shared_ui.mainwindow)
+
+        class ApplicationStub:
+            @staticmethod
+            def exec():
+                return 0
+
+        try:
+            assert shared_ui.mainwindow.isVisible()
+            shared_ui.hide()
+
+            monkeypatch.setattr(
+                sys, 'argv', ['dashboard', '--experiment', 'test']
+            )
+            monkeypatch.setattr(
+                qt_utils, 'mkQApp', lambda _: ApplicationStub()
+            )
+            monkeypatch.setattr(
+                dashboard_module,
+                'load_dashboard_with_experiment',
+                lambda **_: (dashboard, None, shared_ui),
+            )
+
+            with raises(SystemExit) as exit_info:
+                dashboard_module.main()
+
+            assert exit_info.value.code == 0
+            assert not shared_ui.mainwindow.isVisible()
+        finally:
+            dashboard.quit_fun()


### PR DESCRIPTION
## Summary

- preserve dashboard visibility selected while an experiment and extension are loading
- remove the redundant final `show()` now that `SharedUI` shows the dashboard during creation
- add a regression test covering a dashboard hidden during startup

## Root cause

`CustomExt.show_dashboard(False)` correctly hid the dashboard during extension setup, but `dashboard.main()` later called `win.show()` unconditionally. That reopened and activated the dashboard in front of the extension. The same call worked after startup because there was no later show to override it.

## Verification

- regression test failed before the fix and passed afterward
- focused dashboard and extension tests: 9 passed
- full `packages/pymodaq/tests` suite with Python 3.13.2 and PyQt6: 288 passed
- CI fatal-error flake8 selection: 0 findings
- Pyright on the new regression test: 0 errors

Closes #1132

The redundant call is also present on `dev`; this fix should be forward-ported there after the stable-branch approach is accepted.