### PR TITLE
Hotfix/errors in savers

### DIFF
--- a/packages/pymodaq/src/pymodaq/dashboard.py
+++ b/packages/pymodaq/src/pymodaq/dashboard.py
@@ -19,14 +19,11 @@ from qtpy.QtWidgets import (
 )
 
 
-
-
 from pymodaq_utils.logger import set_logger, get_module_name
 from pymodaq_utils import utils
 from pymodaq_utils.utils import ThreadCommand
 from pymodaq_utils.config import GlobalConfig as Config
 from pymodaq_utils.enums import BaseEnum, StrEnum
-
 
 from pymodaq_gui.parameter import ParameterTree, Parameter
 from pymodaq_gui.utils import DockArea, Dock, select_file

--- a/packages/pymodaq_data/src/pymodaq_data/data.py
+++ b/packages/pymodaq_data/src/pymodaq_data/data.py
@@ -2799,6 +2799,10 @@ class DataWithAxes(DataBase, SerializableBase):
 
         do_squeeze = self.check_squeeze(total_slices, is_navigation)
         new_arrays_data = [squeeze(dat[total_slices], do_squeeze) for dat in self.data]
+        if self.errors is not None:
+            new_errors_data = [squeeze(dat[total_slices], do_squeeze) for dat in self.errors]
+        else:
+            new_errors_data = None
         tmp_axes = self._am.get_signal_axes() if is_navigation else self._am.get_nav_axes()
         axes_to_append = [copy.deepcopy(axis) for axis in tmp_axes]
 
@@ -2847,17 +2851,22 @@ class DataWithAxes(DataBase, SerializableBase):
         else:
             distribution = DataDistribution.uniform
 
