### PR TITLE
Feature/load extensions with command line arguments

### DIFF
--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -1356,6 +1356,42 @@ class DashBoard(CustomApp, LECOComponentMixin):
         logger.info(txt)
 
 
+def load_dashboard_with_arguments(show_dashboard=True):
+
+    extensions_names = ExtensionEnum.values()
+    # Command-line argument parsing
+    parser = argparse.ArgumentParser(prog="dashboard",
+                                     description="PyMoDAQ dashboard. "
+                                                 "Command-line options only affect GUI initial state.",
+                                     )
+
+    parser.add_argument("-x", "--experiment", metavar="EXPERIMENT_NAME",
+                        help="experiment name to load at startup")
+    parser.add_argument("-c", "--config", metavar="CONFIG_NAME",
+                        help="config name to execute (ignored if no experiment provided), deprecated, use -s for state")
+    parser.add_argument("-s", "--state", metavar="STATE_NAME",
+                        help="State name to execute (ignored if no experiment provided)")
+    parser.add_argument("-e", "--extension", metavar="EXTENSION_NAME",
+                        help="extension name to execute (ignored if no experiment provided), valid "
+                             'values are within: "' + '\" \"'.join(extensions_names) +'"')
+    args = parser.parse_args()
+
+    # If experiment name is supplied, load dashboard with this experiment
+    if args.experiment:
+        dashboard, extension, win = load_dashboard_with_experiment(
+            experiment_name=args.experiment,
+            extension_name=args.extension.upper() if args.extension is not None else args.extension,
+            state_name=args.state if args.state is not None else args.config,
+            show_dashboard=show_dashboard
+        )
+
+    # If no command-line arguments are supplied, start empty
+    else:
+        win, dashboard = create_load_dashboard(show_dashboard=show_dashboard)
+        extension = None
+    return win, dashboard, extension
+
+
 def create_load_dashboard(show_dashboard=True) -> tuple[SharedUI, DashBoard]:
 
     win, area = make_window(title='PyMoDAQ Dashboard')
@@ -1369,13 +1405,16 @@ def create_load_dashboard(show_dashboard=True) -> tuple[SharedUI, DashBoard]:
 
 def load_dashboard_with_experiment(experiment_name: str,
                                    extension_name: str = None,
-                                   configuration_name: str = None)  -> tuple[DashBoard, 'CustomExt', SharedUI]:
+                                   configuration_name: str = None,
+                                   state_name: str = None,
+                                   show_dashboard=True)  -> tuple[DashBoard, 'CustomExt', SharedUI]:
 
     """ Load the Dashboard using a given experiment then load an extension
 
     Parameters
     ----------
-    configuration_name: str
+    configuration_name: str (deprecated, use state)
+    state_name: str
     experiment_name: str
         The filename (without extension) defining the experiment to be loaded in the Dashboard
     extension_name: str
@@ -1386,13 +1425,14 @@ def load_dashboard_with_experiment(experiment_name: str,
         * 'Bayesian'
 
         or the ones defined within a plugin
-
+    show_dashboard: bool
+        show dashboard at startup  or not (if no extension provided, it is shown)
     Returns
     -------
 
     """
     from pymodaq.utils.config import get_set_experiment_path
-    shared_ui, dashboard = create_load_dashboard()
+    shared_ui, dashboard = create_load_dashboard(show_dashboard=show_dashboard if extension_name is not None else True)
 
     experiment_path = get_set_experiment_path().joinpath(f'{experiment_name}.xml')
     experiment_name = experiment_path.stem
