### PR TITLE
Bugfix/shared UI visibility

### DIFF
--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -1453,8 +1453,8 @@ def main():
     else:
         win, dashboard = create_load_dashboard()
 
-    win.show()
-
+    # SharedUI shows the dashboard on creation; preserve visibility changes
+    # made while loading.
     # Run application
     sys.exit(app.exec())
 

--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -1356,12 +1356,12 @@ class DashBoard(CustomApp, LECOComponentMixin):
         logger.info(txt)
 
 
-def create_load_dashboard() -> tuple[SharedUI, DashBoard]:
+def create_load_dashboard(show_dashboard=True) -> tuple[SharedUI, DashBoard]:
 
     win, area = make_window(title='PyMoDAQ Dashboard')
     win.resize(1000, 500)
 
-    shared_ui = SharedUI(win)
+    shared_ui = SharedUI(win, show=show_dashboard)
     dashboard = DashBoard(area)
     shared_ui.affect_application(dashboard)
     return shared_ui, dashboard

--- a/packages/pymodaq/src/pymodaq/extensions/adaptive_optim/adaptive_optimization.py
+++ b/packages/pymodaq/src/pymodaq/extensions/adaptive_optim/adaptive_optimization.py
@@ -170,11 +170,8 @@ def main():
 
     app = mkQApp('Adaptive Optimizer')
 
-    win, dashboard = create_load_dashboard()
-    win.mainwindow.setVisible(False)
-
-    win_ext, scan = create_extension(dashboard, AdaptiveOptimisation)
-    win_ext.show()
+    win, dashboard = create_load_dashboard(show_dashboard=False)
+    win_ext, scan = create_extension(dashboard, AdaptiveOptimisation, show_extension=True)
 
     sys.exit(app.exec())
 

--- a/packages/pymodaq/src/pymodaq/extensions/bayesian/bayesian_optimization.py
+++ b/packages/pymodaq/src/pymodaq/extensions/bayesian/bayesian_optimization.py
@@ -129,11 +129,8 @@ def main():
 
     app = mkQApp('Bayesian Optimizer')
 
-    win, dashboard = create_load_dashboard()
-    win.mainwindow.setVisible(False)
-
-    win_ext, scan = create_extension(dashboard, BayesianOptimization)
-    win_ext.show()
+    win, dashboard = create_load_dashboard(show_dashboard=False)
+    win_ext, scan = create_extension(dashboard, BayesianOptimization, show_extension=True)
 
     sys.exit(app.exec())
 

--- a/packages/pymodaq/src/pymodaq/extensions/console.py
+++ b/packages/pymodaq/src/pymodaq/extensions/console.py
@@ -110,11 +110,10 @@ def main():
 
     app = mkQApp('Console')
 
-    win, dashboard = create_load_dashboard()
-    win.mainwindow.setVisible(False)
+    win, dashboard = create_load_dashboard(show_dashboard=False)
 
-    win_ext, console = create_extension(dashboard, Console)
-    win_ext.show()
+    win_ext, console = create_extension(dashboard, Console,
+                                        show_extension=True)
 
     sys.exit(app.exec())
 

--- a/packages/pymodaq/src/pymodaq/extensions/daq_logger/daq_logger.py
+++ b/packages/pymodaq/src/pymodaq/extensions/daq_logger/daq_logger.py
@@ -501,12 +501,8 @@ def main():
 
     app = mkQApp('DAQ Logger')
 
-    win, dashboard = create_load_dashboard()
-    win.mainwindow.setVisible(False)
-
-    win_ext, logger = create_extension(dashboard, DAQ_Logger)
-    win_ext.show()
-
+    win, dashboard = create_load_dashboard(show_dashboard=False)
+    win_ext, logger = create_extension(dashboard, DAQ_Logger, show_extension=True)
     sys.exit(app.exec())
 
 

--- a/packages/pymodaq/src/pymodaq/extensions/data_mixer/data_mixer.py
+++ b/packages/pymodaq/src/pymodaq/extensions/data_mixer/data_mixer.py
@@ -233,12 +233,8 @@ def main():
 
     app = mkQApp('Data Mixer')
 
-    win, dashboard = create_load_dashboard()
-    win.mainwindow.setVisible(False)
-
-    win_ext, data_mixer = create_extension(dashboard, DataMixer)
-    win_ext.show()
-
+    win, dashboard = create_load_dashboard(show_dashboard=False)
+    win_ext, data_mixer = create_extension(dashboard, DataMixer, show_extension=True)
     sys.exit(app.exec())
 
 

--- a/packages/pymodaq/src/pymodaq/extensions/pid/pid_controller.py
+++ b/packages/pymodaq/src/pymodaq/extensions/pid/pid_controller.py
@@ -977,10 +977,9 @@ if __name__ == "__main__":
 
     app = mkQApp("DAQ_PID")
 
