### PR TITLE
Bugfix/qthread qtimer teardown leak

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_move.py
@@ -23,6 +23,7 @@ from easydict import EasyDict as edict
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.utils import find_keys_from_val
 from pymodaq_utils import utils
+from pymodaq_utils.weak import weak_slot
 from pymodaq.utils.gui_utils import get_splash_sc
 from pymodaq_utils.config import get_set_local_dir, GlobalConfig as Config
 from pymodaq.utils.exceptions import ActuatorError
@@ -141,7 +142,7 @@ class DAQ_Move(ParameterControlModule):
         if self.ui is not None:
             self.ui.actuators = ACTUATOR_NAMES
             self.ui.add_setting_tree(self.settings_tree)
-            self.ui.command_sig.connect(self.process_ui_cmds)
+            self.ui.command_sig.connect(weak_slot(self.process_ui_cmds))
 
         self.splash_sc = get_splash_sc()
         self._title = title

--- a/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/daq_viewer.py
@@ -7,6 +7,7 @@ Created on Wed Jan 10 16:54:14 2018
 from __future__ import annotations
 
 from abc import ABC
+import functools
 from importlib import import_module
 
 import os
@@ -25,6 +26,7 @@ from pymodaq_data.data import DataToExport, Axis, DataDistribution, Averaging
 from pymodaq.utils.data import DataFromPlugins
 
 from pymodaq_utils.logger import set_logger, get_module_name
+from pymodaq_utils.weak import weak_slot
 from pymodaq.control_modules.utils import ParameterControlModule, HardwareWorkerBase
 
 from pymodaq_gui.utils.file_io import select_file
@@ -149,7 +151,7 @@ class DAQ_Viewer(ParameterControlModule):
         if self.ui is not None:
             QtWidgets.QApplication.processEvents()
             self.ui.add_setting_tree(self.settings_tree)
-            self.ui.command_sig.connect(self.process_ui_cmds)
+            self.ui.command_sig.connect(weak_slot(self.process_ui_cmds))
             self.viewers = self.ui.viewers
             self._viewer_types = self.ui.viewer_types
 
@@ -243,21 +245,33 @@ class DAQ_Viewer(ParameterControlModule):
             except:
                 pass
         for ind_viewer, viewer in enumerate(viewers):
-            viewer.data_to_export_signal.connect(self._get_data_from_viewer)
+            viewer.data_to_export_signal.connect(weak_slot(self._get_data_from_viewer))
 
+            # functools.partial binds ind_viewer by value immediately (unlike the
+            # closure a per-iteration lambda would capture by reference), and
+            # weak_slot() lets connect() hold only a weakref to self.
             viewer.roi_select_signal.connect(
-                lambda roi_info: self.command_hardware.emit(
-                    ThreadCommand(ControlToHardwareViewer.ROI_SELECT,
-                                  dict(roi_info=roi_info,
-                                       ind_viewer=ind_viewer))))
+                weak_slot(functools.partial(self._on_viewer_roi_selected, ind_viewer)))
             viewer.crosshair_dragged.connect(
-                lambda crosshair_info: self.command_hardware.emit(
-                    ThreadCommand(ControlToHardwareViewer.CROSSHAIR,
-                                  dict(crosshair_info=crosshair_info,
-                                       ind_viewer=ind_viewer))))
-
+                weak_slot(functools.partial(self._on_viewer_crosshair_dragged, ind_viewer)))
 
         self._viewers = viewers
+
+    def _on_viewer_roi_selected(self, ind_viewer: int, roi_info):
+        self.command_hardware.emit(
+            ThreadCommand(ControlToHardwareViewer.ROI_SELECT,
+                          dict(roi_info=roi_info, ind_viewer=ind_viewer)))
+
+    def _on_viewer_crosshair_dragged(self, ind_viewer: int, *crosshair_info):
+        # crosshair_dragged emits Signal(float, float). The lambda this replaces
+        # declared only one parameter, and Qt truncates extra signal arguments for
+        # slots that declare fewer params than the signal emits — a generic *args
+        # wrapper (weak_slot()) can't be introspected by Qt for that truncation, so
+        # replicate it explicitly by keeping only the first value.
+        self.command_hardware.emit(
+            ThreadCommand(ControlToHardwareViewer.CROSSHAIR,
+                          dict(crosshair_info=crosshair_info[0] if crosshair_info else None,
+                               ind_viewer=ind_viewer)))
 
     @property
     def Naverage(self):

--- a/packages/pymodaq/src/pymodaq/control_modules/utils.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/utils.py
@@ -11,7 +11,7 @@ from easydict import EasyDict as edict
 from qtpy import QtWidgets
 
 from qtpy import QtWidgets
-from qtpy.QtCore import Signal, QObject, Qt, Slot, QThread
+from qtpy.QtCore import Signal, QObject, Qt, Slot, QThread, QEvent
 
 from pymodaq_utils.utils import ThreadCommand
 from pymodaq_utils.config import GlobalConfig as Config
@@ -481,6 +481,22 @@ class ParameterControlModule(ParameterManager,LECOComponentMixin, ControlModule)
         try:
             if self.ui is not None:
                 self.ui.close()
+                # `close()` alone does not destroy the UI's actions/settings-tree
+                # widgets, and their `self`-closing lambda slots (e.g. grab/snap/stop
+                # buttons) are not released by disconnect() alone (PySide/PyQt keep an
+                # internal reference to a connected Python callable that outlives
+                # disconnect()), which would keep this whole module — and its
+                # `_hardware_thread`/hardware-worker `QTimer`s — alive indefinitely.
+                self.ui.clear_actions()
+                self.ui.clear_settings_tree()
+                # The UI also wires up plain widget signals (grab/snap/stop buttons,
+                # spin boxes, shortcuts, ...) directly with `self`-closing lambdas,
+                # not through clear_actions()'s `_actions` dict. Destroying the UI
+                # itself (not just close()-ing it) is what actually releases those
+                # phantom-cached closures, cascading to every child widget in one go.
+                self.ui.deleteLater()
+                QtWidgets.QApplication.sendPostedEvents(self.ui, QEvent.DeferredDelete)
+            self.clear_settings_tree()
         except Exception as e:
             self.logger.exception(str(e))
 

--- a/packages/pymodaq/src/pymodaq/control_modules/utils.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/utils.py
@@ -11,7 +11,7 @@ from easydict import EasyDict as edict
 from qtpy import QtWidgets
 
 from qtpy import QtWidgets
-from qtpy.QtCore import Signal, QObject, Qt, Slot, QThread, QEvent
+from qtpy.QtCore import Signal, QObject, Qt, Slot, QThread
 
 from pymodaq_utils.utils import ThreadCommand
 from pymodaq_utils.config import GlobalConfig as Config
@@ -481,22 +481,6 @@ class ParameterControlModule(ParameterManager,LECOComponentMixin, ControlModule)
         try:
             if self.ui is not None:
                 self.ui.close()