-        data = DataWithAxes(self.name, data=new_arrays_data, nav_indexes=tuple(nav_indexes),
+        data = DataWithAxes(self.name,
+                            data=new_arrays_data,
+                            errors=new_errors_data,
+                            nav_indexes=tuple(nav_indexes),
                             axes=axes,
                             source=DataSource.calculated, origin=self.origin,
                             labels=self.labels[:],
                             distribution=distribution)
         return data
 
-    def deepcopy_with_new_data(self, data: List[np.ndarray] = None,
+    def deepcopy_with_new_data(self,
+                               data: List[np.ndarray] = None,
                                remove_axes_index: Union[int, List[int]] = None,
                                source: DataSource = DataSource.calculated,
-                               keep_dim=False) -> DataWithAxes:
+                               keep_dim=False,
+                               errors: List[np.ndarray] = None,) -> DataWithAxes:
         """deepcopy without copying the initial data (saving memory)
 
         The new data, may have some axes stripped as specified in remove_axes_index
@@ -2872,16 +2881,26 @@ class DataWithAxes(DataBase, SerializableBase):
         keep_dim: bool
             if False (the default) will calculate the new dim based on the data shape
             else keep the same (be aware it could lead to issues)
+        errors: list of numpy ndarray
+            The new errors corresponding to the new data
 
         Returns
         -------
         DataWithAxes
         """
+        def check_errors(data: list[np.ndarray], errors: list[np.ndarray]) -> bool:
+            for data_array, error_array in zip(data, errors):
+                if data_array.shape != error_array.shape:
+                    return False
+            return True
         try:
+            if errors is not None and check_errors(data, errors):
+                errors = None
             old_data = self.data
             self._data = None
             new_data = self.deepcopy()
             new_data._data = data
+            new_data.errors = errors
             new_data.get_dim_from_data(data)
 
             if source is not None:

--- a/packages/pymodaq_data/src/pymodaq_data/h5modules/data_saving.py
+++ b/packages/pymodaq_data/src/pymodaq_data/h5modules/data_saving.py
@@ -442,7 +442,10 @@ class DataSaverLoader(DataManagement):
             data_nodes = self._get_nodes_from_data_type(parent_node)
             data_node = data_nodes[0]
             error_nodes = self._error_saver._get_nodes_from_data_type(parent_node)
-            error_node = error_nodes[0]
+            if len(error_nodes) > 0:
+                error_node = error_nodes[0]
+            else:
+                error_node = None
         else:
             parent_node = data_node.parent_node
             if not isinstance(data_node, CARRAY):

--- a/packages/pymodaq_data/src/pymodaq_data/h5modules/data_saving.py
+++ b/packages/pymodaq_data/src/pymodaq_data/h5modules/data_saving.py
@@ -441,7 +441,8 @@ class DataSaverLoader(DataManagement):
             parent_node = data_node.parent_node
             data_nodes = self._get_nodes_from_data_type(parent_node)
             data_node = data_nodes[0]
-            error_node = data_node
+            error_nodes = self._error_saver._get_nodes_from_data_type(parent_node)
+            error_node = error_nodes[0]
         else:
             parent_node = data_node.parent_node
             if not isinstance(data_node, CARRAY):
@@ -463,7 +464,7 @@ class DataSaverLoader(DataManagement):
         else:
             ndarrays = self.get_data_arrays(data_node, with_bkg=with_bkg, load_all=load_all)
             axes = self.get_axes(parent_node)
-            if error_node is not None:
+            if error_node is not None and self.data_type != DataType.error:
                 error_arrays = self._error_saver.get_data_arrays(error_node, load_all=load_all)
                 if len(error_arrays) == 0:
                     error_arrays = None

--- a/packages/pymodaq_data/src/pymodaq_data/h5modules/data_saving.py
+++ b/packages/pymodaq_data/src/pymodaq_data/h5modules/data_saving.py
@@ -591,7 +591,9 @@ class DataEnlargeableSaver(DataSaverLoader):
                 nav_indexes = ([0] +
                                list(np.array(nav_indexes, dtype=int) + 1))
 
-                self._h5saver.add_array(where, self._get_next_node_name(where), self.data_type,
+                self._h5saver.add_array(where,
+                                        self._get_next_node_name(where),
+                                        self.data_type,
                                         title=data.name,
                                         array_to_save=data[ind_data],
                                         data_shape=data[ind_data].shape,
@@ -604,6 +606,24 @@ class DataEnlargeableSaver(DataSaverLoader):
                                                       distribution='spread',
                                                       origin=data.origin,
                                                       nav_indexes=tuple(nav_indexes)))
+                if data.errors is not None:
+                    error_dwa = data.errors_as_dwa()
+                    self._h5saver.add_array(where,
+                                            self._error_saver._get_next_node_name(where),
+                                            self._error_saver.data_type,
+                                            title=error_dwa.name,
+                                            array_to_save=error_dwa[ind_data],
+                                            data_shape=error_dwa[ind_data].shape,
+                                            array_type=error_dwa[ind_data].dtype,
+                                            enlargeable=True,
+                                            data_dimension=error_dwa.dim.name,
+                                            metadata=dict(timestamp=error_dwa.timestamp,
+                                                          label=error_dwa.labels[ind_data],
+                                                          source=error_dwa.source.name,
+                                                          distribution='spread',
+                                                          origin=error_dwa.origin,
+                                                          nav_indexes=tuple(nav_indexes)))
+
             if add_enl_axes:
                 for ind_enl_axis in range(self._n_enl_axes):
                     self._axis_saver.add_axis(where,
@@ -661,6 +681,12 @@ class DataEnlargeableSaver(DataSaverLoader):
         for ind_data in range(len(data)):
             array: EARRAY = self.get_node_from_index(where, ind_data)
             array.append(data[ind_data])
+
+            if data.errors is not None:
+                error_array: EARRAY = self._error_saver.get_node_from_index(where, ind_data)
+                error_array.append(data.errors[ind_data])
+
+
         if add_enl_axes:
             for ind_axis in range(self._n_enl_axes):
                 axis_array: EARRAY = self._axis_saver.get_node_from_index(where, ind_axis)
@@ -715,7 +741,10 @@ class DataExtendedSaver(DataSaverLoader):
                 nav_indexes = [ind for ind in range(len(self.extended_shape))] +\
                               list(np.array(nav_indexes, dtype=int) + len(self.extended_shape))
 
-                self._h5saver.add_array(where, self._get_next_node_name(where), self.data_type, title=data.name,
+                self._h5saver.add_array(where,
+                                        self._get_next_node_name(where),
+                                        self.data_type,
+                                        title=data.name,
                                         data_shape=data[ind_data].shape,
                                         array_type=data[ind_data].dtype,
                                         fill_value=self.fill_value,
@@ -726,6 +755,24 @@ class DataExtendedSaver(DataSaverLoader):
                                                       source=data.source.name, distribution=distribution.name,
                                                       origin=data.origin,
                                                       nav_indexes=tuple(nav_indexes)))
+
+                if data.errors is not None:
+                    error_dwa = data.errors_as_dwa()
+                    self._h5saver.add_array(where,
+                                            self._error_saver._get_next_node_name(where),
+                                            self._error_saver.data_type,
+                                            title=error_dwa.name,
+                                            data_shape=error_dwa[ind_data].shape,
+                                            array_type=error_dwa[ind_data].dtype,
+                                            fill_value=self.fill_value,
+                                            scan_shape=self.extended_shape,
+                                            add_scan_dim=True,
+                                            data_dimension=error_dwa.dim.name,
+                                            metadata=dict(timestamp=error_dwa.timestamp, label=error_dwa.labels[ind_data],
+                                                          source=error_dwa.source.name, distribution=distribution.name,
+                                                          origin=error_dwa.origin,
+                                                          nav_indexes=tuple(nav_indexes)))
+
 
             if save_axes:
                 for axis in data.axes:
@@ -756,10 +803,13 @@ class DataExtendedSaver(DataSaverLoader):
             self._create_data_arrays(where, data, save_axes=True, distribution=distribution)
 
         for ind_data in range(len(data)):
-            #todo check that getting with index is safe...
+
             array: CARRAY = self.get_node_from_index(where, ind_data)
             array[tuple(indexes)] = data[ind_data]
             # maybe use array.__setitem__(indexes, data[ind_data]) if it's not working
+            if data.errors is not None:
+                error_array: CARRAY = self._error_saver.get_node_from_index(where, ind_data)
+                error_array[tuple(indexes)] = data.errors[ind_data]
 
 
 class DataToExportSaver:

--- a/packages/pymodaq_data/src/pymodaq_data/post_treatment/process_to_scalar.py
+++ b/packages/pymodaq_data/src/pymodaq_data/post_treatment/process_to_scalar.py
@@ -84,7 +84,11 @@ class StdProcessor(DataProcessorBase):
 
     def operate(self, sub_data: DataWithAxes):
         data_arrays = [np.atleast_1d(np.std(data, axis=sub_data.sig_indexes)) for data in sub_data]
-        return sub_data.deepcopy_with_new_data(data_arrays, sub_data.sig_indexes)
+        if sub_data.errors is not None:
+            error_arrays = [np.atleast_1d(np.std(data, axis=sub_data.sig_indexes)) for data in sub_data.errors]
+        else:
+            error_arrays = None
+        return sub_data.deepcopy_with_new_data(data_arrays, sub_data.sig_indexes, errors=error_arrays)
 
 
 @DataProcessorFactory.register('sum')
@@ -93,7 +97,11 @@ class SumProcessor(DataProcessorBase):
 
     def operate(self, sub_data: DataWithAxes):
         data_arrays = [np.atleast_1d(np.sum(data, axis=sub_data.sig_indexes)) for data in sub_data]
-        return sub_data.deepcopy_with_new_data(data_arrays, sub_data.sig_indexes)
+        if sub_data.errors is not None:
+            error_arrays = [np.atleast_1d(np.sum(data, axis=sub_data.sig_indexes)) for data in sub_data.errors]
+        else:
+            error_arrays = None
+        return sub_data.deepcopy_with_new_data(data_arrays, sub_data.sig_indexes, errors=error_arrays)
 
 
 @DataProcessorFactory.register('max')
@@ -102,7 +110,11 @@ class MaxProcessor(DataProcessorBase):
 
     def operate(self, sub_data: DataWithAxes):
         data_arrays = [np.atleast_1d(np.max(data, axis=sub_data.sig_indexes)) for data in sub_data]
-        return sub_data.deepcopy_with_new_data(data_arrays, sub_data.sig_indexes)
+        if sub_data.errors is not None:
+            error_arrays = [np.atleast_1d(np.max(data, axis=sub_data.sig_indexes)) for data in sub_data.errors]
+        else:
+            error_arrays = None
+        return sub_data.deepcopy_with_new_data(data_arrays, sub_data.sig_indexes, errors=error_arrays)
 
 
 @DataProcessorFactory.register('min')
@@ -111,7 +123,11 @@ class MinProcessor(DataProcessorBase):
 
     def operate(self, sub_data: DataWithAxes):
         data_arrays = [np.atleast_1d(np.min(data, axis=sub_data.sig_indexes)) for data in sub_data]
-        return sub_data.deepcopy_with_new_data(data_arrays, sub_data.sig_indexes)
+        if sub_data.errors is not None:
+            error_arrays = [np.atleast_1d(np.min(data, axis=sub_data.sig_indexes)) for data in sub_data.errors]
+        else:
+            error_arrays = None
+        return sub_data.deepcopy_with_new_data(data_arrays, sub_data.sig_indexes, errors=error_arrays)
 
 
 @DataProcessorFactory.register('argmax')

--- a/packages/pymodaq_data/tests/h5module_test/data_saving_test.py
+++ b/packages/pymodaq_data/tests/h5module_test/data_saving_test.py
@@ -23,6 +23,8 @@ OFFSET = -20.4
 SCALING = 0.22
 SIZE = 20
 
+UNITS_ALL = ['m', 's', 'W', 'K', '°', '°C', 'um', 'J', 'rpm', '']
+
 DATA = OFFSET + SCALING * np.linspace(0, SIZE-1, SIZE)
 
 DATA0D: np.ndarray = np.array([2.7])
@@ -58,10 +60,10 @@ def init_data_to_export():
                           dim='Data2D', distribution='uniform',
                           units='nm',
                           axes=[Axis(data=create_axis_array(DATA2D.shape[0]),
-                                     label='myaxis0', units='myunits0',
+                                     label='myaxis0', units='J',
                                      index=0),
                                 Axis(data=create_axis_array(DATA2D.shape[1]),
-                                     label='myaxis1', units='myunits1',
+                                     label='myaxis1', units='rpm',
                                      index=1)],
                           errors=[np.random.random_sample(DATA2D.shape) for _ in range(Ndata)])
 
@@ -71,7 +73,7 @@ def init_data_to_export():
                           units='s',
                           dim='Data1D', distribution='uniform',
                           axes=[Axis(data=create_axis_array(DATA1D.shape[0]),
-                                     label='myaxis0', units='myunits0',
+                                     label='myaxis0', units='',
                                      index=0)],
                           errors=None)
 