-    win, dashboard = create_load_dashboard()
-    win.mainwindow.setVisible(False)
+    win, dashboard = create_load_dashboard(show_dashboard=False)
 
-    win_ext, scan = create_extension(dashboard, DAQ_PID)
-    win_ext.show()
+    win_ext, scan = create_extension(dashboard, DAQ_PID,
+                                     show_extension=True)
 
     sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan.py
+++ b/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan.py
@@ -1476,14 +1476,10 @@ def main():
 
     app = mkQApp('DAQScan')
 
-    win, dashboard = create_load_dashboard()
-    win.mainwindow.setVisible(False)
+    win, dashboard = create_load_dashboard(show_dashboard=False)
 
-    win_ext, scan = create_extension(dashboard, DAQScan)
-    win_ext.show()
-
-    # preset_file_name = config("pymodaq", "presets", "default_preset_for_scan")
-    # dashboard.preset_manager.execute_entry(preset_file_name)
+    win_ext, scan = create_extension(dashboard, DAQScan,
+                                     show_extension=True)
 
     sys.exit(app.exec())
 

--- a/packages/pymodaq/src/pymodaq/launcher/launcher.py
+++ b/packages/pymodaq/src/pymodaq/launcher/launcher.py
@@ -543,14 +543,11 @@ def main():
     win = QtWidgets.QMainWindow()
     win.setWindowTitle('Launcher')
 
-    shared_ui = SharedUI(win)
+    shared_ui = SharedUI(win, show=True)
     prog = Launcher(win)
     shared_ui.affect_application(prog)
 
     win.resize(850, 450)
-
-    win.show()
-
     sys.exit(app.exec())
 
 

--- a/packages/pymodaq/src/pymodaq/utils/gui_utils/loader_utils.py
+++ b/packages/pymodaq/src/pymodaq/utils/gui_utils/loader_utils.py
@@ -84,6 +84,7 @@ def create_extension(dashboard: 'DashBoard',
                      *ext_args,
                      window: QtWidgets.QMainWindow = None,
                      add_toolbarbreak=True,
+                     show_extension=True,
                      **ext_kwargs) -> tuple[SharedUI, CustomExt]:
 
     from pymodaq_gui.utils.dock import DockArea
@@ -95,7 +96,7 @@ def create_extension(dashboard: 'DashBoard',
         dockarea = DockArea()
         window.setCentralWidget(dockarea)
 
-    shared_ui = SharedUI(window)
+    shared_ui = SharedUI(window, show=show_extension)
     extension = extension_class(dockarea, dashboard, *ext_args, **ext_kwargs)
 
     shared_ui.affect_application(extension)

--- a/packages/pymodaq/tests/dashboard_test.py
+++ b/packages/pymodaq/tests/dashboard_test.py
@@ -1,6 +1,10 @@
+import sys
+
+import pymodaq.dashboard as dashboard_module
+from pymodaq_gui import qt_utils
 from pymodaq.utils.config import get_set_experiment_path
 from pymodaq_utils.config import GlobalConfig
-from pytest import fixture, mark
+from pytest import fixture, raises
 from pymodaq.dashboard import create_load_dashboard
 
 import qt_themes
@@ -26,3 +30,39 @@ class TestGeneral:
         dashboard.experiment_manager.execute_entry()
 
         dashboard.quit_fun()
+
+    def test_main_preserves_dashboard_visibility_after_loading(
+        self, init_qt, monkeypatch
+    ):
+        qtbot = init_qt
+        shared_ui, dashboard = create_load_dashboard()
+        qtbot.addWidget(shared_ui.mainwindow)
+
+        class ApplicationStub:
+            @staticmethod
+            def exec():
+                return 0
+
+        try:
+            assert shared_ui.mainwindow.isVisible()
+            shared_ui.hide()
+
+            monkeypatch.setattr(
+                sys, 'argv', ['dashboard', '--experiment', 'test']
+            )
+            monkeypatch.setattr(
+                qt_utils, 'mkQApp', lambda _: ApplicationStub()
+            )
+            monkeypatch.setattr(
+                dashboard_module,
+                'load_dashboard_with_experiment',
+                lambda **_: (dashboard, None, shared_ui),
+            )
+
+            with raises(SystemExit) as exit_info:
+                dashboard_module.main()
+
+            assert exit_info.value.code == 0
+            assert not shared_ui.mainwindow.isVisible()
+        finally:
+            dashboard.quit_fun()


### PR DESCRIPTION
Add specific keywords to create_dashboard and create_extension method to explicitly show or hide their window at startup.

Applied to all builtin extension main methods