### PR TITLE
hide the docklabel if only one viewer in the dispatcher

### DIFF
--- a/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer.py
+++ b/packages/pymodaq_gui/src/pymodaq_gui/plotting/data_viewers/viewer.py
@@ -220,9 +220,15 @@ class ViewerDispatcher:
         while len(self.viewers) < len(viewers_type):
             self.add_viewer(viewers_type[Nviewers_to_leave + ind_loop],
                             dock_name=viewers_name[Nviewers_to_leave + ind_loop]
-                            if viewers_name is not None else None)
+                            if viewers_name is not None else None,
+                            )
             ind_loop += 1
         QtWidgets.QApplication.processEvents()
+        if len(viewers_type) == 1:
+            self.viewer_docks[-1].hideTitleBar()
+        else:
+            for viewer_dock in self.viewer_docks:
+                viewer_dock.showTitleBar()
 
     def close(self):
         for dock in self.viewer_docks:


### PR DESCRIPTION
Small PR to not show the DockLabel of the viewer when there is only one in a ViewerDispatcher. In that case, the label was redundant and taking too much space for nothing:!