-                # `close()` alone does not destroy the UI's actions/settings-tree
-                # widgets, and their `self`-closing lambda slots (e.g. grab/snap/stop
-                # buttons) are not released by disconnect() alone (PySide/PyQt keep an
-                # internal reference to a connected Python callable that outlives
-                # disconnect()), which would keep this whole module — and its
-                # `_hardware_thread`/hardware-worker `QTimer`s — alive indefinitely.
-                self.ui.clear_actions()
-                self.ui.clear_settings_tree()
-                # The UI also wires up plain widget signals (grab/snap/stop buttons,
-                # spin boxes, shortcuts, ...) directly with `self`-closing lambdas,
-                # not through clear_actions()'s `_actions` dict. Destroying the UI
-                # itself (not just close()-ing it) is what actually releases those
-                # phantom-cached closures, cascading to every child widget in one go.
-                self.ui.deleteLater()
-                QtWidgets.QApplication.sendPostedEvents(self.ui, QEvent.DeferredDelete)
-            self.clear_settings_tree()
         except Exception as e:
             self.logger.exception(str(e))
 

--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import functools
 import itertools
 import sys
 import datetime
 import subprocess
-import weakref
 from pathlib import Path
 
 from typing import Union, List, Any, TYPE_CHECKING, Sequence
@@ -549,7 +549,7 @@ class DashBoard(CustomApp, LECOComponentMixin):
         #         )
         for ext_name in ExtensionEnum.names():
             self.connect_action(ExtensionEnum[ext_name],
-                                self.create_extension_slot(ExtensionEnum[ext_name]))
+                                functools.partial(self.load_extension, ExtensionEnum[ext_name]))
 
     # def update_remote_menu(self):
     #     self.remote_menu.addAction(self.get_action("show_remote"))
@@ -615,21 +615,6 @@ class DashBoard(CustomApp, LECOComponentMixin):
     #
     # def create_menu_slot_remote(self, filename):
     #     return lambda: self.set_remote_configuration(filename)
-
-    def create_extension_slot(self, extenum: ExtensionEnum):
-        # Close over a weakref, not `self`: PySide/PyQt keep an internal reference to
-        # a connected Python callable that outlives disconnect()/deleteLater() (this
-        # appears to survive even destroying the underlying QAction entirely), so a
-        # `self`-closing slot here keeps the DashBoard alive indefinitely regardless
-        # of any teardown code. Closing over a weakref means that even if PySide
-        # leaks this closure forever, it no longer keeps the DashBoard reachable.
-        self_ref = weakref.ref(self)
-
-        def slot():
-            dashboard = self_ref()
-            if dashboard is not None:
-                dashboard.load_extension(extenum)
-        return slot
 
     # def create_roi_file(self):
     #     try:

--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -694,31 +694,6 @@ class DashBoard(CustomApp, LECOComponentMixin):
             if self.pid_window is not None:
                 self.pid_window.close()
 
-            # Break reference cycles created by lambda slots (e.g. extension menu
-            # actions, settings-tree expand/collapse) that close over `self`: closing
-            # the widgets above does not destroy them, so those connections would
-            # otherwise keep this DashBoard (and everything it owns, including
-            # per-module QThreads/QTimers) alive for the rest of the process. Each of
-            # these sub-managers is itself an ActionManager with its own `_actions`
-            # dict of lambda-connected QActions closing over itself, and holds a
-            # `.parent` back-reference to this DashBoard, so they need the same
-            # treatment or they keep the DashBoard alive transitively.
-            for manager in (self, self.experiment_manager, self.state_manager,
-                            self.overshooter, self.roi_manager, self.extension_manager):
-                manager.clear_actions()
-                manager.clear_settings_tree()
-                # ManagerBase subclasses (experiment/state/overshoot managers) also
-                # stash per-file lambda slots (closing over `self`) directly in a
-                # plain dict, and connect a `self`-closing lambda to entries_sync
-                # independently of the QAction machinery clear_actions() handles.
-                if hasattr(manager, '_entry_slots'):
-                    manager._entry_slots.clear()
-                if hasattr(manager, 'entries_sync'):
-                    try:
-                        manager.entries_sync.value_changed.disconnect()
-                    except (TypeError, RuntimeError):
-                        pass
-
         except Exception as e:
             logger.exception(str(e))
         finally:

--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -709,6 +709,30 @@ class DashBoard(CustomApp, LECOComponentMixin):
             if self.pid_window is not None:
                 self.pid_window.close()
 
+            # Break reference cycles created by lambda slots (e.g. extension menu
+            # actions, settings-tree expand/collapse) that close over `self`: closing
+            # the widgets above does not destroy them, so those connections would
+            # otherwise keep this DashBoard (and everything it owns, including
+            # per-module QThreads/QTimers) alive for the rest of the process. Each of
+            # these sub-managers is itself an ActionManager with its own `_actions`
+            # dict of lambda-connected QActions closing over itself, and holds a
+            # `.parent` back-reference to this DashBoard, so they need the same
+            # treatment or they keep the DashBoard alive transitively.
+            for manager in (self, self.experiment_manager, self.state_manager,
+                            self.overshooter, self.roi_manager, self.extension_manager):
+                manager.clear_actions()
+                manager.clear_settings_tree()
+                # ManagerBase subclasses (experiment/state/overshoot managers) also
+                # stash per-file lambda slots (closing over `self`) directly in a
+                # plain dict, and connect a `self`-closing lambda to entries_sync
+                # independently of the QAction machinery clear_actions() handles.
+                if hasattr(manager, '_entry_slots'):
+                    manager._entry_slots.clear()
+                if hasattr(manager, 'entries_sync'):
+                    try:
+                        manager.entries_sync.value_changed.disconnect()
+                    except (TypeError, RuntimeError):
+                        pass
 
         except Exception as e:
             logger.exception(str(e))

--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -4,6 +4,7 @@ import itertools
 import sys
 import datetime
 import subprocess
+import weakref
 from pathlib import Path
 
 from typing import Union, List, Any, TYPE_CHECKING, Sequence
@@ -616,7 +617,19 @@ class DashBoard(CustomApp, LECOComponentMixin):
     #     return lambda: self.set_remote_configuration(filename)
 
     def create_extension_slot(self, extenum: ExtensionEnum):
-        return lambda: self.load_extension(extenum)
+        # Close over a weakref, not `self`: PySide/PyQt keep an internal reference to
+        # a connected Python callable that outlives disconnect()/deleteLater() (this
+        # appears to survive even destroying the underlying QAction entirely), so a
+        # `self`-closing slot here keeps the DashBoard alive indefinitely regardless
+        # of any teardown code. Closing over a weakref means that even if PySide
+        # leaks this closure forever, it no longer keeps the DashBoard reachable.
+        self_ref = weakref.ref(self)
+
+        def slot():
+            dashboard = self_ref()
+            if dashboard is not None:
+                dashboard.load_extension(extenum)
+        return slot
 
     # def create_roi_file(self):
     #     try:

