### PR TITLE
Fix Dashboard scripting

### DIFF
--- a/packages/pymodaq/src/pymodaq/examples/scripting/dashboard_script.py
+++ b/packages/pymodaq/src/pymodaq/examples/scripting/dashboard_script.py
@@ -12,7 +12,7 @@ dashboard.apply_experiment('default')
 print(dashboard.get_configurations().result())
 # >>> ['default', 'my_custom_config']
 
-# Same remark as dashboard.apply_preset
+# Same remark as dashboard.apply_experiment
 dashboard.apply_configuration('default')
 
 print(dashboard.get_devices().result())  # returns the names

--- a/packages/pymodaq/src/pymodaq/scripting/utils.py
+++ b/packages/pymodaq/src/pymodaq/scripting/utils.py
@@ -345,16 +345,16 @@ class LECODashboardWrapper(LECOBaseWrapper):
         self._experiments_future = future
 
         self.set_remote_name()
-        self._director.ask_rpc("get_presets")
+        self._director.ask_rpc("get_experiments")
 
         return future
 
-    def apply_experiment(self, preset: str) -> Future[bool]:
+    def apply_experiment(self, experiment: str) -> Future[bool]:
         future = Future()
         self._applied_experiment_future = future
 
         self.set_remote_name()
-        self._director.ask_rpc("apply_preset", preset=preset)
+        self._director.ask_rpc("apply_experiment", experiment=experiment)
 
         return future
 
@@ -373,9 +373,9 @@ class LECODashboardWrapper(LECOBaseWrapper):
         except (InvalidStateError, AttributeError):
             pass
 
-    def send_experiments(self, presets: list[str]):
+    def send_experiments(self, experiments: list[str]):
         try:
-            self._experiments_future.set_result(presets)
+            self._experiments_future.set_result(experiments)
             self._experiments_future = None
         except (InvalidStateError, AttributeError):
             pass


### PR DESCRIPTION
When presets were renamed to experiments 5 months ago, a few occurences were forgotten. This led to a deadlock while waiting future result for get_experiments() and apply_experiment().