### PR TITLE
hotfix/legacy_mutiaxes_access

### DIFF
--- a/packages/pymodaq/src/pymodaq/control_modules/plugin_base.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/plugin_base.py
@@ -1,3 +1,5 @@
+import warnings
+
 from qtpy.QtCore import QObject, Slot
 from easydict import EasyDict as edict
 from pyqtgraph.parametertree import Parameter
@@ -38,6 +40,12 @@ class _BackCompatGroupParameter(GroupParameter):
             translated = tuple(_LEGACY_SETTINGS_NAMES.get(name, name) for name in names)
             if translated == tuple(names):
                 raise
+            warnings.warn(
+                f"Accessing settings with the legacy name(s) {names} is deprecated and will "
+                f"be removed in a future release. Use {translated} instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return super().__getitem__(translated)
 
 

--- a/packages/pymodaq/src/pymodaq/control_modules/plugin_base.py
+++ b/packages/pymodaq/src/pymodaq/control_modules/plugin_base.py
@@ -1,10 +1,47 @@
 from qtpy.QtCore import QObject, Slot
 from easydict import EasyDict as edict
 from pyqtgraph.parametertree import Parameter
+from pyqtgraph.parametertree.parameterTypes import GroupParameter
+from pyqtgraph.parametertree.Parameter import registerParameterType
 
 from pymodaq.control_modules.thread_commands import ControllerStatus, ThreadStatus
 from pymodaq_gui.parameter import utils as putils
 from pymodaq_utils.utils import ThreadCommand
+
+# mapping from pre-5.1 group/parameter names to their current equivalent, kept so that
+# plugins written before the 'controller' group renaming (PR #1157/#1173) keep working
+_LEGACY_SETTINGS_NAMES = {
+    'multiaxes': 'controller',
+    'multi_status': 'controller_status',
+}
+
+_BACKCOMPAT_SETTINGS_TYPE = 'plugin_backcompat_group'
+
+
+class _BackCompatGroupParameter(GroupParameter):
+    """GroupParameter used only for a plugin's top-level ``settings`` tree.
+
+    Redirects legacy path segments (e.g. ``'multiaxes'``, ``'multi_status'``) to their
+    current names so that old plugin code such as ``self.settings['multiaxes', 'axis']``
+    keeps working. Registered under its own parameter type name (rather than overriding
+    the global ``'group'`` type), so it does not affect every ``GroupParameter`` in the
+    application and stays consistent with pyqtgraph's requirement that a Parameter's
+    ``type`` option match its registered class.
+    """
+
+    def __getitem__(self, names):
+        if isinstance(names, str):
+            names = (names,)
+        try:
+            return super().__getitem__(names)
+        except KeyError:
+            translated = tuple(_LEGACY_SETTINGS_NAMES.get(name, name) for name in names)
+            if translated == tuple(names):
+                raise
+            return super().__getitem__(translated)
+
+
+registerParameterType(_BACKCOMPAT_SETTINGS_TYPE, _BackCompatGroupParameter, override=True)
 
 
 class PluginBase(QObject):
@@ -23,7 +60,8 @@ class PluginBase(QObject):
     def __init__(self, parent=None, params_state=None):
         QObject.__init__(self)
         self.parent_parameters_path = []
-        self.settings = Parameter.create(name='Settings', type='group', children=self.params)
+        self.settings = Parameter.create(name='Settings', type=_BACKCOMPAT_SETTINGS_TYPE,
+                                         children=self.params)
         if params_state is not None:
             if isinstance(params_state, dict):
                 self.settings.restoreState(params_state)

--- a/packages/pymodaq/tests/control_modules/move_utility_test.py
+++ b/packages/pymodaq/tests/control_modules/move_utility_test.py
@@ -162,6 +162,8 @@ def test_settings_legacy_multiaxes_access(qtbot):
 
     hardware = HardwareWithList()
 
-    assert hardware.settings['multiaxes', 'axis'] == hardware.settings['controller', 'axis']
-    assert (hardware.settings['multiaxes', 'multi_status']
-            == hardware.settings['controller', 'controller_status'])
+    with pytest.deprecated_call():
+        assert hardware.settings['multiaxes', 'axis'] == hardware.settings['controller', 'axis']
+    with pytest.deprecated_call():
+        assert (hardware.settings['multiaxes', 'multi_status']
+                == hardware.settings['controller', 'controller_status'])

--- a/packages/pymodaq/tests/control_modules/move_utility_test.py
+++ b/packages/pymodaq/tests/control_modules/move_utility_test.py
@@ -150,3 +150,18 @@ def test_axis_dict(qtbot, AXIS_NAMES, EPSILONS, UNITS, error):
             else:
                 assert hardware.axis_unit == UNITS[axis_name]
                 assert hardware.axis_units == UNITS
+
+
+def test_settings_legacy_multiaxes_access(qtbot):
+    """Regression test for #1173: old plugin code reading settings using the pre-5.1
+    'multiaxes'/'multi_status' group names should still work after the 'controller'
+    renaming introduced in #1157.
+    """
+    class HardwareWithList(DAQ_Move_base):
+        params = comon_parameters_fun(is_multiaxes=True, axis_names=['a', 'b'])
+
+    hardware = HardwareWithList()
+
+    assert hardware.settings['multiaxes', 'axis'] == hardware.settings['controller', 'axis']
+    assert (hardware.settings['multiaxes', 'multi_status']
+            == hardware.settings['controller', 'controller_status'])


### PR DESCRIPTION
Fixing #1173 
- Using the old patching (with a custom GroupParameter) for DAQ_move with a custom type 
- Adding a deprecation warning for old style plugins