### PR TITLE
resize is interactive but resized to content dynamically

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/parameter_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/parameter_manager.py
@@ -278,8 +278,9 @@ class ParameterManager:
         )  # create a Parameter
         # object containing the settings defined in the preamble
         self._settings_tree.tree.header().setSectionResizeMode(
-            QtWidgets.QHeaderView.ResizeToContents,
+            QtWidgets.QHeaderView.Interactive,
         )
+        self._settings_tree.tree.resizeColumnToContents(0)
 
     @property
     def settings_tree(self) -> QtWidgets.QWidget:
@@ -318,6 +319,8 @@ class ParameterManager:
             self._settings, showTop=False,
         )  # load the tree with this parameter object
         self._settings.sigTreeStateChanged.connect(self.parameter_tree_changed)
+        self._settings_tree.tree.itemExpanded.connect(lambda: self._settings_tree.tree.resizeColumnToContents(0))
+        self._settings_tree.tree.itemCollapsed.connect(lambda: self._settings_tree.tree.resizeColumnToContents(0))
 
     @staticmethod
     def create_parameter(


### PR DESCRIPTION
At the moment a ParameterTree (from ParameterManager) has its header resize mode set to ResizeToContent. While it should be right, in fact the header doesn't stretch accordingly. Moreover, in this mode, the user cannot resize interactively...

In this PR, the mode is set to Interactive **BUT** the programm dynamically resize the columns to content when the tree is populated or when items are expanded or collapsed making all the titles in the first column visibles!