@@ -155,10 +157,10 @@ class TestAxisSaverLoader:
         OFFSET = -5.
         SCALING = 0.2
         LABEL = 'myaxis'
-        UNITS = 'myunits'
+
         axes_ini = []
         for ind in range(3):
-            axes_ini.append(Axis(label=f'LABEL{ind}', units=f'UNITS{ind}',
+            axes_ini.append(Axis(label=f'LABEL{ind}', units=UNITS_ALL[ind],
                                  data=OFFSET + SCALING * np.linspace(0, SIZE-1, SIZE),
                                  index=ind))
             axis_node = axis_saver.add_axis(h5saver.raw_group, axes_ini[ind])
@@ -189,9 +191,9 @@ class TestDataSaverLoader:
         data = DataWithAxes(name='mydata', data=[DATA2D for _ in range(Ndata)], labels=['mylabel1', 'mylabel2'],
                             source='raw',
                             dim='Data2D', distribution='uniform',
-                            axes=[Axis(data=create_axis_array(DATA2D.shape[0]), label='myaxis0', units='myunits0',
+                            axes=[Axis(data=create_axis_array(DATA2D.shape[0]), label='myaxis0', units='W',
                                        index=0),
-                                  Axis(data=create_axis_array(DATA2D.shape[1]), label='myaxis1', units='myunits1',
+                                  Axis(data=create_axis_array(DATA2D.shape[1]), label='myaxis1', units='°C',
                                        index=1)])
 
         data_saver.add_data(h5saver.raw_group, data)
@@ -212,10 +214,10 @@ class TestDataSaverLoader:
                             units='mm',
                             dim='Data2D', distribution='uniform',
                             axes=[Axis(data=create_axis_array(DATA2D.shape[0]),
-                                       label='myaxis0', units='myunits0',
+                                       label='myaxis0', units='K',
                                        index=0),
                                   Axis(data=create_axis_array(DATA2D.shape[1]),
-                                       label='myaxis1', units='myunits1',
+                                       label='myaxis1', units='s',
                                        index=1)],
                             errors=errors)
 
@@ -506,6 +508,7 @@ class TestDataExtendedSaver:
                             labels=['mylabel1', 'mylabel2'],
                             source='raw',
                             dim='Data2D', distribution='uniform',
+                            errors = [np.random.random_sample(DATA2D.shape) for _ in range(Ndata)],
                             axes=[Axis(data=create_axis_array(DATA2D.shape[0]), label='myaxis0',
                                        units='ms',
                                        index=0),
@@ -520,9 +523,10 @@ class TestDataExtendedSaver:
         assert len(data_saver.get_axes(h5saver.raw_group)) == Ndata
         for ind in range(len(data)):
             data_node = h5saver.get_node(f'/RawData/Data0{ind}')
-
+            error_node = h5saver.get_node(f'/RawData/ErrorBar0{ind}')
             assert data_node.attrs['shape'] == tuple(data_ext_shape)
             assert np.all(data_node[tuple(INDEXES)] == pytest.approx(data[ind]))
+            assert np.all(error_node[tuple(INDEXES)] == pytest.approx(data.errors[ind]))
 
 
     @pytest.mark.parametrize('fill_value,checker', [
@@ -661,7 +665,7 @@ class TestDataToExportExtendedSaver:
         INDEXES = [4, 3]
         data_saver.add_nav_axes(det_group, nav_axes)
         data_saver.add_data(det_group, data_to_export, INDEXES)
-
+        pass
 
     def test_fill_value_nan_unwritten_positions(self, h5saver_lowlevel):
         """NaN fill: positions not yet written contain NaN; written position has real data."""


### PR DESCRIPTION
This PR fixes #1163 

* Errors are now saved in Extended saver (type DAQ_Scan) and in Enlargeable Saver (type logger)
* Slicing was also not hnadling errors, this is now ok
* Plotting in h5browser from complex data (scans with ND viewer) s also ok