--- a/packages/pymodaq/src/pymodaq/utils/managers/extension/extension_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/extension/extension_manager.py
@@ -1,4 +1,5 @@
 import sys
+import weakref
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -130,9 +131,18 @@ class ExtensionManager(ManagerBase):
 
     def connect_things(self):
         """Connect extension actions to load methods."""
+        # Close over a weakref, not `self`: PySide/PyQt keep an internal reference to
+        # a connected Python callable that outlives disconnect()/deleteLater() (this
+        # can survive even destroying the underlying QAction entirely), so a
+        # `self`-closing slot here would keep this manager alive indefinitely
+        # regardless of any teardown code.
+        self_ref = weakref.ref(self)
         for ext_name in ExtensionEnum.names():
-            self.connect_action(ExtensionEnum[ext_name],
-                               lambda e=ExtensionEnum[ext_name]: self.load_extension(e))
+            def slot(e=ExtensionEnum[ext_name]):
+                obj = self_ref()
+                if obj is not None:
+                    obj.load_extension(e)
+            self.connect_action(ExtensionEnum[ext_name], slot)
 
     def quit_fun(self):
         """Clean up extensions and internal dashboard."""

--- a/packages/pymodaq/src/pymodaq/utils/managers/extension/extension_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/extension/extension_manager.py
@@ -1,5 +1,5 @@
+import functools
 import sys
-import weakref
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -131,18 +131,14 @@ class ExtensionManager(ManagerBase):
 
     def connect_things(self):
         """Connect extension actions to load methods."""
-        # Close over a weakref, not `self`: PySide/PyQt keep an internal reference to
-        # a connected Python callable that outlives disconnect()/deleteLater() (this
-        # can survive even destroying the underlying QAction entirely), so a
-        # `self`-closing slot here would keep this manager alive indefinitely
-        # regardless of any teardown code.
-        self_ref = weakref.ref(self)
+        # connect_action() auto-wraps bound-method slots in a weakref (see
+        # ActionManager.connect_action / pymodaq_utils.weak.weak_slot): PySide/PyQt
+        # keep an internal reference to a connected Python callable that outlives
+        # disconnect()/deleteLater(), so a plain functools.partial of a bound method
+        # here would otherwise keep this manager alive indefinitely.
         for ext_name in ExtensionEnum.names():
-            def slot(e=ExtensionEnum[ext_name]):
-                obj = self_ref()
-                if obj is not None:
-                    obj.load_extension(e)
-            self.connect_action(ExtensionEnum[ext_name], slot)
+            self.connect_action(ExtensionEnum[ext_name],
+                               functools.partial(self.load_extension, ExtensionEnum[ext_name]))
 
     def quit_fun(self):
         """Clean up extensions and internal dashboard."""

--- a/packages/pymodaq/src/pymodaq/utils/managers/state/state_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/state/state_manager.py
@@ -2,6 +2,7 @@
 from typing import Union, TYPE_CHECKING
 from pathlib import Path
 import sys
+import weakref
 
 import toml
 from qtpy import QtWidgets, QtCore, QtGui
@@ -308,7 +309,16 @@ class StateManager(ManagerBase):
             self.experiment_manager.get_action(ManagerActions.LIST_EXTERNAL).widget.setEnabled(False)
             self.experiment_manager.applied_entry.connect(self.set_experiment_filename)  #action slot from experiment menu need this to update the list onf state entries
 
-        self.experiment_manager.entries_sync.value_changed.connect(lambda value: self.set_experiment_filename(value['current']))
+        # Close over a weakref, not `self`: see the note in
+        # pymodaq_gui.managers.manager_base.ManagerBase.connect_things_base for why a
+        # `self`-closing slot here would keep this manager alive indefinitely.
+        self_ref = weakref.ref(self)
+
+        def _on_experiment_entry_changed(value):
+            obj = self_ref()
+            if obj is not None:
+                obj.set_experiment_filename(value['current'])
+        self.experiment_manager.entries_sync.value_changed.connect(_on_experiment_entry_changed)
     def _update_entry(self, entry: Path):
         self.config_model.load(self.entry_filepath)
 

--- a/packages/pymodaq/src/pymodaq/utils/managers/state/state_manager.py
+++ b/packages/pymodaq/src/pymodaq/utils/managers/state/state_manager.py
@@ -2,7 +2,6 @@
 from typing import Union, TYPE_CHECKING
 from pathlib import Path
 import sys
-import weakref
 
 import toml
 from qtpy import QtWidgets, QtCore, QtGui
@@ -14,6 +13,7 @@ from pymodaq.utils.managers.modules.module_settings_manager import SettingsManag
 from pymodaq.utils.managers.experiment.experiment_manager import ExperimentManager
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils.config import GlobalConfig as Config, get_set_local_dir
+from pymodaq_utils.weak import weak_slot
 
 from pymodaq_gui.parameter import Parameter, ioxml
 from pymodaq_gui.parameter.utils import ParameterWithPath
@@ -307,18 +307,19 @@ class StateManager(ManagerBase):
 
         else:
             self.experiment_manager.get_action(ManagerActions.LIST_EXTERNAL).widget.setEnabled(False)
-            self.experiment_manager.applied_entry.connect(self.set_experiment_filename)  #action slot from experiment menu need this to update the list onf state entries
+            #action slot from experiment menu need this to update the list onf state entries
+            self.experiment_manager.applied_entry.connect(weak_slot(self.set_experiment_filename))
 
-        # Close over a weakref, not `self`: see the note in
+        # These connect directly to a signal, not through connect_action(), so they
+        # need weak_slot() applied explicitly (see the note in
         # pymodaq_gui.managers.manager_base.ManagerBase.connect_things_base for why a
-        # `self`-closing slot here would keep this manager alive indefinitely.
-        self_ref = weakref.ref(self)
+        # `self`-closing slot here would keep this manager alive indefinitely).
+        self.experiment_manager.entries_sync.value_changed.connect(
+            weak_slot(self._on_experiment_entry_changed))
 
