### PR TITLE
Hotfix/daq type detector backcompat

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
@@ -210,19 +210,6 @@ class DAQ_Viewer(ParameterControlModule):
         return self.viewer_docks
 
     @property
-    def daq_type(self) -> DAQTypesEnum:
-        """Get/Set the daq_type as a DAQTypesEnum
-
-        Update the detector property with the list of available detectors of a given daq_type
-        """
-        return self.detector.daq_type
-
-    @property
-    def daq_types(self) -> List[str]:
-        """List of available DAQ_TYPES as keys of the DAQTypesEnum"""
-        return DAQTypesEnum.names()
-
-    @property
     def grab_state(self):
         """:obj:`bool`: Get the current grabbing status"""
         return self._grabing
@@ -287,6 +274,24 @@ class DAQ_Viewer(ParameterControlModule):
         if self.ui is not None:
             self.ui.detector = det
         self._reload_plugin_settings()
+
+    @property
+    def daq_type(self) -> DAQTypesEnum:
+        """Get/Set the daq_type as a DAQTypesEnum
+
+        Update the detector property with the list of available detectors of a given daq_type
+        """
+        return self.detector.daq_type
+
+    @daq_type.setter
+    def daq_type(self, daq_type: DAQTypesEnum | str):
+        daq_type = enum_checker(DAQTypesEnum, daq_type)
+        self.detector = SelectedModule(daq_type=daq_type)
+
+    @property
+    def daq_types(self) -> List[str]:
+        """List of available DAQ_TYPES as keys of the DAQTypesEnum"""
+        return DAQTypesEnum.names()
 
     @property
     def current_data(self) -> DataToExport:

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
@@ -117,7 +117,7 @@ class DAQ_Viewer(ParameterControlModule):
         self,
         parent: Optional[QtWidgets.QWidget] = None,
         title: str = "Testing",
-        daq_type=config("pymodaq", "viewer", "daq_type"),
+        daq_type = config("pymodaq", "viewer", "daq_type"),
         **kwargs,
     ):
 
@@ -268,7 +268,9 @@ class DAQ_Viewer(ParameterControlModule):
         return self._detector
 
     @detector.setter
-    def detector(self, det: SelectedModule):
+    def detector(self, det: SelectedModule | str):
+        if isinstance(det, str):
+            det = SelectedModule(self._detector.daq_type, det)
         self._detector = det
         self.update_plugin_config()
         if self.ui is not None:

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer_ui/viewer_selector.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer_ui/viewer_selector.py
@@ -4,6 +4,7 @@ from qtpy import QtCore
 from pymodaq.control_modules.instruments import DAQTypesEnum
 from ..control_module_selector import ModuleSelector
 
+
 @dataclass
 class SelectedModule:
     daq_type: DAQTypesEnum = field(default_factory=lambda: DAQTypesEnum.DAQ0D)
@@ -16,6 +17,7 @@ class SelectedModule:
 
     def __repr__(self):
         return f'{self.daq_type.name}/{self.module_name}'
+
 
 class ViewerSelector(ModuleSelector):
 

--- a/packages/pymodaq/tests/control_modules/daq_viewer_test.py
+++ b/packages/pymodaq/tests/control_modules/daq_viewer_test.py
@@ -86,7 +86,26 @@ class TestWithUI:
     def test_daq_type_changed(self, ini_daq_viewer_ui, daq_type):
         prog, qtbot, dockarea = ini_daq_viewer_ui
         with qtbot.waitSignal(prog.ui.command_sig) as blocker:
+            prog.daq_type = daq_type
+        assert len(prog.viewers) == 1
+        assert prog.viewers[0].viewer_type == f'Data{daq_type[3:]}'
+
+
+    @pytest.mark.parametrize("daq_type", DAQTypesEnum.names())
+    def test_detector_changed(self, ini_daq_viewer_ui, daq_type):
+        prog, qtbot, dockarea = ini_daq_viewer_ui
+        with qtbot.waitSignal(prog.ui.command_sig) as blocker:
             prog.detector = SelectedModule(DAQTypesEnum[daq_type], 'Mock')
         assert len(prog.viewers) == 1
         assert prog.viewers[0].viewer_type == f'Data{daq_type[3:]}'
 
+
+    @pytest.mark.parametrize("daq_type", DAQTypesEnum.names())
+    def test_detector_name_changed(self, ini_daq_viewer_ui, daq_type):
+        prog, qtbot, dockarea = ini_daq_viewer_ui
+        with qtbot.waitSignal(prog.ui.command_sig) as blocker:
+            prog.daq_type = daq_type
+        with qtbot.waitSignal(prog.ui.command_sig) as blocker:
+            prog.detector = 'Mock'
+        assert len(prog.viewers) == 1
+        assert prog.viewers[0].viewer_type == f'Data{daq_type[3:]}'


### PR DESCRIPTION
This PR closes #1131 by reimplementing a setter for the DAQ_Type and detector properties but based on the new SelectedModule class 