### PR TITLE
make sure to keep a ref to shared_ui when opening the H5Browser

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/h5modules/saving.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/h5modules/saving.py
@@ -655,7 +655,7 @@ class H5Saver(H5SaverBase, QObject):
             self.flush()
             self.analysis_prog = browsing.H5Browser(
                 win, h5file=self.h5file, backend=self.backend)
-        shared_ui = SharedUI(win)
-        shared_ui.affect_application(self.analysis_prog)
+        self.shared_ui = SharedUI(win)
+        self.shared_ui.affect_application(self.analysis_prog)
 
-        shared_ui.show()
+        self.shared_ui.show()


### PR DESCRIPTION
to make sure the shared ui action don't disapear