-        def _on_experiment_entry_changed(value):
-            obj = self_ref()
-            if obj is not None:
-                obj.set_experiment_filename(value['current'])
-        self.experiment_manager.entries_sync.value_changed.connect(_on_experiment_entry_changed)
+    def _on_experiment_entry_changed(self, value):
+        self.set_experiment_filename(value['current'])
+
     def _update_entry(self, entry: Path):
         self.config_model.load(self.entry_filepath)
 

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
@@ -715,44 +715,6 @@ class ActionManager:
         """
         self.get_action(action_name).setText(text)
 
-    def clear_actions(self):
-        """Disconnect and destroy every managed action, dropping all references to them.
-
-        Actions connected via :meth:`connect_action` typically hold a slot (often a
-        lambda) that closes over ``self``. Disconnecting the signal alone is *not*
-        enough to release that closure: PySide/PyQt keep an internal reference to a
-        connected Python callable that outlives ``disconnect()`` (and even a plain
-        ``deleteLater()`` + ``processEvents()``) until the underlying C++ QAction
-        object is actually destroyed. Without this, that closure keeps ``self`` (and
-        everything reachable from it) alive for as long as the action exists, even
-        after the owning widget/window has been closed, since ``QWidget.close()``
-        does not destroy child widgets/actions by itself.
-        """
-        for entry in self._actions.values():
-            # A WidgetActionProxy forwards unknown attributes to the wrapped widget
-            # (which has no `triggered`); disconnect/destroy its real QAction instead.
-            action = entry.action if isinstance(entry, WidgetActionProxy) else entry
-            try:
-                action.triggered.disconnect()
-            except (TypeError, RuntimeError):
-                pass  # not connected, or already deleted C++-side
-            try:
-                action.deleteLater()
-                # deleteLater() alone only *schedules* destruction; force it now, for
-                # this object only, so the Python closure it held is released
-                # synchronously. Flushing with a `None` receiver would process
-                # *every* pending deferred-delete in the whole application, which can
-                # race with other teardown code still in progress elsewhere and crash.
-                QtWidgets.QApplication.sendPostedEvents(action, QtCore.QEvent.DeferredDelete)
-                if isinstance(entry, WidgetActionProxy):
-                    entry.deleteLater()
-                    QtWidgets.QApplication.sendPostedEvents(entry, QtCore.QEvent.DeferredDelete)
-            except RuntimeError:
-                pass  # underlying C++ widget already deleted (e.g. parent cascaded)
-        self._actions.clear()
-        self._menus.clear()
-        self._toolbars.clear()
-
     @property
     def actions(self) -> list[QAction]:
         return list(self._actions.values())

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
@@ -714,6 +714,44 @@ class ActionManager:
         """
         self.get_action(action_name).setText(text)
 
+    def clear_actions(self):
+        """Disconnect and destroy every managed action, dropping all references to them.
+
+        Actions connected via :meth:`connect_action` typically hold a slot (often a
+        lambda) that closes over ``self``. Disconnecting the signal alone is *not*
+        enough to release that closure: PySide/PyQt keep an internal reference to a
+        connected Python callable that outlives ``disconnect()`` (and even a plain
+        ``deleteLater()`` + ``processEvents()``) until the underlying C++ QAction
+        object is actually destroyed. Without this, that closure keeps ``self`` (and
+        everything reachable from it) alive for as long as the action exists, even
+        after the owning widget/window has been closed, since ``QWidget.close()``
+        does not destroy child widgets/actions by itself.
+        """
+        for entry in self._actions.values():
+            # A WidgetActionProxy forwards unknown attributes to the wrapped widget
+            # (which has no `triggered`); disconnect/destroy its real QAction instead.
+            action = entry.action if isinstance(entry, WidgetActionProxy) else entry
+            try:
+                action.triggered.disconnect()
+            except (TypeError, RuntimeError):
+                pass  # not connected, or already deleted C++-side
+            try:
+                action.deleteLater()
+                # deleteLater() alone only *schedules* destruction; force it now, for
+                # this object only, so the Python closure it held is released
+                # synchronously. Flushing with a `None` receiver would process
+                # *every* pending deferred-delete in the whole application, which can
+                # race with other teardown code still in progress elsewhere and crash.
+                QtWidgets.QApplication.sendPostedEvents(action, QtCore.QEvent.DeferredDelete)
+                if isinstance(entry, WidgetActionProxy):
+                    entry.deleteLater()
+                    QtWidgets.QApplication.sendPostedEvents(entry, QtCore.QEvent.DeferredDelete)
+            except RuntimeError:
+                pass  # underlying C++ widget already deleted (e.g. parent cascaded)
+        self._actions.clear()
+        self._menus.clear()
+        self._toolbars.clear()
+
     @property
     def actions(self) -> list[QAction]:
         return list(self._actions.values())

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/action_manager.py
@@ -11,6 +11,7 @@ from qtpy.QtWidgets import QAction as QtQAction
 from pymodaq_gui.utils.styling import create_icon
 from pymodaq_utils.warnings import deprecation_msg
 from pymodaq_utils.config import GlobalConfig as Config
+from pymodaq_utils.weak import weak_slot
 
 try:
     from pymodaq_gui.resources.material_icons import MaterialIcon
@@ -926,13 +927,25 @@ class ActionManager:
             if True connect the trigger signal of the action to the defined slot else disconnect it
         signal_name: str
             try to use it as a signal (for widgets added...) otherwise use the *triggered* signal