@@ -1400,8 +1440,11 @@ def load_dashboard_with_experiment(experiment_name: str,
 
     if experiment_name in dashboard.experiment_manager.entries:
         dashboard.experiment_manager.entry = experiment_name
-        if configuration_name is not None:
-            dashboard.state_manager.entry = configuration_name
+        if state_name is None:
+            # backcompatibility
+            state_name = configuration_name
+        if state_name is not None:
+            dashboard.state_manager.entry = state_name
         dashboard.experiment_manager.execute_entry(experiment_path)
 
         if extension_name in ExtensionEnum.names():
@@ -1425,33 +1468,7 @@ def main():
     # Create application and main window
     app = mkQApp('Dashboard')
 
-    extensions_names = ExtensionEnum.values()
-    # Command-line argument parsing
-    parser = argparse.ArgumentParser(prog="dashboard",
-                                     description="PyMoDAQ dashboard. "
-                                                 "Command-line options only affect GUI initial state.",
-                                     )
-    parser.add_argument("-x", "--experiment", metavar="EXPERIMENT_NAME",
-                        help="experiment name to load at startup")
-    parser.add_argument("-c", "--config", metavar="CONFIG_NAME",
-                        help="config name to execute (ignored if no experiment provided)")
-    parser.add_argument("-e", "--extension", metavar="EXTENSION_NAME",
-                        help="extension name to execute (ignored if no experiment provided), valid "
-                             'values are within: "' + '\" \"'.join(extensions_names) +'"')
-    args = parser.parse_args()
-
-    # If experiment name is supplied, load dashboard with this experiment
-    if args.experiment:
-        dashboard, extension, win = load_dashboard_with_experiment(
-            experiment_name=args.experiment,
-            extension_name=args.extension.upper() if args.extension is not None else args.extension,
-            configuration_name=args.config
-        )
-
-
-    # If no command-line arguments are supplied, start empty
-    else:
-        win, dashboard = create_load_dashboard()
+    load_dashboard_with_arguments(show_dashboard=True)
 
     # SharedUI shows the dashboard on creation; preserve visibility changes
     # made while loading.

--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -1356,7 +1356,7 @@ class DashBoard(CustomApp, LECOComponentMixin):
         logger.info(txt)
 
 
-def load_dashboard_with_arguments(show_dashboard=True):
+def load_dashboard_with_arguments(show_dashboard=True, load_extension=True):
 
     extensions_names = ExtensionEnum.values()
     # Command-line argument parsing
@@ -1371,16 +1371,23 @@ def load_dashboard_with_arguments(show_dashboard=True):
                         help="config name to execute (ignored if no experiment provided), deprecated, use -s for state")
     parser.add_argument("-s", "--state", metavar="STATE_NAME",
                         help="State name to execute (ignored if no experiment provided)")
-    parser.add_argument("-e", "--extension", metavar="EXTENSION_NAME",
-                        help="extension name to execute (ignored if no experiment provided), valid "
-                             'values are within: "' + '\" \"'.join(extensions_names) +'"')
-    args = parser.parse_args()
+    if load_extension:
+        parser.add_argument("-e", "--extension", metavar="EXTENSION_NAME",
+                            help="extension name to execute (ignored if no experiment provided), valid "
+                                 'values are within: "' + '\" \"'.join(extensions_names) +'"')
+
+    args, unknown_args = parser.parse_known_args()
+
+    if load_extension:
+        extension_name = args.extension.upper() if args.extension is not None else args.extension
+    else:
+        extension_name = None
 
     # If experiment name is supplied, load dashboard with this experiment
     if args.experiment:
         dashboard, extension, win = load_dashboard_with_experiment(
             experiment_name=args.experiment,
-            extension_name=args.extension.upper() if args.extension is not None else args.extension,
+            extension_name=extension_name,
             state_name=args.state if args.state is not None else args.config,
             show_dashboard=show_dashboard
         )

--- a/packages/pymodaq/src/pymodaq/extensions/adaptive_optim/adaptive_optimization.py
+++ b/packages/pymodaq/src/pymodaq/extensions/adaptive_optim/adaptive_optimization.py
@@ -170,7 +170,9 @@ def main():
 
     app = mkQApp('Adaptive Optimizer')
 
-    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False,
+                                                      load_extension=False,
+                                                      )
     win.mainwindow.setVisible(False)
     win_ext, scan = create_extension(dashboard, AdaptiveOptimisation, show_extension=True)
 

--- a/packages/pymodaq/src/pymodaq/extensions/adaptive_optim/adaptive_optimization.py
+++ b/packages/pymodaq/src/pymodaq/extensions/adaptive_optim/adaptive_optimization.py
@@ -165,12 +165,13 @@ class AdaptiveOptimisation(GenericOptimization):
 def main():
     import sys
     from pymodaq_gui.qt_utils import mkQApp
-    from pymodaq.dashboard import create_load_dashboard
+    from pymodaq.dashboard import load_dashboard_with_arguments
     from pymodaq.utils.gui_utils.loader_utils import create_extension
 
     app = mkQApp('Adaptive Optimizer')
 