+
+        Notes
+        -----
+        A bound method (``self.some_method``) or a ``functools.partial`` of one is
+        automatically wrapped to hold a weakref to its owner instead of a strong
+        reference (see :func:`pymodaq_utils.weak.weak_slot`): PySide/PyQt keep an
+        internal reference to a connected Python callable that outlives
+        ``disconnect()``, so an unwrapped self-referencing slot would keep the owner
+        alive for as long as the action exists, regardless of any teardown code. A
+        raw lambda/closure cannot be safely rewritten this way and is connected
+        unchanged — prefer a bound method or ``functools.partial`` over a lambda here
+        when the slot needs to close over ``self``.
         """
         signal = 'triggered'
         if name in self._actions:
             if hasattr(self._actions[name], signal_name):
                 signal = signal_name
             if connect:
-                getattr(self._actions[name], signal).connect(slot)
+                getattr(self._actions[name], signal).connect(weak_slot(slot))
             else:
                 try:
                     if slot is not None:

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -1,5 +1,5 @@
+import functools
 import sys
-import weakref
 from pathlib import Path
 from typing import Any, Union, TYPE_CHECKING, Optional
 
@@ -10,6 +10,7 @@ from qtpy.QtGui import QKeySequence
 from pymodaq_gui.utils.styling import create_icon
 
 from pymodaq_utils.logger import set_logger, get_module_name
+from pymodaq_utils.weak import weak_slot
 from pymodaq.extensions.custom_ext import CustomExt
 
 from pymodaq_utils.enums import StrEnum
@@ -329,36 +330,27 @@ class ManagerBase(CustomExt):
         return combo
 
     def connect_things_base(self):
-        # Close over a weakref, not `self`: PySide/PyQt keep an internal reference to
-        # a connected Python callable that outlives disconnect()/deleteLater() (this
-        # can survive even destroying the underlying QAction entirely), so a
-        # `self`-closing slot here would keep this manager alive indefinitely
-        # regardless of any teardown code. Closing over a weakref means that even if
-        # PySide leaks these closures forever, they no longer keep it reachable.
-        self_ref = weakref.ref(self)
+        # connect_action() auto-wraps bound-method slots in a weakref (see
+        # ActionManager.connect_action / pymodaq_utils.weak.weak_slot): PySide/PyQt
+        # keep an internal reference to a connected Python callable that outlives
+        # disconnect()/deleteLater(), so a plain bound method here would otherwise
+        # keep this manager alive indefinitely regardless of any teardown code.
+        self.connect_action(ManagerActions.COPY, self.copy_entry)
+        self.connect_action(ManagerActions.NEW, self.create_entry)
+        self.connect_action(ManagerActions.DELETE, self.delete_entry)
+        self.connect_action(ManagerActions.SAVE, self.save_check)
+        self.connect_action(ManagerActions.RELOAD, self.update_entry)
+        self.connect_action(ManagerActions.EXECUTE, self.execute_current_entry)
 
-        def _bind(method_name: str):
-            def slot():
-                obj = self_ref()
-                if obj is not None:
-                    getattr(obj, method_name)()
-            return slot
+        self.connect_action(ManagerActions.OPEN, self.show)
 
-        self.connect_action(ManagerActions.COPY, _bind('copy_entry'))
-        self.connect_action(ManagerActions.NEW, _bind('create_entry'))
-        self.connect_action(ManagerActions.DELETE, _bind('delete_entry'))
-        self.connect_action(ManagerActions.SAVE, _bind('save_check'))
-        self.connect_action(ManagerActions.RELOAD, _bind('update_entry'))
-        self.connect_action(ManagerActions.EXECUTE, _bind('execute_current_entry'))
-
-        self.connect_action(ManagerActions.OPEN, _bind('show'))
-
-        def _update_entry_from_sync(value):
-            obj = self_ref()
-            if obj is not None:
-                obj.update_entry(value['current'])
-        self.entries_sync.value_changed.connect(_update_entry_from_sync)
+        # entries_sync.value_changed is not routed through connect_action(), so it
+        # needs the same weak-wrapping applied explicitly.
+        self.entries_sync.value_changed.connect(weak_slot(self._on_entries_sync_changed))
         self.sync_entries_with(self.get_action_list())
+
+    def _on_entries_sync_changed(self, value):
+        self.update_entry(value['current'])
 
     def execute_current_entry(self):
         self.execute_entry(self.entry)
@@ -597,16 +589,10 @@ class ManagerBase(CustomExt):
             f'Execute the selected {self.entry_type} entry: {entry} ("Ctrl+A")')
 
     def create_slot_from_file(self, filename: Path):
-        # See the weakref note in connect_things_base(): a `self`-closing slot
-        # connected to a per-file QAction would keep this manager (and everything it
-        # owns) alive indefinitely, even after the action is destroyed.
-        self_ref = weakref.ref(self)
-
-        def slot():
-            obj = self_ref()
-            if obj is not None:
-                obj.execute_entry(filename)
-        return slot
+        # A functools.partial of a bound method: connect_action() auto-weakifies
+        # this (see the note in connect_things_base()), so it's safe to connect to
+        # a per-file QAction without keeping this manager alive indefinitely.
+        return functools.partial(self.execute_entry, filename)
 
     def update_menu(self, menu: QtWidgets.QMenu = None):
         try:

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/manager_base.py
@@ -1,4 +1,5 @@
 import sys
+import weakref
 from pathlib import Path
 from typing import Any, Union, TYPE_CHECKING, Optional
 
@@ -328,16 +329,35 @@ class ManagerBase(CustomExt):
         return combo
 
     def connect_things_base(self):
-        self.connect_action(ManagerActions.COPY, lambda: self.copy_entry())
-        self.connect_action(ManagerActions.NEW, lambda: self.create_entry())
-        self.connect_action(ManagerActions.DELETE, lambda: self.delete_entry())
-        self.connect_action(ManagerActions.SAVE, lambda: self.save_check())
-        self.connect_action(ManagerActions.RELOAD, lambda: self.update_entry())
-        self.connect_action(ManagerActions.EXECUTE, lambda: self.execute_current_entry())
+        # Close over a weakref, not `self`: PySide/PyQt keep an internal reference to
+        # a connected Python callable that outlives disconnect()/deleteLater() (this
+        # can survive even destroying the underlying QAction entirely), so a
+        # `self`-closing slot here would keep this manager alive indefinitely
+        # regardless of any teardown code. Closing over a weakref means that even if
+        # PySide leaks these closures forever, they no longer keep it reachable.
+        self_ref = weakref.ref(self)
 
-        self.connect_action(ManagerActions.OPEN, lambda: self.show())
+        def _bind(method_name: str):
+            def slot():
+                obj = self_ref()
+                if obj is not None:
+                    getattr(obj, method_name)()
+            return slot
 
-        self.entries_sync.value_changed.connect(lambda value: self.update_entry(value['current']))
+        self.connect_action(ManagerActions.COPY, _bind('copy_entry'))
+        self.connect_action(ManagerActions.NEW, _bind('create_entry'))
+        self.connect_action(ManagerActions.DELETE, _bind('delete_entry'))
+        self.connect_action(ManagerActions.SAVE, _bind('save_check'))
+        self.connect_action(ManagerActions.RELOAD, _bind('update_entry'))
+        self.connect_action(ManagerActions.EXECUTE, _bind('execute_current_entry'))
+
+        self.connect_action(ManagerActions.OPEN, _bind('show'))
+
+        def _update_entry_from_sync(value):
+            obj = self_ref()
+            if obj is not None:
+                obj.update_entry(value['current'])
+        self.entries_sync.value_changed.connect(_update_entry_from_sync)
         self.sync_entries_with(self.get_action_list())
 
     def execute_current_entry(self):
@@ -577,7 +597,16 @@ class ManagerBase(CustomExt):
             f'Execute the selected {self.entry_type} entry: {entry} ("Ctrl+A")')
 
     def create_slot_from_file(self, filename: Path):
-        return lambda: self.execute_entry(filename)
+        # See the weakref note in connect_things_base(): a `self`-closing slot
+        # connected to a per-file QAction would keep this manager (and everything it
+        # owns) alive indefinitely, even after the action is destroyed.
+        self_ref = weakref.ref(self)
+
+        def slot():
+            obj = self_ref()
+            if obj is not None:
+                obj.execute_entry(filename)
+        return slot
 
     def update_menu(self, menu: QtWidgets.QMenu = None):
         try:

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/parameter_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/parameter_manager.py
@@ -282,39 +282,6 @@ class ParameterManager:
         )
         self._settings_tree.tree.resizeColumnToContents(0)
 
-    def clear_settings_tree(self):
-        """Disconnect and destroy the settings tree widget, dropping references to it.
-
-        :meth:`set_settings` connects lambdas (closing over ``self``) to the tree's
-        ``itemExpanded``/``itemCollapsed`` signals, and ``self._settings_tree`` is
-        itself an :class:`~pymodaq_gui.managers.action_manager.ActionManager` with its
-        own toolbar actions connected to bound methods of ``self``. As with
-        :meth:`~pymodaq_gui.managers.action_manager.ActionManager.clear_actions`,
-        disconnecting alone is not enough to release those closures: PySide/PyQt keep
-        an internal reference to a connected Python callable that outlives
-        ``disconnect()`` until the underlying C++ widget is actually destroyed.
-        """
-        try:
-            self._settings_tree.tree.itemExpanded.disconnect()
-            self._settings_tree.tree.itemCollapsed.disconnect()
-        except (TypeError, RuntimeError):
-            pass
-        if isinstance(self._settings_tree, ActionManager):
-            self._settings_tree.clear_actions()
-        # deleteLater() the tree widget itself, not just its container: a parent's
-        # deleteLater() only *schedules* its own destruction, and does not
-        # necessarily cascade to children within a single DeferredDelete flush.
-        for widget in (self._settings_tree.tree, self._settings_tree.widget):
-            try:
-                widget.deleteLater()
-                # Scoped to this widget only: flushing with a `None` receiver would
-                # process every pending deferred-delete in the whole application,
-                # which can race with other teardown code still in progress
-                # elsewhere and crash.
-                QtWidgets.QApplication.sendPostedEvents(widget, QtCore.QEvent.DeferredDelete)
-            except RuntimeError:
-                pass  # underlying C++ widget already deleted (e.g. parent cascaded)
-
     @property
     def settings_tree(self) -> QtWidgets.QWidget:
         """QWidget: The main widget containing the parameter tree and toolbar."""

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/parameter_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/parameter_manager.py
@@ -319,8 +319,15 @@ class ParameterManager:
             self._settings, showTop=False,
         )  # load the tree with this parameter object
         self._settings.sigTreeStateChanged.connect(self.parameter_tree_changed)
-        self._settings_tree.tree.itemExpanded.connect(lambda: self._settings_tree.tree.resizeColumnToContents(0))
-        self._settings_tree.tree.itemCollapsed.connect(lambda: self._settings_tree.tree.resizeColumnToContents(0))
+        # Close over the tree widget directly, not `self`: every ParameterManager
+        # subclass (DashBoard, ModulesManager, per-module settings, ...) goes through
+        # here, and a `self`-closing lambda connected to a Qt signal is not reliably
+        # released by disconnect() alone (PySide/PyQt keep an internal reference to a
+        # connected Python callable that outlives disconnect()), which would keep
+        # every such instance alive indefinitely.
+        tree = self._settings_tree.tree
+        tree.itemExpanded.connect(lambda: tree.resizeColumnToContents(0))
+        tree.itemCollapsed.connect(lambda: tree.resizeColumnToContents(0))
 
     @staticmethod
     def create_parameter(

--- a/packages/pymodaq_gui/src/pymodaq_gui/managers/parameter_manager.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/managers/parameter_manager.py
@@ -282,6 +282,39 @@ class ParameterManager:
         )
         self._settings_tree.tree.resizeColumnToContents(0)
 
+    def clear_settings_tree(self):
+        """Disconnect and destroy the settings tree widget, dropping references to it.
+
+        :meth:`set_settings` connects lambdas (closing over ``self``) to the tree's
+        ``itemExpanded``/``itemCollapsed`` signals, and ``self._settings_tree`` is
+        itself an :class:`~pymodaq_gui.managers.action_manager.ActionManager` with its
+        own toolbar actions connected to bound methods of ``self``. As with
+        :meth:`~pymodaq_gui.managers.action_manager.ActionManager.clear_actions`,
+        disconnecting alone is not enough to release those closures: PySide/PyQt keep
+        an internal reference to a connected Python callable that outlives
+        ``disconnect()`` until the underlying C++ widget is actually destroyed.
+        """
+        try:
+            self._settings_tree.tree.itemExpanded.disconnect()
+            self._settings_tree.tree.itemCollapsed.disconnect()
+        except (TypeError, RuntimeError):
+            pass
+        if isinstance(self._settings_tree, ActionManager):
+            self._settings_tree.clear_actions()
+        # deleteLater() the tree widget itself, not just its container: a parent's
+        # deleteLater() only *schedules* its own destruction, and does not
+        # necessarily cascade to children within a single DeferredDelete flush.
+        for widget in (self._settings_tree.tree, self._settings_tree.widget):
+            try:
+                widget.deleteLater()
+                # Scoped to this widget only: flushing with a `None` receiver would
+                # process every pending deferred-delete in the whole application,
+                # which can race with other teardown code still in progress
+                # elsewhere and crash.
+                QtWidgets.QApplication.sendPostedEvents(widget, QtCore.QEvent.DeferredDelete)
+            except RuntimeError:
+                pass  # underlying C++ widget already deleted (e.g. parent cascaded)
+
     @property
     def settings_tree(self) -> QtWidgets.QWidget:
         """QWidget: The main widget containing the parameter tree and toolbar."""

--- a/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/utils/widget_sync/core.py
@@ -870,12 +870,20 @@ class BaseWidgetSync(QObject):
         property_key: str | None,
     ) -> Callable:
         """Create callback for widget → sync updates."""
+        # Weak-reference `self` (not just the widget): PySide/PyQt keep an internal
+        # reference to a connected Python callable that outlives disconnect(), so a
+        # `self`-closing callback connected to the widget's signal would otherwise
+        # keep this sync instance alive indefinitely regardless of unbind()/
+        # unbind_all().
+        sync_ref = ref(self)
+
         def on_widget_change(*args):
+            sync = sync_ref()
             widget_obj = widget_ref()
-            if widget_obj is None:
+            if sync is None or widget_obj is None:
                 return
 
-            conn = self._connections.get(connection_key)
+            conn = sync._connections.get(connection_key)
             if conn is None or not conn.get('enabled', True):
                 return
 
@@ -887,24 +895,24 @@ class BaseWidgetSync(QObject):
                 # Track this widget as the sender to prevent feedback loop
                 # Store only widget_id to block ALL property updates on this widget
                 widget_id = connection_key[0]
-                self._sender_widget_id = widget_id
+                sync._sender_widget_id = widget_id
                 try:
                     # Property connection: update dict key
                     if property_key is not None:
                         # In single-value mode, set_value expects unwrapped value
                         if property_key == "__value__":
-                            self.set_value(value, emit=True)
+                            sync.set_value(value, emit=True)
                         # In dict mode, set_value expects the full dict
-                        elif isinstance(self._value, dict):
-                            new_dict = self._value.copy()
+                        elif isinstance(sync._value, dict):
+                            new_dict = sync._value.copy()
                             new_dict[property_key] = value
-                            self.set_value(new_dict, emit=True)
+                            sync.set_value(new_dict, emit=True)
                     # Regular connection: update entire value
                     else:
-                        self.set_value(value, emit=True)
+                        sync.set_value(value, emit=True)
                 finally:
                     # Always clear sender after update
-                    self._sender_widget_id = None
+                    sync._sender_widget_id = None
             except Exception as e:
                 logger.error(
                     f"Error syncing from widget {type(widget_obj).__name__}: {e}",
@@ -922,19 +930,27 @@ class BaseWidgetSync(QObject):
         property_key: str | None,
     ) -> Callable:
         """Create callback for sync → widget updates."""
+        # Weak-reference `self`: this callback is connected to self.value_changed
+        # (the sync's own signal), and PySide/PyQt keep an internal reference to a
+        # connected Python callable that outlives disconnect() — connecting a
+        # `self`-closing callback to its own signal would otherwise keep this sync
+        # instance alive indefinitely regardless of unbind()/unbind_all().
+        sync_ref = ref(self)
+
         def on_sync_change(value):
+            sync = sync_ref()
             widget_obj = widget_ref()
-            if widget_obj is None:
+            if sync is None or widget_obj is None:
                 return
 
-            conn = self._connections.get(connection_key)
+            conn = sync._connections.get(connection_key)
             if conn is None or not conn.get('enabled', True):
                 return
 
             # Skip updating the widget that triggered this change (prevent feedback loop)
             # Check widget_id only, so ALL properties on the sender widget are skipped
             widget_id = connection_key[0]
-            if self._sender_widget_id == widget_id:
+            if sync._sender_widget_id == widget_id:
                 return
 
             try:
@@ -944,8 +960,8 @@ class BaseWidgetSync(QObject):
                     if property_key == "__value__":
                         # Value is already unwrapped, use it directly
                         # Check if it actually changed
-                        if self._previous_value and isinstance(self._previous_value, dict):
-                            old_prop_value = self._previous_value.get("__value__")
+                        if sync._previous_value and isinstance(sync._previous_value, dict):
+                            old_prop_value = sync._previous_value.get("__value__")
                             if old_prop_value == value:
                                 return  # Value didn't change, skip update
                     # In dict mode, extract the specific property from the dict
@@ -954,8 +970,8 @@ class BaseWidgetSync(QObject):
 
                         # Optimization: Only update if this specific property changed
                         # Compare old and new dict values for this property
-                        if self._previous_value and isinstance(self._previous_value, dict):
-                            old_prop_value = self._previous_value.get(property_key)
+                        if sync._previous_value and isinstance(sync._previous_value, dict):
+                            old_prop_value = sync._previous_value.get(property_key)
                             if old_prop_value == new_prop_value:
                                 return  # Property didn't change, skip update
 
@@ -965,7 +981,7 @@ class BaseWidgetSync(QObject):
 
                 if from_sync_transform:
                     value = from_sync_transform(value)
-                with self._block_signals(widget_obj):
+                with sync._block_signals(widget_obj):
                     setter(value)
             except Exception as e:
                 logger.error(
@@ -1731,25 +1747,33 @@ class DictSync(BaseWidgetSync):
 
             # Parameter → Sync (TO_SYNC or BIDIRECTIONAL)
             if mode in (SyncMode.TO_SYNC, SyncMode.BIDIRECTIONAL) and signal and getter:
-                def make_param_to_sync_callback(key, get_fn, callbacks_ref):
+                def make_param_to_sync_callback(key, get_fn, callbacks_ref, sync_ref):
+                    # Weak-reference the sync instance: this callback is connected to
+                    # the Parameter's signal, and PySide/PyQt keep an internal
+                    # reference to a connected Python callable that outlives
+                    # disconnect(), so closing over `self` here would otherwise keep
+                    # this sync instance alive indefinitely.
                     def on_param_change(param, value):
+                        sync = sync_ref()
+                        if sync is None:
+                            return
                         # Get actual value using getter
                         actual_value = get_fn()
-                        if actual_value != self.value.get(key):
-                            new_dict = self.value.copy()
+                        if actual_value != sync.value.get(key):
+                            new_dict = sync.value.copy()
                             new_dict[key] = actual_value
                             # Get the reverse callback to disconnect it
                             reverse_cb = callbacks_ref.get((key, 'sync_to_param'))
                             if reverse_cb:
-                                self.value_changed.disconnect(reverse_cb)
+                                sync.value_changed.disconnect(reverse_cb)
                             try:
-                                self.value = new_dict
+                                sync.value = new_dict
                             finally:
                                 if reverse_cb:
-                                    self.value_changed.connect(reverse_cb)
+                                    sync.value_changed.connect(reverse_cb)
                     return on_param_change
 
-                callback = make_param_to_sync_callback(property_key, getter, all_param_callbacks)
+                callback = make_param_to_sync_callback(property_key, getter, all_param_callbacks, ref(self))
                 signal.connect(callback)
                 all_param_callbacks[(property_key, 'param_to_sync')] = (signal, callback)
                 # Note: Don't add to connection_info['callbacks'] - Qt auto-disconnects

--- a/packages/pymodaq_utils/src/pymodaq_utils/weak.py
+++ b/packages/pymodaq_utils/src/pymodaq_utils/weak.py
@@ -56,11 +56,17 @@ def weak_slot(callback: Callable) -> Callable:
 
     receiver_ref = weakref.ref(receiver)
 
-    @functools.wraps(unbound_func)
     def wrapper(*call_args, **call_kwargs):
         obj = receiver_ref()
         if obj is None:
             return None
         return unbound_func(obj, *bound_args, *call_args, **bound_kwargs, **call_kwargs)
+
+    # Copy __name__/__doc__ for readability (tracebacks, repr) without using
+    # functools.wraps(unbound_func): that would set __wrapped__ to the
+    # *unbound* function, which some introspection consumers resolve back to
+    # (a signature still including `self`) instead of `wrapper`'s own.
+    wrapper.__name__ = getattr(unbound_func, '__name__', wrapper.__name__)
+    wrapper.__doc__ = unbound_func.__doc__
 
     return wrapper

--- a/packages/pymodaq_utils/src/pymodaq_utils/weak.py
+++ b/packages/pymodaq_utils/src/pymodaq_utils/weak.py
@@ -1,0 +1,66 @@
+"""
+Helper for connecting Qt (or any) signals without leaking the receiver.
+
+PySide/PyQt keep an internal reference to a connected Python callable that
+outlives ``disconnect()`` (and can survive even destroying the underlying
+QObject it was connected to). A slot that closes over ``self`` — a bound
+method, or a lambda capturing ``self`` — therefore keeps the receiving
+object alive for as long as the connection exists, regardless of any
+teardown code, unless that connection is force-broken.
+
+``weak_slot()`` sidesteps the problem at the source: it wraps a bound
+method (or a :func:`functools.partial` of one) so the connection only ever
+holds a :class:`weakref.ref` to the receiver. Even if the underlying Qt
+binding never releases the wrapper closure, the closure itself cannot keep
+the receiver reachable.
+"""
+import functools
+import weakref
+from typing import Callable
+
+
+def weak_slot(callback: Callable) -> Callable:
+    """Wrap a bound method (or a ``functools.partial`` of one) to hold a weakref.
+
+    Parameters
+    ----------
+    callback : Callable
+        A bound method (``obj.method``), or ``functools.partial(obj.method, *args)``.
+
+    Returns
+    -------
+    Callable
+        A plain function that looks up the receiver via a weakref on each call
+        and is a no-op once the receiver has been garbage collected. If
+        `callback` is not a bound method (or partial of one) — e.g. it is a
+        plain function, an already-bound `staticmethod`, or a lambda — it
+        cannot be safely rewritten this way and is returned unchanged.
+
+    Examples
+    --------
+    >>> action.triggered.connect(weak_slot(self.on_triggered))
+    >>> action.triggered.connect(weak_slot(functools.partial(self.load_extension, name)))
+    """
+    func = callback
+    bound_args: tuple = ()
+    bound_kwargs: dict = {}
+    if isinstance(callback, functools.partial):
+        func = callback.func
+        bound_args = callback.args
+        bound_kwargs = callback.keywords or {}
+
+    receiver = getattr(func, '__self__', None)
+    unbound_func = getattr(func, '__func__', None)
+    if receiver is None or unbound_func is None:
+        return callback  # not a bound method we can safely rewrite
+
+    receiver_ref = weakref.ref(receiver)
+
+    @functools.wraps(unbound_func)
+    def wrapper(*call_args, **call_kwargs):
+        obj = receiver_ref()
+        if obj is None:
+            return None
+        return unbound_func(obj, *bound_args, *call_args, **bound_kwargs, **call_kwargs)
+
+    return wrapper

--- a/packages/pymodaq_utils/src/pymodaq_utils/weak.py
+++ b/packages/pymodaq_utils/src/pymodaq_utils/weak.py
@@ -78,12 +78,45 @@ def weak_slot(callback: Callable) -> Callable:
     except (TypeError, ValueError):
         pass
 
-    def wrapper(*call_args, **call_kwargs):
-        obj = receiver_ref()
-        if obj is None:
-            return None
-        args = call_args if max_extra_args is None else call_args[:max_extra_args]
-        return unbound_func(obj, *bound_args, *args, **bound_kwargs, **call_kwargs)
+    if max_extra_args is None:
+        # Unknown/unbounded arity (the target itself declares *args) -- nothing
+        # to pin down, fall back to forwarding everything.
+        def wrapper(*call_args, **call_kwargs):
+            obj = receiver_ref()
+            if obj is None:
+                return None
+            return unbound_func(obj, *bound_args, *call_args, **bound_kwargs, **call_kwargs)
+    else:
+        # Qt determines how many signal arguments to deliver to a connected
+        # Python callable by introspecting it -- and does so *reliably* only
+        # for a callable with a concrete, fixed parameter list. A generic
+        # `def wrapper(*call_args)` has no such list: its true arity is
+        # ambiguous to that introspection, and in practice different Qt/
+        # pytest-qt code paths resolve that ambiguity inconsistently (observed
+        # directly: identical connections deliver the full signal argument in
+        # one case and none of it in another, depending only on whether a
+        # pytest-qt `qtbot` fixture is active in the process -- not on
+        # anything specific to the target method). Rather than depend on
+        # guessing that resolution, generate a wrapper with exactly
+        # `max_extra_args` named positional parameters, so its arity is
+        # concrete and unambiguous to any introspector.
+        param_names = [f'_a{i}' for i in range(max_extra_args)]
+        extra_call_args = ''.join(f', {name}' for name in param_names)
+        source = (
+            f"def wrapper({', '.join(param_names)}):\n"
+            f"    obj = receiver_ref()\n"
+            f"    if obj is None:\n"
+            f"        return None\n"
+            f"    return unbound_func(obj, *bound_args{extra_call_args}, **bound_kwargs)\n"
+        )
+        namespace: dict = {}
+        exec(source, {
+            'receiver_ref': receiver_ref,
+            'unbound_func': unbound_func,
+            'bound_args': bound_args,
+            'bound_kwargs': bound_kwargs,
+        }, namespace)
+        wrapper = namespace['wrapper']
 
     # Copy __name__/__doc__ for readability (tracebacks, repr) without using
     # functools.wraps(unbound_func): that would set __wrapped__ to the

--- a/packages/pymodaq_utils/src/pymodaq_utils/weak.py
+++ b/packages/pymodaq_utils/src/pymodaq_utils/weak.py
@@ -15,6 +15,7 @@ binding never releases the wrapper closure, the closure itself cannot keep
 the receiver reachable.
 """
 import functools
+import inspect
 import weakref
 from typing import Callable
 
@@ -56,11 +57,33 @@ def weak_slot(callback: Callable) -> Callable:
 
     receiver_ref = weakref.ref(receiver)
 
+    # A real Qt slot may declare fewer parameters than the signal it's connected
+    # to provides (e.g. a plain `def _grab(self):` connected to a checkable
+    # QAction's `triggered(bool)`) -- Qt introspects the slot and only passes as
+    # many arguments as it declares. That introspection needs a concrete
+    # parameter list; it can't be done for `wrapper`'s own generic `*call_args`,
+    # so Qt falls back to passing everything the signal provides, regardless of
+    # what `unbound_func` actually accepts. Work out the true accepted arity
+    # from `callback` itself (a bound method or `functools.partial` already
+    # correctly excludes `self`/pre-bound args from its own signature) and
+    # truncate `call_args` to match, replicating Qt's own truncation.
+    max_extra_args = None  # None == unlimited (unknown, or callback itself takes *args)
+    try:
+        sig = inspect.signature(callback)
+        if not any(p.kind is inspect.Parameter.VAR_POSITIONAL for p in sig.parameters.values()):
+            max_extra_args = sum(
+                1 for p in sig.parameters.values()
+                if p.kind in (inspect.Parameter.POSITIONAL_ONLY,
+                              inspect.Parameter.POSITIONAL_OR_KEYWORD))
+    except (TypeError, ValueError):
+        pass
+
     def wrapper(*call_args, **call_kwargs):
         obj = receiver_ref()
         if obj is None:
             return None