-    win, dashboard = create_load_dashboard(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win.mainwindow.setVisible(False)
     win_ext, scan = create_extension(dashboard, AdaptiveOptimisation, show_extension=True)
 
     sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/extensions/bayesian/bayesian_optimization.py
+++ b/packages/pymodaq/src/pymodaq/extensions/bayesian/bayesian_optimization.py
@@ -124,12 +124,13 @@ class BayesianOptimization(GenericOptimization):
 def main():
     import sys
     from pymodaq_gui.qt_utils import mkQApp
-    from pymodaq.dashboard import create_load_dashboard
+    from pymodaq.dashboard import load_dashboard_with_arguments
     from pymodaq.utils.gui_utils.loader_utils import create_extension
 
     app = mkQApp('Bayesian Optimizer')
 
-    win, dashboard = create_load_dashboard(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win.mainwindow.setVisible(False)
     win_ext, scan = create_extension(dashboard, BayesianOptimization, show_extension=True)
 
     sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/extensions/bayesian/bayesian_optimization.py
+++ b/packages/pymodaq/src/pymodaq/extensions/bayesian/bayesian_optimization.py
@@ -129,7 +129,9 @@ def main():
 
     app = mkQApp('Bayesian Optimizer')
 
-    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False,
+                                                      load_extension=False,
+                                                      )
     win.mainwindow.setVisible(False)
     win_ext, scan = create_extension(dashboard, BayesianOptimization, show_extension=True)
 

--- a/packages/pymodaq/src/pymodaq/extensions/console.py
+++ b/packages/pymodaq/src/pymodaq/extensions/console.py
@@ -110,7 +110,9 @@ def main():
 
     app = mkQApp('Console')
 
-    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False,
+                                                      load_extension=False,
+                                                      )
     win.mainwindow.setVisible(False)
 
     win_ext, console = create_extension(dashboard, Console,

--- a/packages/pymodaq/src/pymodaq/extensions/console.py
+++ b/packages/pymodaq/src/pymodaq/extensions/console.py
@@ -105,12 +105,13 @@ class Console(CustomExt):
 def main():
     import sys
     from pymodaq_gui.qt_utils import mkQApp
-    from pymodaq.dashboard import create_load_dashboard
+    from pymodaq.dashboard import load_dashboard_with_arguments
     from pymodaq.utils.gui_utils.loader_utils import create_extension
 
     app = mkQApp('Console')
 
-    win, dashboard = create_load_dashboard(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win.mainwindow.setVisible(False)
 
     win_ext, console = create_extension(dashboard, Console,
                                         show_extension=True)

--- a/packages/pymodaq/src/pymodaq/extensions/daq_logger/daq_logger.py
+++ b/packages/pymodaq/src/pymodaq/extensions/daq_logger/daq_logger.py
@@ -496,12 +496,13 @@ class DAQ_Logging(QObject):
 def main():
     import sys
     from pymodaq_gui.qt_utils import mkQApp
-    from pymodaq.dashboard import create_load_dashboard
+    from pymodaq.dashboard import load_dashboard_with_arguments
     from pymodaq.utils.gui_utils.loader_utils import create_extension
 
     app = mkQApp('DAQ Logger')
 
-    win, dashboard = create_load_dashboard(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win.mainwindow.setVisible(False)
     win_ext, logger = create_extension(dashboard, DAQ_Logger, show_extension=True)
     sys.exit(app.exec())
 

--- a/packages/pymodaq/src/pymodaq/extensions/daq_logger/daq_logger.py
+++ b/packages/pymodaq/src/pymodaq/extensions/daq_logger/daq_logger.py
@@ -501,7 +501,9 @@ def main():
 
     app = mkQApp('DAQ Logger')
 
-    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False,
+                                                      load_extension=False,
+                                                      )
     win.mainwindow.setVisible(False)
     win_ext, logger = create_extension(dashboard, DAQ_Logger, show_extension=True)
     sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/extensions/data_mixer/data_mixer.py
+++ b/packages/pymodaq/src/pymodaq/extensions/data_mixer/data_mixer.py
@@ -233,7 +233,9 @@ def main():
 
     app = mkQApp('Data Mixer')
 
-    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False,
+                                                      load_extension=False,
+                                                      )
     win.mainwindow.setVisible(False)
     win_ext, data_mixer = create_extension(dashboard, DataMixer, show_extension=True)
     sys.exit(app.exec())

--- a/packages/pymodaq/src/pymodaq/extensions/data_mixer/data_mixer.py
+++ b/packages/pymodaq/src/pymodaq/extensions/data_mixer/data_mixer.py
@@ -228,12 +228,13 @@ class DataMixer(CustomExt):
 def main():
     import sys
     from pymodaq_gui.qt_utils import mkQApp
-    from pymodaq.dashboard import create_load_dashboard
+    from pymodaq.dashboard import load_dashboard_with_arguments
     from pymodaq.utils.gui_utils.loader_utils import create_extension
 
     app = mkQApp('Data Mixer')
 
-    win, dashboard = create_load_dashboard(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win.mainwindow.setVisible(False)
     win_ext, data_mixer = create_extension(dashboard, DataMixer, show_extension=True)
     sys.exit(app.exec())
 

--- a/packages/pymodaq/src/pymodaq/extensions/pid/pid_controller.py
+++ b/packages/pymodaq/src/pymodaq/extensions/pid/pid_controller.py
@@ -977,7 +977,9 @@ if __name__ == "__main__":
 
     app = mkQApp("DAQ_PID")
 
-    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False,
+                                                      load_extension=False,
+                                                      )
     win.mainwindow.setVisible(False)
 
     win_ext, scan = create_extension(dashboard, DAQ_PID,

--- a/packages/pymodaq/src/pymodaq/extensions/pid/pid_controller.py
+++ b/packages/pymodaq/src/pymodaq/extensions/pid/pid_controller.py
@@ -972,12 +972,13 @@ class PIDRunner(QObject):
 if __name__ == "__main__":
     import sys
     from pymodaq_gui.qt_utils import mkQApp
-    from pymodaq.dashboard import create_load_dashboard
+    from pymodaq.dashboard import load_dashboard_with_arguments
     from pymodaq.utils.gui_utils.loader_utils import create_extension
 
     app = mkQApp("DAQ_PID")
 
-    win, dashboard = create_load_dashboard(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win.mainwindow.setVisible(False)
 
     win_ext, scan = create_extension(dashboard, DAQ_PID,
                                      show_extension=True)

--- a/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan.py
+++ b/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan.py
@@ -1471,12 +1471,13 @@ class DAQScanAcquisition(QObject):
 def main():
     import sys
     from pymodaq_gui.qt_utils import mkQApp
-    from pymodaq.dashboard import create_load_dashboard
+    from pymodaq.dashboard import load_dashboard_with_arguments
     from pymodaq.utils.gui_utils.loader_utils import create_extension
 
     app = mkQApp('DAQScan')
 
-    win, dashboard = create_load_dashboard(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win.mainwindow.setVisible(False)
 
     win_ext, scan = create_extension(dashboard, DAQScan,
                                      show_extension=True)

--- a/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan.py
+++ b/packages/pymodaq/src/pymodaq/extensions/scan/daq_scan.py
@@ -1476,7 +1476,9 @@ def main():
 
     app = mkQApp('DAQScan')
 
-    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False)
+    win, dashboard, _ = load_dashboard_with_arguments(show_dashboard=False,
+                                                      load_extension=False,
+                                                      )
     win.mainwindow.setVisible(False)
 
     win_ext, scan = create_extension(dashboard, DAQScan,

--- a/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/tableview.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/parameter/pymodaq_ptypes/tableview.py
@@ -71,7 +71,12 @@ class TableViewCustom(QtWidgets.QTableView):
 
 
 class TableViewParameterItem(WidgetParameterItem):
-    def makeWidget(self):
+
+    def __init__(self, *args, **kwargs):
+        self.widget: TableViewCustom = None
+        super().__init__(*args, **kwargs)
+
+    def makeWidget(self) -> TableViewCustom:
         """
             Make and initialize an instance of Table_custom.
 
@@ -127,7 +132,7 @@ class TableViewParameterItem(WidgetParameterItem):
             self.widget.setItemDelegate(styledItemDelegate)
 
         if 'menu' in opts:
-            self.widget.setup_menu(opts['menu'])
+            self.widget.setmenu(opts['menu'])
 
 
 class TableViewParameter(Parameter):

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/lcd.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widgets/lcd.py
@@ -3,7 +3,7 @@ from typing import List, Sequence
 import numpy as np
 
 from qtpy import QtWidgets
-from qtpy.QtCore import QObject
+from qtpy.QtCore import QObject, QThread
 from pymodaq_gui.plotting.data_viewers.viewer0D import Viewer0D
 from pymodaq_data.data import DataRaw
 import sys


### PR DESCRIPTION
Allow to load directly extensions script :

```bash
python -m path/to/extension -x experiment_name -s state name
```

to load dashboard with preconfigured experiment and state!