-        return unbound_func(obj, *bound_args, *call_args, **bound_kwargs, **call_kwargs)
+        args = call_args if max_extra_args is None else call_args[:max_extra_args]
+        return unbound_func(obj, *bound_args, *args, **bound_kwargs, **call_kwargs)
 
     # Copy __name__/__doc__ for readability (tracebacks, repr) without using
     # functools.wraps(unbound_func): that would set __wrapped__ to the


### PR DESCRIPTION
Here is the tentative to get rid of errors in pytest and making sure that connections using self are properly garbage collected once the instance gets closed.
`DashBoard` instances (and everything reachable from them — modules,
hardware `QThread`s, extensions) were never garbage collected once created,
because several Qt signal connections closed over `self` (bound methods or
`self`-capturing lambdas). PySide/PyQt keep an internal reference to a
connected Python callable that outlives `disconnect()` and can survive even
after the underlying `QObject` is destroyed, so any such connection kept the
whole object graph alive indefinitely — including live hardware `QThread`s.
Left running, this surfaced as a `SIGABRT` at full test-suite exit (Qt
aborting on threads that were never `.wait()`-ed on because nothing had
released them).

This PR centralizes on a single pattern, `weak_slot()`, for every connection
that needs to close over `self`, removes teardown scaffolding that becomes
redundant once that pattern is applied consistently.